### PR TITLE
[PM-38798] Create validation link confirmation

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidationRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidationRequest.cs
@@ -1,0 +1,21 @@
+﻿using Bit.Core.Entities;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+/// <summary>
+/// The data required to determine whether a user is eligible to be confirmed into an organization
+/// via an invite link. This is the shared input for the read-only precheck performed before the
+/// org key is released and before the user is confirmed.
+/// </summary>
+public record ConfirmOrganizationInviteLinkValidationRequest
+{
+    /// <summary>
+    /// The secret code embedded in the invite link the user is attempting to use.
+    /// </summary>
+    public required Guid Code { get; init; }
+
+    /// <summary>
+    /// The authenticated user attempting to confirm their membership.
+    /// </summary>
+    public required User User { get; init; }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidationResult.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidationResult.cs
@@ -1,0 +1,29 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+using Bit.Core.Entities;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+/// <summary>
+/// The validated context produced by <see cref="IConfirmOrganizationInviteLinkValidator"/> when a user
+/// is eligible to be confirmed via an invite link. The confirmation endpoints reuse this so they do not
+/// have to re-resolve the link, organization, or existing membership after validation succeeds.
+/// </summary>
+public record ConfirmOrganizationInviteLinkValidationResult
+{
+    /// <summary>
+    /// The invite link resolved from the request code.
+    /// </summary>
+    public required OrganizationInviteLink InviteLink { get; init; }
+
+    /// <summary>
+    /// The organization the invite link belongs to.
+    /// </summary>
+    public required Organization Organization { get; init; }
+
+    /// <summary>
+    /// The user's existing membership in the organization, or <see langword="null"/> when the user is
+    /// not yet a member and a new membership will be created during confirmation.
+    /// </summary>
+    public OrganizationUser? ExistingOrganizationUser { get; init; }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidator.cs
@@ -1,0 +1,179 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Models.Business;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.AcceptMembership;
+using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers.Validation.PasswordManager;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.AdminConsole.Utilities;
+using Bit.Core.AdminConsole.Utilities.v2;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+using Bit.Core.Auth.UserFeatures.TwoFactorAuth.Interfaces;
+using Bit.Core.Billing.Pricing;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Repositories;
+using PasswordManagerValidation = Bit.Core.AdminConsole.Utilities.Validation;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+/// <summary>
+/// Shared read-only precheck for the invite link confirmation flow. See
+/// <see cref="IConfirmOrganizationInviteLinkValidator"/> for the checks performed.
+/// </summary>
+/// <remarks>
+/// This intentionally mirrors the eligibility checks in <see cref="AcceptOrganizationInviteLinkCommand"/>
+/// without duplicating its write side effects, so the confirmation endpoints can verify a user before
+/// they are given the organization key. Write-time concerns (e.g. creating the default collection,
+/// auto-scaling seats) are left to the consuming command.
+/// </remarks>
+public class ConfirmOrganizationInviteLinkValidator(
+    IOrganizationInviteLinkRepository organizationInviteLinkRepository,
+    IOrganizationRepository organizationRepository,
+    IOrganizationUserRepository organizationUserRepository,
+    IProviderUserRepository providerUserRepository,
+    IPricingClient pricingClient,
+    IPolicyRequirementQuery policyRequirementQuery,
+    ITwoFactorIsEnabledQuery twoFactorIsEnabledQuery)
+    : IConfirmOrganizationInviteLinkValidator
+{
+    public async Task<CommandResult<ConfirmOrganizationInviteLinkValidationResult>> ValidateAsync(
+        ConfirmOrganizationInviteLinkValidationRequest request)
+    {
+        var user = request.User;
+
+        var link = await organizationInviteLinkRepository.GetByCodeAsync(request.Code);
+        if (link is null)
+        {
+            return new InviteLinkNotFound();
+        }
+
+        var organization = await organizationRepository.GetByIdAsync(link.OrganizationId);
+        if (organization is null or { Enabled: false })
+        {
+            return new InviteLinkNotFound();
+        }
+
+        if (!organization.UseInviteLinks)
+        {
+            return new InviteLinkNotAvailable();
+        }
+
+        if (!InviteLinkDomainValidator.IsEmailDomainAllowed(user.Email, link.GetAllowedDomains()))
+        {
+            return new EmailDomainNotAllowed();
+        }
+
+        // Provider users cannot confirm via invite links.
+        if ((await providerUserRepository.GetManyByUserAsync(user.Id)).Count != 0)
+        {
+            return new ProviderUsersCannotAcceptInviteLink();
+        }
+
+        var existingOrganizationUser = await ResolveExistingOrganizationUserAsync(organization, user);
+
+        var membershipStatusError = ValidateExistingMembershipStatus(existingOrganizationUser);
+        if (membershipStatusError is not null)
+        {
+            return membershipStatusError;
+        }
+
+        // A seat is only consumed when a brand-new membership will be created. An existing pending
+        // invitation already occupies a seat, so confirming it adds no capacity pressure.
+        if (existingOrganizationUser is null)
+        {
+            var seatError = await ValidatePasswordManagerSeatsAsync(organization);
+            if (seatError is not null)
+            {
+                return seatError;
+            }
+        }
+
+        var policyError = await ValidatePoliciesAsync(organization.Id, user);
+        if (policyError is not null)
+        {
+            return policyError;
+        }
+
+        return new ConfirmOrganizationInviteLinkValidationResult
+        {
+            InviteLink = link,
+            Organization = organization,
+            ExistingOrganizationUser = existingOrganizationUser,
+        };
+    }
+
+    /// <summary>
+    /// Resolves the membership to confirm, preferring an existing user-linked membership and falling
+    /// back to a pending email invitation for the same address.
+    /// </summary>
+    private async Task<OrganizationUser?> ResolveExistingOrganizationUserAsync(Organization organization, User user)
+    {
+        var userLinkedOrganizationUser = await organizationUserRepository.GetByOrganizationAsync(organization.Id, user.Id);
+        if (userLinkedOrganizationUser is not null)
+        {
+            return userLinkedOrganizationUser;
+        }
+
+        return await organizationUserRepository.GetByOrganizationEmailAsync(organization.Id, user.Email);
+    }
+
+    private static Error? ValidateExistingMembershipStatus(OrganizationUser? existingOrganizationUser) =>
+        existingOrganizationUser?.Status switch
+        {
+            OrganizationUserStatusType.Revoked => new OrganizationAccessRevoked(),
+            OrganizationUserStatusType.Confirmed => new AlreadyOrganizationMember(),
+            _ => null
+        };
+
+    /// <summary>
+    /// Enforces the membership policies that gate confirmation: Single Organization and Require Two-Factor
+    /// Authentication. These are read-only checks; no enrollment or revocation side effects are performed.
+    /// </summary>
+    private async Task<Error?> ValidatePoliciesAsync(
+        Guid organizationId, User user)
+    {
+        var allOrganizationMemberships = await organizationUserRepository.GetManyByUserAsync(user.Id);
+
+        var singleOrgRequirement = await policyRequirementQuery
+            .GetAsync<SingleOrganizationPolicyRequirement>(user.Id);
+        var singleOrgError = singleOrgRequirement.CanJoinOrganization(organizationId, allOrganizationMemberships);
+        if (singleOrgError is not null)
+        {
+            return singleOrgError;
+        }
+
+        if (!await twoFactorIsEnabledQuery.TwoFactorIsEnabledAsync(user))
+        {
+            var twoFactorRequirement = await policyRequirementQuery
+                .GetAsync<RequireTwoFactorPolicyRequirement>(user.Id);
+            if (twoFactorRequirement.IsTwoFactorRequiredForOrganization(organizationId))
+            {
+                return new TwoFactorRequiredForMembership();
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Reuses the Password Manager seat validation to confirm the organization can accommodate one more
+    /// member. This covers having Password Manager seats, the plan allowing additional seats, the max
+    /// additional seats, and the autoscale seat limit.
+    /// </summary>
+    private async Task<Error?> ValidatePasswordManagerSeatsAsync(Organization organization)
+    {
+        var plan = await pricingClient.GetPlan(organization.PlanType);
+        var inviteOrganization = new InviteOrganization(organization, plan);
+        var occupiedSeats = (await organizationRepository
+            .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)).Total;
+
+        var subscriptionUpdate = new PasswordManagerSubscriptionUpdate(inviteOrganization, occupiedSeats, newUsersToAdd: 1);
+
+        return InviteUsersPasswordManagerValidator.ValidatePasswordManager(subscriptionUpdate)
+            is PasswordManagerValidation.Invalid<PasswordManagerSubscriptionUpdate>
+            ? new OrganizationHasNoAvailableSeats()
+            : null;
+    }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidator.cs
@@ -23,10 +23,9 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
 /// <see cref="IConfirmOrganizationInviteLinkValidator"/> for the checks performed.
 /// </summary>
 /// <remarks>
-/// This intentionally mirrors the eligibility checks in <see cref="AcceptOrganizationInviteLinkCommand"/>
-/// without duplicating its write side effects, so the confirmation endpoints can verify a user before
-/// they are given the organization key. Write-time concerns (e.g. creating the default collection,
-/// auto-scaling seats) are left to the consuming command.
+/// This performs the eligibility checks without any write side effects, so the confirmation endpoints
+/// can verify a user before they are given the organization key. Write-time concerns (e.g. creating the
+/// default collection, auto-scaling seats) are left to the consuming command.
 /// </remarks>
 public class ConfirmOrganizationInviteLinkValidator(
     IOrganizationInviteLinkRepository organizationInviteLinkRepository,

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidator.cs
@@ -120,10 +120,10 @@ public class ConfirmOrganizationInviteLinkValidator(
     }
 
     private static Error? ValidateExistingMembershipStatus(OrganizationUser? existingOrganizationUser) =>
-        existingOrganizationUser?.Status switch
+        existingOrganizationUser switch
         {
-            OrganizationUserStatusType.Revoked => new OrganizationAccessRevoked(),
-            OrganizationUserStatusType.Confirmed => new AlreadyOrganizationMember(),
+            { RevocationReason: not null } => new OrganizationAccessRevoked(),
+            { Status: OrganizationUserStatusType.Confirmed } => new AlreadyOrganizationMember(),
             _ => null
         };
 

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IConfirmOrganizationInviteLinkValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IConfirmOrganizationInviteLinkValidator.cs
@@ -1,0 +1,25 @@
+﻿using Bit.Core.AdminConsole.Utilities.v2.Results;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+
+/// <summary>
+/// Performs the read-only validation and policy precheck shared by the invite link confirmation
+/// endpoints (retrieving the encrypted org key and confirming the user). No write operations are
+/// performed; the caller is responsible for any state changes once validation succeeds.
+/// </summary>
+/// <remarks>
+/// The following are validated:
+/// <list type="bullet">
+///     <item>The invite link exists and its organization is enabled and supports invite links.</item>
+///     <item>The user's email domain is allowed by the link.</item>
+///     <item>The user is not a provider user.</item>
+///     <item>Any existing membership is neither revoked nor already confirmed.</item>
+///     <item>The organization has an available seat for a new member.</item>
+///     <item>The Require Two-Factor Authentication and Single Organization policies.</item>
+/// </list>
+/// </remarks>
+public interface IConfirmOrganizationInviteLinkValidator
+{
+    Task<CommandResult<ConfirmOrganizationInviteLinkValidationResult>> ValidateAsync(
+        ConfirmOrganizationInviteLinkValidationRequest request);
+}

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -206,6 +206,7 @@ public static class OrganizationServiceCollectionExtensions
         services.TryAddScoped<IDeleteOrganizationInviteLinkCommand, DeleteOrganizationInviteLinkCommand>();
         services.TryAddScoped<IRefreshOrganizationInviteLinkCommand, RefreshOrganizationInviteLinkCommand>();
         services.TryAddScoped<IAcceptOrganizationInviteLinkCommand, AcceptOrganizationInviteLinkCommand>();
+        services.TryAddScoped<IConfirmOrganizationInviteLinkValidator, ConfirmOrganizationInviteLinkValidator>();
     }
 
     private static void AddOrganizationDomainCommandsQueries(this IServiceCollection services)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidatorTests.cs
@@ -169,7 +169,7 @@ public class ConfirmOrganizationInviteLinkValidatorTests
     {
         // Arrange
         SetupHappyPath(organization, inviteLink, user, sutProvider);
-        revokedOrganizationUser.Status = OrganizationUserStatusType.Revoked;
+        revokedOrganizationUser.RevocationReason = RevocationReason.Manual;
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organization.Id, user.Id)
@@ -194,7 +194,7 @@ public class ConfirmOrganizationInviteLinkValidatorTests
     {
         // Arrange
         SetupHappyPath(organization, inviteLink, user, sutProvider);
-        revokedEmailInvite.Status = OrganizationUserStatusType.Revoked;
+        revokedEmailInvite.RevocationReason = RevocationReason.Manual;
         revokedEmailInvite.Email = user.Email;
         revokedEmailInvite.UserId = null;
 
@@ -222,6 +222,7 @@ public class ConfirmOrganizationInviteLinkValidatorTests
         // Arrange
         SetupHappyPath(organization, inviteLink, user, sutProvider);
         existingOrganizationUser.Status = OrganizationUserStatusType.Confirmed;
+        existingOrganizationUser.RevocationReason = null;
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organization.Id, user.Id)
@@ -250,6 +251,7 @@ public class ConfirmOrganizationInviteLinkValidatorTests
         // Arrange
         SetupHappyPath(organization, inviteLink, user, sutProvider);
         existingOrganizationUser.Status = status;
+        existingOrganizationUser.RevocationReason = null;
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationAsync(organization.Id, user.Id)
@@ -413,6 +415,7 @@ public class ConfirmOrganizationInviteLinkValidatorTests
         invitedOrganizationUser.Status = OrganizationUserStatusType.Invited;
         invitedOrganizationUser.Email = user.Email;
         invitedOrganizationUser.UserId = null;
+        invitedOrganizationUser.RevocationReason = null;
 
         sutProvider.GetDependency<IOrganizationUserRepository>()
             .GetByOrganizationEmailAsync(organization.Id, user.Email)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidatorTests.cs
@@ -1,0 +1,491 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.AcceptMembership;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements.Errors;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Auth.UserFeatures.TwoFactorAuth.Interfaces;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Pricing;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data.Organizations.OrganizationUsers;
+using Bit.Core.Repositories;
+using Bit.Core.Test.Billing.Mocks.Plans;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.InviteLinks;
+
+[SutProviderCustomize]
+public class ConfirmOrganizationInviteLinkValidatorTests
+{
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithLinkNotFound_ReturnsInviteLinkNotFound(
+        ConfirmOrganizationInviteLinkValidationRequest request,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Act
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotFound>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithOrganizationNotFound_ReturnsInviteLinkNotFound(
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByCodeAsync(inviteLink.Code)
+            .Returns(inviteLink);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotFound>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithOrganizationDisabled_ReturnsInviteLinkNotFound(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        organization.Enabled = false;
+        inviteLink.OrganizationId = organization.Id;
+
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByCodeAsync(inviteLink.Code)
+            .Returns(inviteLink);
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotFound>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithOrganizationNotUsingInviteLinks_ReturnsInviteLinkNotAvailable(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        organization.Enabled = true;
+        organization.UseInviteLinks = false;
+        inviteLink.OrganizationId = organization.Id;
+
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByCodeAsync(inviteLink.Code)
+            .Returns(inviteLink);
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotAvailable>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithEmailDomainNotAllowed_ReturnsEmailDomainNotAllowed(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        inviteLink.AllowedDomains = "[\"allowed.example.com\"]";
+        user.Email = "user@notallowed.example.com";
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<EmailDomainNotAllowed>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithProviderUser_ReturnsProviderUsersCannotAcceptInviteLink(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        Bit.Core.AdminConsole.Entities.Provider.ProviderUser providerUser,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+
+        sutProvider.GetDependency<IProviderUserRepository>()
+            .GetManyByUserAsync(user.Id)
+            .Returns([providerUser]);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<ProviderUsersCannotAcceptInviteLink>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithRevokedMember_ReturnsOrganizationAccessRevoked(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser revokedOrganizationUser,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        revokedOrganizationUser.Status = OrganizationUserStatusType.Revoked;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(organization.Id, user.Id)
+            .Returns(revokedOrganizationUser);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<OrganizationAccessRevoked>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithRevokedEmailInvite_ReturnsOrganizationAccessRevoked(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser revokedEmailInvite,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        revokedEmailInvite.Status = OrganizationUserStatusType.Revoked;
+        revokedEmailInvite.Email = user.Email;
+        revokedEmailInvite.UserId = null;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationEmailAsync(organization.Id, user.Email)
+            .Returns(revokedEmailInvite);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<OrganizationAccessRevoked>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithConfirmedMember_ReturnsAlreadyOrganizationMember(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser existingOrganizationUser,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        existingOrganizationUser.Status = OrganizationUserStatusType.Confirmed;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(organization.Id, user.Id)
+            .Returns(existingOrganizationUser);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<AlreadyOrganizationMember>(result.AsError);
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserStatusType.Invited)]
+    [BitAutoData(OrganizationUserStatusType.Accepted)]
+    public async Task ValidateAsync_WithUnconfirmedExistingMember_IsAllowed(
+        OrganizationUserStatusType status,
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser existingOrganizationUser,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        existingOrganizationUser.Status = status;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(organization.Id, user.Id)
+            .Returns(existingOrganizationUser);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Same(existingOrganizationUser, result.AsSuccess.ExistingOrganizationUser);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithNewUserAndNoSeatsAvailable_ReturnsOrganizationHasNoAvailableSeats(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        organization.PlanType = PlanType.EnterpriseAnnually;
+        organization.Seats = 4;
+        organization.MaxAutoscaleSeats = 4;
+
+        sutProvider.GetDependency<IPricingClient>()
+            .GetPlan(organization.PlanType)
+            .Returns(new Enterprise2023Plan(isAnnual: true));
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)
+            .Returns(new OrganizationSeatCounts { Users = 4, Sponsored = 0 });
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<OrganizationHasNoAvailableSeats>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithSingleOrganizationPolicyViolation_ReturnsError(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser membershipInAnotherOrganization,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+
+        // Single Org enabled for the target org, and the user belongs to a different org.
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<SingleOrganizationPolicyRequirement>(user.Id)
+            .Returns(new SingleOrganizationPolicyRequirement(
+                [new PolicyDetails { OrganizationId = organization.Id }]));
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyByUserAsync(user.Id)
+            .Returns([membershipInAnotherOrganization]);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<UserIsAMemberOfAnotherOrganization>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithTwoFactorRequiredAndUserLacks2FA_ReturnsError(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<RequireTwoFactorPolicyRequirement>(user.Id)
+            .Returns(new RequireTwoFactorPolicyRequirement(
+                [new PolicyDetails { OrganizationId = organization.Id }]));
+
+        sutProvider.GetDependency<ITwoFactorIsEnabledQuery>()
+            .TwoFactorIsEnabledAsync(user)
+            .Returns(false);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<TwoFactorRequiredForMembership>(result.AsError);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithTwoFactorRequiredAndUserHas2FA_IsAllowed(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<RequireTwoFactorPolicyRequirement>(user.Id)
+            .Returns(new RequireTwoFactorPolicyRequirement(
+                [new PolicyDetails { OrganizationId = organization.Id }]));
+
+        sutProvider.GetDependency<ITwoFactorIsEnabledQuery>()
+            .TwoFactorIsEnabledAsync(user)
+            .Returns(true);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithNewUser_ReturnsValidatedContext(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Same(inviteLink, result.AsSuccess.InviteLink);
+        Assert.Same(organization, result.AsSuccess.Organization);
+        Assert.Null(result.AsSuccess.ExistingOrganizationUser);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ValidateAsync_WithExistingInvitedUser_SkipsSeatCheckAndReturnsContext(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser invitedOrganizationUser,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        invitedOrganizationUser.Status = OrganizationUserStatusType.Invited;
+        invitedOrganizationUser.Email = user.Email;
+        invitedOrganizationUser.UserId = null;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationEmailAsync(organization.Id, user.Email)
+            .Returns(invitedOrganizationUser);
+
+        // Act
+        var request = new ConfirmOrganizationInviteLinkValidationRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Same(invitedOrganizationUser, result.AsSuccess.ExistingOrganizationUser);
+
+        // An existing invite already occupies a seat, so no Password Manager seat check is performed.
+        await sutProvider.GetDependency<IPricingClient>()
+            .DidNotReceiveWithAnyArgs()
+            .GetPlan(Arg.Any<PlanType>());
+    }
+
+    private static void SetupHappyPath(
+        Organization org,
+        OrganizationInviteLink link,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        org.Enabled = true;
+        org.UseInviteLinks = true;
+        org.Seats = 10;
+        org.MaxAutoscaleSeats = null;
+        org.PlanType = PlanType.EnterpriseAnnually;
+        link.OrganizationId = org.Id;
+        link.AllowedDomains = "[\"example.com\"]";
+        user.Email = "user@example.com";
+
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByCodeAsync(link.Code)
+            .Returns(link);
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(org.Id)
+            .Returns(org);
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetOccupiedSeatCountByOrganizationIdAsync(org.Id)
+            .Returns(new OrganizationSeatCounts { Users = 1, Sponsored = 0 });
+
+        sutProvider.GetDependency<IPricingClient>()
+            .GetPlan(org.PlanType)
+            .Returns(new Enterprise2023Plan(isAnnual: true));
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(org.Id, user.Id)
+            .Returns((OrganizationUser?)null);
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationEmailAsync(org.Id, user.Email)
+            .Returns((OrganizationUser?)null);
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetManyByUserAsync(user.Id)
+            .Returns(new List<OrganizationUser>());
+
+        sutProvider.GetDependency<IProviderUserRepository>()
+            .GetManyByUserAsync(user.Id)
+            .Returns([]);
+
+        // No policies enforced by default.
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<SingleOrganizationPolicyRequirement>(user.Id)
+            .Returns(new SingleOrganizationPolicyRequirement([]));
+
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<RequireTwoFactorPolicyRequirement>(user.Id)
+            .Returns(new RequireTwoFactorPolicyRequirement([]));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38798

## 📔 Objective
The goal of this task is to create the validation and policy check logic that will be consumed by two endpoints in the tickets associated with this one.

We're only doing read checks here since this will be used in an endpoint before the actual confirmation. We won't perform any write checks, such as Organization Data Ownership, because we'll need to create a default collection for the invited user.

1. Add a validation class
2. Add unit tests

QA Note: No code is consuming this yet.


