### PR TITLE
[PM-39816] fix: Raise migrated Password Manager seats to cover Secrets Manager seats

### DIFF
--- a/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
+++ b/src/Billing/Services/Implementations/SubscriptionUpdatedHandler.cs
@@ -640,11 +640,12 @@ public class SubscriptionUpdatedHandler : ISubscriptionUpdatedHandler
 
             // Packaged source plans (Teams Starter's flat bundle cap, Teams 2019's base seat allotment) store a
             // seat count in Seats that doesn't match the billed per-seat quantity; reconcile to what was billed.
+            // Also floor Seats on the DB SmSeats value to keep SM <= PM in the persisted record. Idempotent.
             if (isPackagedSourcePlan)
             {
                 var billedSeatQuantity = subscription.Items
                     .First(item => item.Price?.Id == targetPriceId).Quantity;
-                organization.Seats = (int)Math.Max(1, billedSeatQuantity);
+                organization.Seats = (int)Math.Max(Math.Max(1L, billedSeatQuantity), (long)(organization.SmSeats ?? 0));
             }
 
             await _organizationRepository.ReplaceAsync(organization);

--- a/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
+++ b/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
@@ -512,7 +512,15 @@ public class UpcomingInvoiceHandler(
         {
             var occupied = (await organizationRepository
                 .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)).Total;
-            return sourcePlan.ResolveMigratedSeatCount(occupied, organization.Seats);
+            var passwordManagerSeats = sourcePlan.ResolveMigratedSeatCount(occupied, organization.Seats);
+
+            // Floor the quote on the Stripe SM seat line so the email matches the billed PM seats (SM <= PM).
+            var secretsManagerSeatQuantity = subscription.Items.Data
+                .FirstOrDefault(item =>
+                    sourcePlan.SecretsManager is not null &&
+                    item.Price?.Id == sourcePlan.SecretsManager.StripeSeatPlanId)?.Quantity ?? 0;
+
+            return (int)Math.Max((long)passwordManagerSeats, secretsManagerSeatQuantity);
         }
 
         var seatItem = subscription.Items.Data

