### PR TITLE
[PM-39805] fix: Expose SM migration-grace service accounts on subscription response

### DIFF
--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationResponseModel.cs
@@ -156,6 +156,7 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
         bool hideSensitiveData) : this(organization, plan)
     {
         Subscription = subscription.Subscription != null ? new BillingSubscription(subscription.Subscription) : null;
+        SmServiceAccountsGrace = subscription.Subscription?.ServiceAccountGrace;
         UpcomingInvoice = subscription.UpcomingInvoice != null ? new BillingSubscriptionUpcomingInvoice(subscription.UpcomingInvoice) : null;
         CustomerDiscount = subscription.CustomerDiscount != null ? new BillingCustomerDiscount(subscription.CustomerDiscount) : null;
         Expiration = DateTime.UtcNow.AddYears(1); // Not used, so just give it a value.
@@ -218,6 +219,14 @@ public class OrganizationSubscriptionResponseModel : OrganizationResponseModel
     public BillingCustomerDiscount CustomerDiscount { get; set; }
     public BillingSubscription Subscription { get; set; }
     public BillingSubscriptionUpcomingInvoice UpcomingInvoice { get; set; }
+
+    /// <summary>
+    /// The count of permanently-free Secrets Manager service accounts granted beyond the plan baseline during a
+    /// pricing migration. Clients subtract this from <see cref="OrganizationResponseModel.SmServiceAccounts"/> so the
+    /// migration-grace allotment is not billed. Null on self-hosted and when there is no gateway subscription;
+    /// a concrete count (including 0 for a non-migrated cloud organization) otherwise.
+    /// </summary>
+    public int? SmServiceAccountsGrace { get; set; }
 
     /// <summary>
     /// Date when a self-hosted organization's subscription expires, without any grace period.

--- a/src/Core/Billing/Extensions/SubscriptionExtensions.cs
+++ b/src/Core/Billing/Extensions/SubscriptionExtensions.cs
@@ -7,7 +7,8 @@ namespace Bit.Core.Billing.Extensions;
 public static class SubscriptionExtensions
 {
     public static int GetMigrationGraceServiceAccounts(this Subscription subscription) =>
-        subscription.Metadata.TryGetValue(StripeConstants.MetadataKeys.MigrationGraceServiceAccounts, out var raw)
+        subscription.Metadata != null
+        && subscription.Metadata.TryGetValue(StripeConstants.MetadataKeys.MigrationGraceServiceAccounts, out var raw)
         && int.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var grace)
         && grace > 0
             ? grace

--- a/src/Core/Models/Business/SubscriptionInfo.cs
+++ b/src/Core/Models/Business/SubscriptionInfo.cs
@@ -147,6 +147,7 @@ public class SubscriptionInfo
             GracePeriod = sub?.CollectionMethod == "charge_automatically"
                 ? 14
                 : 30;
+            ServiceAccountGrace = sub?.GetMigrationGraceServiceAccounts() ?? 0;
         }
 
         public DateTime? TrialStartDate { get; set; }
@@ -163,6 +164,12 @@ public class SubscriptionInfo
         public DateTime? SuspensionDate { get; set; }
         public DateTime? UnpaidPeriodEndDate { get; set; }
         public int GracePeriod { get; set; }
