### PR TITLE
[PM-20344] Throw BadRequestException when uploading attachments with …

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -1332,6 +1332,11 @@ public class CiphersController : Controller
             throw new BadRequestException($"Max file size is {CipherService.MAX_FILE_SIZE_READABLE}.");
         }
 
+        if (cipher.GetAttachments().Values.Any(v => v.FileName == request.FileName))
+        {
+            throw new BadRequestException("Items cannot have multiple attachments with the same file name");
+        }
+
         var (attachmentId, uploadUrl) = await _cipherService.CreateAttachmentForDelayedUploadAsync(cipher,
             request.Key, request.FileName, request.FileSize, request.AdminRequest, user.Id, request.LastKnownRevisionDate);
 

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -2486,4 +2486,37 @@ public class CiphersControllerTests
         Assert.Equal(fileName, fileResult.FileDownloadName);
         Assert.Same(stream, fileResult.FileStream);
     }
+
+    [Theory, BitAutoData]
+    public async Task PostAttachment_WithDuplicateFilename_ThrowsBadRequestError(
+        User user, Guid cipherId, string attachmentId,
+        SutProvider<CiphersController> sutProvider)
+    {
+        var fileName = "shared-filename.txt";
+        var metaData = new CipherAttachment.MetaData
+        {
+            AttachmentId = attachmentId,
+            FileName = fileName,
+            Size = 10,
+        };
+
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        var cipherDetails = new CipherDetails { Id = cipherId, UserId = user.Id, Type = CipherType.Login, Data = "{}", Attachments = JsonSerializer.Serialize(
+            new Dictionary<string, CipherAttachment.MetaData> { { attachmentId, metaData } })};
+        sutProvider.GetDependency<ICipherRepository>().GetByIdAsync(cipherId, user.Id)
+            .Returns(Task.FromResult(cipherDetails));
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.PostAttachment(cipherId, new AttachmentRequestModel {
+                AdminRequest = false,
+                FileName = fileName,
+                FileSize = 10,
+                Key = "test-key"
+            })
+        );
+        Assert.Equal("Items cannot have multiple attachments with the same file name", exception.Message);
+    }
 }


### PR DESCRIPTION
…same name as existing attachment

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20344

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds a BadRequestException when trying to upload an attachment with the same name as an existing attachment. This will be prevented client-side by [this PR](https://github.com/bitwarden/clients/pull/21596) for every client except the CLI, which will be covered by this server change.