--- a/src/Core/Billing/Pricing/PriceIncreaseScheduler.cs
+++ b/src/Core/Billing/Pricing/PriceIncreaseScheduler.cs
@@ -557,6 +557,11 @@ public class PriceIncreaseScheduler(
         // quantity. Scalable sources preserve their line-item quantities.
         var isPackagedSourcePlan = sourcePlan.IsPackagedMigrationSource(migrationPath.SeatCountPolicy);
 
+        // Captured while iterating below: the billed SM seat line quantity used to floor the collapsed PM
+        // seat line (keep SM <= PM). Matched on the source SM seat price id, distinct from the SM
+        // service-account line. Stays 0 when there is no SM seat line.
+        var secretsManagerSeatQuantity = 0L;
+
         var items = new List<SubscriptionSchedulePhaseItemOptions>();
         foreach (var item in subscription.Items.Data)
         {
@@ -567,6 +572,11 @@ public class PriceIncreaseScheduler(
                     "Subscription ({SubscriptionId}) line item price ({PriceId}) has no mapping in migration path {PathName}; skipping schedule",
                     subscription.Id, item.Price.Id, migrationPath.Name);
                 return null;
+            }
+
+            if (sourcePlan.SecretsManager is not null && item.Price.Id == sourcePlan.SecretsManager.StripeSeatPlanId)
+            {
+                secretsManagerSeatQuantity = item.Quantity;
             }
 
             // Skip the packaged source's seat line(s) here; one collapsed seat line is added below.
@@ -587,7 +597,7 @@ public class PriceIncreaseScheduler(
             items.Add(new SubscriptionSchedulePhaseItemOptions
             {
                 Price = targetSeatPriceId,
-                Quantity = await CalculateTargetPlanSeatCountAsync(sourcePlan, organizationId)
+                Quantity = await CalculatePasswordManagerSeatCountAsync(sourcePlan, organizationId, secretsManagerSeatQuantity)
             });
         }
 
@@ -617,16 +627,27 @@ public class PriceIncreaseScheduler(
     }
 
     /// <summary>
-    /// Resolves the billed Phase 2 seat count for a Packaged source from the organization's actual usage.
+    /// Resolves the billed Password Manager seat count for a Packaged source from the organization's actual
+    /// usage, floored at the Stripe Secrets Manager seat line quantity to keep SM &lt;= PM.
     /// </summary>
-    private async Task<int> CalculateTargetPlanSeatCountAsync(OrganizationPlan sourcePlan, Guid organizationId)
+    private async Task<int> CalculatePasswordManagerSeatCountAsync(
+        OrganizationPlan sourcePlan, Guid organizationId, long secretsManagerSeatQuantity)
     {
-        // Packaged line items don't reflect the true total, so bill by actual usage. organization.Seats
-        // supplies the purchased count ResolveMigratedSeatCount uses for the seat-overage case.
+        // Packaged line items don't reflect the true total; bill by actual usage.
         var occupiedSeatCount = (await organizationRepository
             .GetOccupiedSeatCountByOrganizationIdAsync(organizationId)).Total;
         var organization = await organizationRepository.GetByIdAsync(organizationId);
-        return sourcePlan.ResolveMigratedSeatCount(occupiedSeatCount, organization?.Seats);
+        var passwordManagerSeatCount = sourcePlan.ResolveMigratedSeatCount(occupiedSeatCount, organization?.Seats);
+
+        // Floor on the billed Stripe line, not DB SmSeats, so Stripe billing stays correct under drift; log drift.
+        if (secretsManagerSeatQuantity != (organization?.SmSeats ?? 0))
+        {
+            logger.LogWarning(
+                "Secrets Manager seat drift for organization ({OrganizationId}) during business migration: Stripe SM seat line quantity ({StripeSecretsManagerSeats}) does not match Organization.SmSeats ({OrganizationSecretsManagerSeats}); flooring billed Password Manager seats on the Stripe line",
+                organizationId, secretsManagerSeatQuantity, organization?.SmSeats ?? 0);
+        }
+
+        return (int)Math.Max((long)passwordManagerSeatCount, secretsManagerSeatQuantity);
     }
 
     /// <summary>

--- a/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
+++ b/test/Billing.Test/Services/SubscriptionUpdatedHandlerTests.cs
@@ -4367,6 +4367,226 @@ public class SubscriptionUpdatedHandlerTests
         Assert.NotNull(assignment.MigratedDate);
     }
 
