### PR TITLE
Auth - Tokenables Claude Rule Update - Add binding-property lockdown and known-limitation note 

### DIFF
--- a/.claude/rules/auth-tokenables.md
+++ b/.claude/rules/auth-tokenables.md
@@ -18,7 +18,16 @@ with an ad-hoc or missing expiry. Direct `new` construction is the historical pa
   a constant hardcoded at the call site, so the token's lifetime is configurable without a redeploy.
 - **The lifetime-setting constructor MUST be `internal`.** Leave only the public `[JsonConstructor]` parameterless ctor
   (for deserialization) public, so callers in other assemblies (Identity, Api, Admin) cannot bypass the factory.
+- **Binding properties MUST be `[JsonInclude] public { get; internal set; }`.** `internal set` keeps the factory the
+  only mint path; `[JsonInclude]` is required because `JsonSerializer.Deserialize` silently skips non-public setters
+  with default options, so deserialized tokens come back with `default` values and fail validation.
 - **Expose a static validator.** Provide a static validation method returning a typed `TokenableValidationError?`
   so mint-time and validate-time logic stay consistent.
 
 For broader C#/DI conventions, defer to the `writing-server-code` skill.
+
+## Known limitation
+
+`ExpiringTokenable.ExpirationDate` has a `public` setter a derived tokenable cannot tighten. External callers can
+set it via object initializer, but the token still fails validation (binding properties remain `default`). Closing
+this fully needs a base-class change.


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
n/a but the issue was discovered as a result of this Claude comment on my 2FA refactor PR: https://github.com/bitwarden/server/pull/7841#discussion_r3500264896

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Two additions to the rule for new tokenables:

1. Binding properties MUST be `[JsonInclude] public { get; internal set; }`. `internal set` blocks the object-initializer bypass left open by `internal`-ctor-alone; `[JsonInclude]` is required because `JsonSerializer.Deserialize` with default options (what `Tokenable.FromToken` uses) silently skips non-public setters and tokens would deserialize with `default` values.

2. Known limitation section documenting that `ExpiringTokenable.ExpirationDate` has a public setter a derived tokenable cannot tighten. External callers can still set it via object initializer, but the token fails validation because binding properties remain `default`; fully closing the surface needs a base-class change.

Backed by 15 probe tests run against `JsonSerializer.Deserialize` with default options, covering:

- Baseline round-trip with public setters.
- `internal set` without `[JsonInclude]` silently drops values (the footgun).
- `internal set` with `[JsonInclude]` round-trips correctly.
- Internal lifetime-setting ctor alongside public `[JsonConstructor]` does not affect deserialization.
- Internal ctor alone does not prevent object-initializer bypass.
- Inherited `ExpirationDate` remains publicly settable in derived types.
- Properties with compile-time defaults are overwritten by wire values during deserialize.
- Old wire format -> new shape and new wire format -> old shape both round-trip (backward/forward compatible).
- `[JsonInclude]` does not suppress JSON emission.
- `init` setters do NOT lock down cross-assembly construction (justifies choosing `internal set` over `init`).
- `[JsonInclude]` composes cleanly with `[JsonConverter]` on the same property.
- Nullable `string?` round-trips both null and value with the locked-down shape.
- End-to-end mirror of the post-refactor production shape round-trips and validates.
- Same-assembly vs cross-assembly object-initializer asymmetry documented in tests.

Probe file `InternalSetterDeserializationProbe.cs` attached to the PR as evidence: [InternalSetterDeserializationProbe.cs](https://github.com/user-attachments/files/29518693/InternalSetterDeserializationProbe.cs)



## 📸 Screenshots
<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
n/a