+
+        /// <summary>
+        /// The count of permanently-free Secrets Manager service accounts granted beyond the plan baseline
+        /// during a pricing migration. Read from Stripe subscription metadata; 0 when none was granted.
+        /// </summary>
+        public int ServiceAccountGrace { get; set; }
 
         public class BillingSubscriptionItem
         {

--- a/test/Api.Test/Billing/Controllers/OrganizationsControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/OrganizationsControllerTests.cs
@@ -27,9 +27,11 @@ using Bit.Core.Models.Data.Organizations.OrganizationUsers;
 using Bit.Core.OrganizationFeatures.OrganizationSubscriptions.Interface;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Test.Billing.Mocks.Plans;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using OneOf.Types;
+using Stripe;
 using Xunit;
 using GlobalSettings = Bit.Core.Settings.GlobalSettings;
 
@@ -342,5 +344,122 @@ public class OrganizationsControllerTests : IDisposable
         _organizationRepository.GetByIdAsync(organizationId).ReturnsNull();
 
         await Assert.ThrowsAsync<NotFoundException>(() => _sut.PostReinstate(organizationId));
+    }
+
+    [Theory, AutoData]
+    public async Task GetSubscription_CloudOrganizationWithMigrationGrace_PopulatesSmServiceAccountsGrace(
+        Guid organizationId,
+        Organization organization)
+    {
+        organization.GatewaySubscriptionId = "sub_123";
+        var plan = new EnterprisePlan(isAnnual: true);
+        var subscriptionInfo = new SubscriptionInfo
+        {
+            Subscription = new SubscriptionInfo.BillingSubscription(
+                new Subscription { Items = new StripeList<SubscriptionItem> { Data = [] } })
+            {
+                ServiceAccountGrace = 30
+            }
+        };
+
+        _currentContext.ViewSubscription(organizationId).Returns(true);
+        _currentContext.EditSubscription(organizationId).Returns(true);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(plan);
+        _paymentService.GetSubscriptionAsync(organization).Returns(subscriptionInfo);
+
+        var response = await _sut.GetSubscription(organizationId);
+
+        Assert.Equal(30, response.SmServiceAccountsGrace);
+    }
+
+    [Theory, AutoData]
+    public async Task GetSubscription_CloudOrganizationWithoutGrace_SmServiceAccountsGraceIsZero(
+        Guid organizationId,
+        Organization organization)
+    {
+        organization.GatewaySubscriptionId = "sub_123";
+        var plan = new EnterprisePlan(isAnnual: true);
+        var subscriptionInfo = new SubscriptionInfo
+        {
+            Subscription = new SubscriptionInfo.BillingSubscription(
+                new Subscription { Items = new StripeList<SubscriptionItem> { Data = [] } })
+            {
+                ServiceAccountGrace = 0
+            }
+        };
+
+        _currentContext.ViewSubscription(organizationId).Returns(true);
+        _currentContext.EditSubscription(organizationId).Returns(true);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(plan);
+        _paymentService.GetSubscriptionAsync(organization).Returns(subscriptionInfo);
+
+        var response = await _sut.GetSubscription(organizationId);
+
+        Assert.Equal(0, response.SmServiceAccountsGrace);
+    }
+
+    [Theory, AutoData]
+    public async Task GetSubscription_SelfHosted_SmServiceAccountsGraceIsNull(
+        Guid organizationId,
+        Organization organization)
+    {
+        _globalSettings.SelfHosted = true;
+        _currentContext.ViewSubscription(organizationId).Returns(true);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+
+        var response = await _sut.GetSubscription(organizationId);
+
+        Assert.Null(response.SmServiceAccountsGrace);
+        await _paymentService.DidNotReceiveWithAnyArgs().GetSubscriptionAsync(default);
+    }
+
+    [Theory, AutoData]
+    public async Task GetSubscription_NoGatewaySubscription_SmServiceAccountsGraceIsNull(
+        Guid organizationId,
+        Organization organization)
+    {
+        organization.GatewaySubscriptionId = null;
+        var plan = new EnterprisePlan(isAnnual: true);
+
+        _currentContext.ViewSubscription(organizationId).Returns(true);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(plan);
+
+        var response = await _sut.GetSubscription(organizationId);
+
+        Assert.Null(response.SmServiceAccountsGrace);
+        await _paymentService.DidNotReceiveWithAnyArgs().GetSubscriptionAsync(default);
+    }
+
+    [Theory, AutoData]
+    public async Task GetSubscription_WhenHidingSensitiveData_StillPopulatesSmServiceAccountsGrace(
+        Guid organizationId,
+        Organization organization)
+    {
+        organization.GatewaySubscriptionId = "sub_123";
+        var plan = new EnterprisePlan(isAnnual: true);
+        var subscriptionInfo = new SubscriptionInfo
+        {
+            Subscription = new SubscriptionInfo.BillingSubscription(
+                new Subscription { Items = new StripeList<SubscriptionItem> { Data = [] } })
+            {
+                ServiceAccountGrace = 30
+            }
+        };
+
+        _currentContext.ViewSubscription(organizationId).Returns(true);
+        _currentContext.EditSubscription(organizationId).Returns(false); // hideSensitiveData = true
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(plan);
+        _paymentService.GetSubscriptionAsync(organization).Returns(subscriptionInfo);
+
+        var response = await _sut.GetSubscription(organizationId);
+
+        // Grace is a non-sensitive count and must survive the hideSensitiveData branch...
+        Assert.Equal(30, response.SmServiceAccountsGrace);
+        // ...while genuinely sensitive data is still hidden.
+        Assert.Null(response.BillingEmail);
     }
 }