+    // PM-39816: the migrated Seats must cover purchased Secrets Manager seats so the current Teams invariant
+    // SM <= PM holds in the persisted record. The DB-domain reconcile floors Seats on the DB SmSeats value,
+    // never lowering SmSeats. Applies to every Packaged source: both Teams Starter PlanTypes (21, 16) and
+    // Teams 2019 (the same target invariant and the same latent bug).
+    [Theory]
+    [InlineData(PlanType.TeamsStarter, 4, 5, 5)]        // SM purchased above billed PM -> raise Seats to 5
+    [InlineData(PlanType.TeamsStarter2023, 4, 5, 5)]    // 2023 starter source
+    [InlineData(PlanType.TeamsMonthly2019, 4, 5, 5)]    // Teams 2019 packaged source
+    [InlineData(PlanType.TeamsStarter, 4, null, 4)]     // no SM seats -> Seats stays at billed (no regression)
+    [InlineData(PlanType.TeamsStarter2023, 4, null, 4)]
+    [InlineData(PlanType.TeamsMonthly2019, 4, null, 4)]
+    [InlineData(PlanType.TeamsStarter, 1, 3, 3)]        // floored billed PM (1), SM 3 -> Seats 3
+    [InlineData(PlanType.TeamsStarter2023, 1, 3, 3)]
+    [InlineData(PlanType.TeamsMonthly2019, 1, 3, 3)]
+    public async Task HandleAsync_BusinessMigration_PackagedSource_FloorsSeatsOnSmSeats(
+        PlanType sourcePlanType, long billedSeats, int? smSeats, int expectedSeats)
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var sourcePlan = MockPlans.Get(sourcePlanType);
+        var teamsMonthly = MockPlans.Get(PlanType.TeamsMonthly);
+        var migrationPathId = sourcePlanType switch
+        {
+            PlanType.TeamsStarter => MigrationPathId.TeamsStarterToCurrent,
+            PlanType.TeamsStarter2023 => MigrationPathId.TeamsStarter2023ToCurrent,
+            PlanType.TeamsMonthly2019 => MigrationPathId.Teams2019MonthlyToCurrent,
+            _ => throw new ArgumentOutOfRangeException(nameof(sourcePlanType))
+        };
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = sourcePlan.PasswordManager.StripePlanId },
+                        Plan = new Plan { Id = sourcePlan.PasswordManager.StripePlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_floor_sm",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },
+                        Quantity = billedSeats
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = sourcePlanType,
+            Plan = sourcePlan.Name,
+            Seats = 10,
+            SmSeats = smSeats,
+            SmServiceAccounts = 20
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(sourcePlanType).Returns(sourcePlan);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(teamsMonthly);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = sourcePlanType.ToString(),
+            MigrationPathId = migrationPathId,
+            IsActive = true
+        });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — Seats floored at SmSeats and persisted; SmSeats itself untouched (we raise PM, never lower SM).
+        Assert.Equal(expectedSeats, organization.Seats);
+        Assert.Equal(smSeats, organization.SmSeats);
+        await _organizationRepository.Received(1).ReplaceAsync(Arg.Is<Organization>(o =>
+            o.Id == organizationId &&
+            o.PlanType == PlanType.TeamsMonthly &&
+            o.Seats == expectedSeats &&
+            o.SmSeats == smSeats));
+    }
+
+    // PM-39816 (Risk 4): the Math.Max floor is idempotent. If Stripe replays the event before MigratedDate is
+    // stamped, the reconcile re-runs and must recompute the identical Seats value.
+    [Fact]
+    public async Task HandleAsync_BusinessMigration_TeamsStarter_FloorOnSmSeatsIsIdempotentAcrossRetry()
+    {
+        // Arrange
+        var organizationId = Guid.NewGuid();
+        var cohortId = Guid.NewGuid();
+        var teamsStarter = new TeamsStarterPlan();
+        var teamsMonthly = new TeamsPlan(false);
+
+        var previousSubscription = new Subscription
+        {
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = teamsStarter.PasswordManager.StripePlanId },
+                        Plan = new Plan { Id = teamsStarter.PasswordManager.StripePlanId }
+                    }
+                ]
+            }
+        };
+
+        var subscription = new Subscription
+        {
+            Id = "sub_idem_sm",
+            ScheduleId = "sub_sched_x",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem
+                    {
+                        Price = new Price { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },
+                        Plan = new Plan { Id = teamsMonthly.PasswordManager.StripeSeatPlanId },
+                        Quantity = 4
+                    }
+                ]
+            },
+            Metadata = new Dictionary<string, string> { { "organizationId", organizationId.ToString() } },
+            LatestInvoice = new Invoice { BillingReason = BillingReasons.SubscriptionCycle }
+        };
+
+        var organization = new Organization
+        {
+            Id = organizationId,
+            PlanType = PlanType.TeamsStarter,
+            Plan = teamsStarter.Name,
+            Seats = 10,
+            SmSeats = 5,
+            SmServiceAccounts = 20
+        };
+
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            CohortId = cohortId
+        };
+
+        var parsedEvent = new Event
+        {
+            Data = new EventData
+            {
+                Object = subscription,
+                PreviousAttributes = JObject.FromObject(previousSubscription)
+            }
+        };
+
+        _stripeEventService.GetSubscription(Arg.Any<Event>(), Arg.Any<bool>(), Arg.Any<List<string>>())
+            .Returns(subscription);
+        _organizationRepository.GetByIdAsync(organizationId).Returns(organization);
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsStarter).Returns(teamsStarter);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(teamsMonthly);
+        _pricingClient.ListPlans().Returns(MockPlans.Plans);
+        _cohortAssignmentRepository.GetByOrganizationIdAsync(organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "TeamsStarter",
+            MigrationPathId = MigrationPathId.TeamsStarterToCurrent,
+            IsActive = true
+        });
+
+        // Act — first apply, then simulate a pre-stamp Stripe retry by clearing MigratedDate so the reconcile re-runs.
+        await _sut.HandleAsync(parsedEvent);
+        Assert.Equal(5, organization.Seats);
+
+        assignment.MigratedDate = null;
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — the replay recomputes the identical floored value.
+        Assert.Equal(5, organization.Seats);
+        Assert.Equal(5, organization.SmSeats);
+    }
+
     [Theory]
     [InlineData(3)]
     [InlineData(7)]

--- a/test/Billing.Test/Services/UpcomingInvoiceHandlerTests.cs
+++ b/test/Billing.Test/Services/UpcomingInvoiceHandlerTests.cs
@@ -4856,6 +4856,142 @@ public class UpcomingInvoiceHandlerTests
             mail.View.PerUserMonthlyPrice == "$5"));
     }
 
+    // PM-39816: when the org holds more Secrets Manager seats than occupied members, the renewal email must
+    // quote the raised Password Manager seat count so it matches what the scheduler bills (current Teams
+    // requires SM <= PM). 9 SM seats / 7 occupied members => the email quotes 9, flooring on the Stripe SM line.
+    [Fact]
+    public async Task SendBusinessRenewalEmail_TeamsStarter_RaisesQuotedSeatsToCoverSecretsManager()
+    {
+        // Arrange
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        var parsedEvent = new Event { Id = "evt_123", Type = "invoice.upcoming" };
+        var (invoice, subscription, customer) = BuildBusinessFixture(PlanType.TeamsStarter2023);
+        var sourcePlan = new TeamsStarterPlan2023();
+        var targetPlan = new TeamsPlan(isAnnual: false);
+
+        // The surviving Stripe SM seat line (9) is what the scheduler floors Password Manager on.
+        subscription.Items.Data.Add(new SubscriptionItem
+        {
+            Price = new Price { Id = sourcePlan.SecretsManager.StripeSeatPlanId },
+            Quantity = 9
+        });
+
+        var organization = new Organization
+        {
+            Id = _organizationId,
+            BillingEmail = "org@example.com",
+            PlanType = PlanType.TeamsStarter2023,
+            Seats = 10,
+            SmSeats = 9
+        };
+        var cohortId = Guid.NewGuid();
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _organizationId,
+            CohortId = cohortId,
+            ScheduledDate = null
+        };
+        var cohort = new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "teams-starter-2023",
+            MigrationPathId = MigrationPathId.TeamsStarter2023ToCurrent,
+            IsActive = true
+        };
+
+        _stripeEventService.GetInvoice(parsedEvent).Returns(invoice);
+        _stripeAdapter.GetCustomerAsync(customer.Id, Arg.Any<CustomerGetOptions>()).Returns(customer);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(_organizationId, null, null));
+        _organizationRepository.GetByIdAsync(_organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsStarter2023).Returns(sourcePlan);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(targetPlan);
+        _stripeEventUtilityService.IsSponsoredSubscription(subscription).Returns(false);
+        _assignmentRepository.GetByOrganizationIdAsync(_organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(cohort);
+        _organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(_organizationId)
+            .Returns(new OrganizationSeatCounts { Users = 7 });
+        _priceIncreaseScheduler.ScheduleForSubscription(subscription, Arg.Any<OrganizationPriceIncreaseOptions>())
+            .Returns(true);
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — the email quotes 9 seats (raised from 7 occupied to cover SM), matching the invoice.
+        await _mailer.Received(1).SendEmail(Arg.Is<BusinessPlanRenewal2020MigrationMail>(mail =>
+            mail.ToEmails.Contains("org@example.com") &&
+            !mail.View.IsAnnual &&
+            mail.View.Seats == 9));
+    }
+
+    // PM-39816: the renewal email also raises the quoted seat count for the Teams 2019 packaged source,
+    // matching the scheduler's floor on the Stripe SM seat line. 9 SM seats / 7 occupied -> quote 9.
+    [Fact]
+    public async Task SendBusinessRenewalEmail_Teams2019_RaisesQuotedSeatsToCoverSecretsManager()
+    {
+        // Arrange
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+        var parsedEvent = new Event { Id = "evt_123", Type = "invoice.upcoming" };
+        var (invoice, subscription, customer) = BuildBusinessFixture(PlanType.TeamsMonthly2019);
+        var sourcePlan = new Teams2019Plan(isAnnual: false);
+        var targetPlan = new TeamsPlan(isAnnual: false);
+
+        // The surviving Stripe SM seat line (9) is what the scheduler floors Password Manager on.
+        subscription.Items.Data.Add(new SubscriptionItem
+        {
+            Price = new Price { Id = sourcePlan.SecretsManager.StripeSeatPlanId },
+            Quantity = 9
+        });
+
+        var organization = new Organization
+        {
+            Id = _organizationId,
+            BillingEmail = "org@example.com",
+            PlanType = PlanType.TeamsMonthly2019,
+            Seats = 5,
+            SmSeats = 9
+        };
+        var cohortId = Guid.NewGuid();
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = _organizationId,
+            CohortId = cohortId,
+            ScheduledDate = null
+        };
+        var cohort = new OrganizationPlanMigrationCohort
+        {
+            Id = cohortId,
+            Name = "teams-2019-monthly",
+            MigrationPathId = MigrationPathId.Teams2019MonthlyToCurrent,
+            IsActive = true
+        };
+
+        _stripeEventService.GetInvoice(parsedEvent).Returns(invoice);
+        _stripeAdapter.GetCustomerAsync(customer.Id, Arg.Any<CustomerGetOptions>()).Returns(customer);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(_organizationId, null, null));
+        _organizationRepository.GetByIdAsync(_organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly2019).Returns(sourcePlan);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(targetPlan);
+        _stripeEventUtilityService.IsSponsoredSubscription(subscription).Returns(false);
+        _assignmentRepository.GetByOrganizationIdAsync(_organizationId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohortId).Returns(cohort);
+        _organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(_organizationId)
+            .Returns(new OrganizationSeatCounts { Users = 7 });
+        _priceIncreaseScheduler.ScheduleForSubscription(subscription, Arg.Any<OrganizationPriceIncreaseOptions>())
+            .Returns(true);
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert — the email quotes 9 seats (raised from 7 occupied to cover SM), matching the invoice.
+        await _mailer.Received(1).SendEmail(Arg.Is<BusinessPlanRenewal2020MigrationMail>(mail =>
+            mail.ToEmails.Contains("org@example.com") &&
+            mail.View.Seats == 9));
+    }
+
     [Fact]
     public async Task HandleAsync_WhenBusinessTier_AndCohortCouponOnPhase_PlusSubscriptionCoupon_ItemizesAndTotalsBoth()
     {

--- a/test/Core.Test/Billing/Pricing/PriceIncreaseSchedulerTests.cs
+++ b/test/Core.Test/Billing/Pricing/PriceIncreaseSchedulerTests.cs
@@ -2275,6 +2275,282 @@ public class PriceIncreaseSchedulerTests
                     i.Price == target.PasswordManager.StripeStoragePlanId && i.Quantity == 5)));
     }
 