--- a/test/Core.Test/Billing/Services/StripePaymentServiceTests.cs
+++ b/test/Core.Test/Billing/Services/StripePaymentServiceTests.cs
@@ -1568,4 +1568,72 @@ public class StripePaymentServiceTests
         Assert.Equal(4, item.Quantity); // carried from Phase 2, not the base line's 1
         Assert.Equal(16m, item.Amount * item.Quantity);
     }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetSubscriptionAsync_WithMigrationGraceMetadata_MapsServiceAccountGrace(
+        SutProvider<StripePaymentService> sutProvider,
+        User subscriber)
+    {
+        // Arrange — a migrated subscription carries the free service-account grace in metadata.
+        subscriber.Gateway = GatewayType.Stripe;
+        subscriber.GatewayCustomerId = "cus_test123";
+        subscriber.GatewaySubscriptionId = "sub_test123";
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Status = "active",
+            CollectionMethod = "charge_automatically",
+            Customer = new Customer { Discount = null },
+            Discounts = new List<Discount>(),
+            Items = new StripeList<SubscriptionItem> { Data = [] },
+            Metadata = new Dictionary<string, string>
+            {
+                { MetadataKeys.MigrationGraceServiceAccounts, "30" }
+            }
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(subscriber.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        // Act
+        var result = await sutProvider.Sut.GetSubscriptionAsync(subscriber);
+
+        // Assert — grace is read off metadata onto the wrapper using the already-fetched subscription.
+        Assert.Equal(30, result.Subscription!.ServiceAccountGrace);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task GetSubscriptionAsync_WithoutMigrationGraceMetadata_ServiceAccountGraceIsZero(
+        SutProvider<StripePaymentService> sutProvider,
+        User subscriber)
+    {
+        // Arrange — Metadata intentionally left null (non-migrated subscription); the read must not throw.
+        subscriber.Gateway = GatewayType.Stripe;
+        subscriber.GatewayCustomerId = "cus_test123";
+        subscriber.GatewaySubscriptionId = "sub_test123";
+
+        var subscription = new Subscription
+        {
+            Id = "sub_test123",
+            Status = "active",
+            CollectionMethod = "charge_automatically",
+            Customer = new Customer { Discount = null },
+            Discounts = new List<Discount>(),
+            Items = new StripeList<SubscriptionItem> { Data = [] }
+        };
+
+        sutProvider.GetDependency<IStripeAdapter>()
+            .GetSubscriptionAsync(subscriber.GatewaySubscriptionId, Arg.Any<SubscriptionGetOptions>())
+            .Returns(subscription);
+
+        // Act
+        var result = await sutProvider.Sut.GetSubscriptionAsync(subscriber);
+
+        // Assert
+        Assert.Equal(0, result.Subscription!.ServiceAccountGrace);
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39805

## 📔 Objective

After a Teams Starter 2023 → Teams (Monthly) migration, the Secrets Manager subscription response priced the permanent migration-grace service accounts as billable. The web vault's "Additional machine accounts" field showed 55 (30 grace + 25 paid) at $55/month, while the billing summary and Stripe correctly billed 25 @ $25/month — two conflicting machine-account costs for the same subscription.

The grace allotment (e.g. 30 = source SM baseline 50 − target baseline 20) is written to Stripe subscription metadata as `migration_grace_service_accounts` at migration, but was never surfaced on the subscription response, so the client could not exclude it.

This PR exposes that count on the subscription/organization response via `SubscriptionInfo.ServiceAccountGrace` (read through `SubscriptionExtensions.GetMigrationGraceServiceAccounts`), letting the client subtract the free, permanent grace from the billable additional-machine-accounts figure. The field then reports 25 @ $1 = $25, matching the billing summary and Stripe.

Unit tests added in `StripePaymentServiceTests` (Core.Test) and `OrganizationsControllerTests` (Api.Test).