+    // PM-39816: when an org holds more Secrets Manager seats than occupied Password Manager members, the
+    // migration must raise the billed PM seat line to cover SM (current Teams requires SM <= PM). 5 SM seats /
+    // 4 occupied members => the bug's exact 5/4 -> 5/5 case.
+    [Fact]
+    public async Task ScheduleBusinessPriceIncrease_TeamsStarter_RaisesSeatsToCoverSecretsManager()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+
+        var source = MockPlans.Get(PlanType.TeamsStarter);
+        var target = MockPlans.Get(PlanType.TeamsMonthly);
+
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsStarter).Returns(source);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(target);
+
+        var orgId = Guid.NewGuid();
+        var cohort = CreateCohort(MigrationPathId.TeamsStarterToCurrent);
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = cohort.Id
+        };
+
+        var organization = CreateOrganization(orgId, PlanType.TeamsStarter);
+        organization.SmSeats = 5;
+
+        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohort.Id).Returns(cohort);
+        _organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(orgId)
+            .Returns(new OrganizationSeatCounts { Users = 4 });
+
+        var subscription = CreateBusinessSubscription("sub_1", "cus_1", orgId,
+            CreateSubscriptionItem(source.PasswordManager.StripePlanId, 1),
+            CreateSubscriptionItem(source.SecretsManager.StripeSeatPlanId, 5));
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+
+        var sut = CreateSut();
+        var result = await sut.ScheduleForSubscription(subscription);
+
+        Assert.True(result);
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                // PM seat line raised from 4 occupied to 5 to cover the SM seats.
+                o.Phases[1].Items.Any(i =>
+                    i.Price == target.PasswordManager.StripeSeatPlanId && i.Quantity == 5) &&
+                // SM seat line passes through unchanged.
+                o.Phases[1].Items.Any(i =>
+                    i.Price == target.SecretsManager.StripeSeatPlanId && i.Quantity == 5)));
+    }
+
+    // PM-39816: same SM >= occupied raise for the Teams Starter 2023 source (PlanType 16).
+    [Fact]
+    public async Task ScheduleBusinessPriceIncrease_TeamsStarter2023_RaisesSeatsToCoverSecretsManager()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+
+        var source = MockPlans.Get(PlanType.TeamsStarter2023);
+        var target = MockPlans.Get(PlanType.TeamsMonthly);
+
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsStarter2023).Returns(source);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(target);
+
+        var orgId = Guid.NewGuid();
+        var cohort = CreateCohort(MigrationPathId.TeamsStarter2023ToCurrent);
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = cohort.Id
+        };
+
+        var organization = CreateOrganization(orgId, PlanType.TeamsStarter2023);
+        organization.SmSeats = 5;
+
+        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohort.Id).Returns(cohort);
+        _organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(orgId)
+            .Returns(new OrganizationSeatCounts { Users = 4 });
+
+        var subscription = CreateBusinessSubscription("sub_1", "cus_1", orgId,
+            CreateSubscriptionItem(source.PasswordManager.StripePlanId, 1),
+            CreateSubscriptionItem(source.SecretsManager.StripeSeatPlanId, 5));
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+
+        var sut = CreateSut();
+        var result = await sut.ScheduleForSubscription(subscription);
+
+        Assert.True(result);
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases[1].Items.Any(i =>
+                    i.Price == target.PasswordManager.StripeSeatPlanId && i.Quantity == 5) &&
+                o.Phases[1].Items.Any(i =>
+                    i.Price == target.SecretsManager.StripeSeatPlanId && i.Quantity == 5)));
+    }
+
+    // PM-39816 edge: SM seats with zero occupied members bills the SM count (3), not the floored-at-1 default.
+    [Fact]
+    public async Task ScheduleBusinessPriceIncrease_TeamsStarter_SecretsManagerSeatsWithZeroOccupied_BillsSecretsManagerCount()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+
+        var source = MockPlans.Get(PlanType.TeamsStarter);
+        var target = MockPlans.Get(PlanType.TeamsMonthly);
+
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsStarter).Returns(source);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(target);
+
+        var orgId = Guid.NewGuid();
+        var cohort = CreateCohort(MigrationPathId.TeamsStarterToCurrent);
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = cohort.Id
+        };
+
+        var organization = CreateOrganization(orgId, PlanType.TeamsStarter);
+        organization.SmSeats = 3;
+
+        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohort.Id).Returns(cohort);
+        _organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(orgId)
+            .Returns(new OrganizationSeatCounts { Users = 0 });
+
+        var subscription = CreateBusinessSubscription("sub_1", "cus_1", orgId,
+            CreateSubscriptionItem(source.PasswordManager.StripePlanId, 1),
+            CreateSubscriptionItem(source.SecretsManager.StripeSeatPlanId, 3));
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+
+        var sut = CreateSut();
+        var result = await sut.ScheduleForSubscription(subscription);
+
+        Assert.True(result);
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases[1].Items.Any(i =>
+                    i.Price == target.PasswordManager.StripeSeatPlanId && i.Quantity == 3)));
+    }
+
+    // PM-39816 regression: SM seats below occupied members must not lower the PM seat count. 2 SM / 7 occupied -> 7.
+    [Fact]
+    public async Task ScheduleBusinessPriceIncrease_TeamsStarter_SecretsManagerBelowOccupied_DoesNotLowerSeats()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+
+        var source = MockPlans.Get(PlanType.TeamsStarter);
+        var target = MockPlans.Get(PlanType.TeamsMonthly);
+
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsStarter).Returns(source);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(target);
+
+        var orgId = Guid.NewGuid();
+        var cohort = CreateCohort(MigrationPathId.TeamsStarterToCurrent);
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = cohort.Id
+        };
+
+        var organization = CreateOrganization(orgId, PlanType.TeamsStarter);
+        organization.SmSeats = 2;
+
+        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohort.Id).Returns(cohort);
+        _organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(orgId)
+            .Returns(new OrganizationSeatCounts { Users = 7 });
+
+        var subscription = CreateBusinessSubscription("sub_1", "cus_1", orgId,
+            CreateSubscriptionItem(source.PasswordManager.StripePlanId, 1),
+            CreateSubscriptionItem(source.SecretsManager.StripeSeatPlanId, 2));
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+
+        var sut = CreateSut();
+        var result = await sut.ScheduleForSubscription(subscription);
+
+        Assert.True(result);
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases[1].Items.Any(i =>
+                    i.Price == target.PasswordManager.StripeSeatPlanId && i.Quantity == 7)));
+    }
+
+    // PM-39816 (Risk 2): when the DB SmSeats lags below the billed Stripe SM seat line, PM must floor on the
+    // Stripe line (the exact billed value), not the stale DB value, and the divergence must be logged.
+    [Fact]
+    public async Task ScheduleBusinessPriceIncrease_TeamsStarter_FloorsOnStripeSmLineNotStaleDb_LogsDrift()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+
+        var source = MockPlans.Get(PlanType.TeamsStarter);
+        var target = MockPlans.Get(PlanType.TeamsMonthly);
+
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsStarter).Returns(source);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(target);
+
+        var orgId = Guid.NewGuid();
+        var cohort = CreateCohort(MigrationPathId.TeamsStarterToCurrent);
+        var assignment = new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = cohort.Id
+        };
+
+        // DB SmSeats (3) lags below the billed Stripe SM seat line (5).
+        var organization = CreateOrganization(orgId, PlanType.TeamsStarter);
+        organization.SmSeats = 3;
+
+        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(assignment);
+        _cohortRepository.GetByIdAsync(cohort.Id).Returns(cohort);
+        _organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(orgId)
+            .Returns(new OrganizationSeatCounts { Users = 4 });
+
+        var subscription = CreateBusinessSubscription("sub_1", "cus_1", orgId,
+            CreateSubscriptionItem(source.PasswordManager.StripePlanId, 1),
+            CreateSubscriptionItem(source.SecretsManager.StripeSeatPlanId, 5));
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+
+        var sut = CreateSut();
+        var result = await sut.ScheduleForSubscription(subscription);
+
+        Assert.True(result);
+        // PM floors on the Stripe SM line (5), not the stale DB SmSeats (3).
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases[1].Items.Any(i =>
+                    i.Price == target.PasswordManager.StripeSeatPlanId && i.Quantity == 5)));
+
+        // The DB <-> Stripe SM divergence is surfaced as a warning (org id + counts only).
+        _logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o =>
+                o.ToString().Contains("Secrets Manager seat drift") &&
+                o.ToString().Contains(orgId.ToString())),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception, string>>());
+    }
+
     // Boundary contrast: a Scalable source (Enterprise 2020) is not packaged, so the seat override is
     // skipped and the copied quantity (10) is kept even though occupied count is stubbed lower.
     [Fact]
@@ -2661,6 +2937,56 @@ public class PriceIncreaseSchedulerTests
                 o.Phases[1].Items.Count == 2 &&
                 o.Phases[1].Items.Single(i => i.Price == target.PasswordManager.StripeSeatPlanId).Quantity == occupiedSeats &&
                 o.Phases[1].Items.Any(i => i.Price == target.PasswordManager.StripeStoragePlanId && i.Quantity == additionalStorage)));
+    }
+
+    // PM-39816: the SM <= PM floor also applies to the Teams 2019 packaged source — the same target invariant
+    // and the same latent bug. Occupied 3 (below the base 5) resolves PM to 3; an SM seat line of 5 raises the
+    // billed PM line to 5.
+    [Fact]
+    public async Task ScheduleBusinessPriceIncrease_Teams2019Monthly_RaisesSeatsToCoverSecretsManager()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.PM35215_BusinessPlanPriceMigration).Returns(true);
+
+        var source = MockPlans.Get(PlanType.TeamsMonthly2019);
+        var target = MockPlans.Get(PlanType.TeamsMonthly);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly2019).Returns(source);
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsMonthly).Returns(target);
+
+        var orgId = Guid.NewGuid();
+        var periodStart = DateTime.UtcNow;
+        var periodLength = TimeSpan.FromDays(30);
+        var subscription = CreateBusinessSubscription("sub_1", "cus_1", orgId,
+            CreateSubscriptionItem(source.PasswordManager.StripePlanId, 1, periodStart, periodLength),
+            CreateSubscriptionItem(source.SecretsManager.StripeSeatPlanId, 5, periodStart, periodLength));
+        var cohort = CreateCohort(MigrationPathId.Teams2019MonthlyToCurrent);
+
+        _organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(orgId)
+            .Returns(new OrganizationSeatCounts { Users = 3 });
+        _organizationRepository.GetByIdAsync(orgId)
+            .Returns(new Organization { Id = orgId, PlanType = PlanType.TeamsMonthly2019, Seats = 5, SmSeats = 5 });
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
+        _stripeAdapter.CreateSubscriptionScheduleAsync(Arg.Any<SubscriptionScheduleCreateOptions>())
+            .Returns(CreateScheduleWithPhase("sched_1", "sub_1"));
+        _assignmentRepository.GetByOrganizationIdAsync(orgId).Returns(new OrganizationPlanMigrationCohortAssignment
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            CohortId = cohort.Id
+        });
+
+        var sut = CreateSut();
+        var result = await sut.ScheduleBusinessPriceIncrease(subscription, cohort);
+
+        Assert.True(result);
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            "sched_1",
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                // PM seat line raised from 3 occupied to 5 to cover the SM seats.
+                o.Phases[1].Items.Single(i => i.Price == target.PasswordManager.StripeSeatPlanId).Quantity == 5 &&
+                // SM seat line passes through unchanged.
+                o.Phases[1].Items.Any(i => i.Price == target.SecretsManager.StripeSeatPlanId && i.Quantity == 5)));
     }
 
     private static Subscription CreateSubscription(string id, string customerId, params SubscriptionItem[] items) =>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39816](https://bitwarden.atlassian.net/browse/PM-39816) — QA bug under parent [PM-37512](https://bitwarden.atlassian.net/browse/PM-37512) (Support migration of Teams Starter), epic [PM-37496](https://bitwarden.atlassian.net/browse/PM-37496).

## 📔 Objective

The Teams Starter → current Teams migration recomputed the Password Manager (PM) seat count from occupied members (floored at 1) while passing the Secrets Manager (SM) seat count through untouched. When an org held more SM seats than occupied PM members, the migration produced SM seats > PM seats, violating the current Teams invariant that SM ≤ PM.

This raises the billed/persisted PM seat count to cover SM at the three migration seat-count sites, so the migration completes (never aborts) with PM ≥ SM:

- **Stage 1** — Phase-2 Stripe schedule (`PriceIncreaseScheduler`)
- **Stage 2** — cycle-time DB reconcile (`SubscriptionUpdatedHandler`)
- **Stage 3** — renewal-email quote (`UpcomingInvoiceHandler`)

The SM source is bound per domain: the Stripe-facing sites (Stage 1, renewal email) floor PM on the surviving **Stripe SM seat line quantity** (the exact billed value); the DB reconcile floors `Organization.Seats` on **`Organization.SmSeats`**. The two agree in normal operation; binding each site to its own domain keeps both the Stripe and DB invariants correct under DB↔Stripe drift, and a drift warning in Stage 1 surfaces any divergence.

The clamp lives on the shared packaged-source path, so it also covers the Teams 2019 → current migration (same target plan, same latent reconcile bug). Tests lock in both Teams Starter PlanTypes (21, 16) and Teams 2019.

Server-only, webhook-driven, gated by the existing `PM35215_BusinessPlanPriceMigration` flag — purely additive (orgs without SM seats are unaffected). Preventive: a data-warehouse check found 0 production orgs currently in the SM > PM state.

**Tests:** unit coverage proving PM ≥ SM after migration at all three sites for both Teams Starter PlanTypes and Teams 2019, plus the SM-with-zero-occupied edge and the DB-below-Stripe-line drift case.


[PM-39816]: https://bitwarden.atlassian.net/browse/PM-39816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-37512]: https://bitwarden.atlassian.net/browse/PM-37512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-37496]: https://bitwarden.atlassian.net/browse/PM-37496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