### PR TITLE
[BRE-1533] Trigger Bitwarden Lite for server builds (including PRs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -497,12 +497,27 @@ jobs:
 
   bitwarden-lite-build:
     name: Trigger Bitwarden lite build
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
     needs: build-artifacts
     permissions:
       id-token: write
     steps:
+      - name: Compute Bitwarden lite server tag
+        id: server-tag
+        uses: bitwarden/gh-actions/sanitize-image-tag@main
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fork_repo: ${{ github.event.pull_request.head.repo.fork == true && github.event.pull_request.head.repo.full_name || '' }}
+
+      - name: Compute Bitwarden lite override tag
+        id: override-tag
+        uses: bitwarden/gh-actions/sanitize-image-tag@main
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fork_repo: ${{ github.event.pull_request.head.repo.fork == true && github.event.pull_request.head.repo.full_name || '' }}
+          prefix: "server-"
+
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main
         with:
@@ -531,6 +546,10 @@ jobs:
 
       - name: Trigger Bitwarden lite build
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SERVER_BRANCH: ${{ github.head_ref || github.ref_name }}
+          SERVER_TAG: ${{ steps.server-tag.outputs.tag }}
+          OVERRIDE_TAG: ${{ steps.override-tag.outputs.tag }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -540,7 +559,9 @@ jobs:
               workflow_id: 'build-bitwarden-lite.yml',
               ref: 'main',
               inputs: {
-                server_branch: process.env.GITHUB_REF
+                server_branch: process.env.SERVER_BRANCH,
+                server_tag: process.env.SERVER_TAG,
+                override_tag: process.env.OVERRIDE_TAG
               }
             });
 


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1533](https://bitwarden.atlassian.net/browse/BRE-1533)

## 📔 Objective

Run Bitwarden Lite builds for every server build, including PRs, and route them to our ACR via a `server-` prefixed `override_tag` so they're not retained in GHCR indefinitely.

## Changes

- Removed `if: github.event_name != 'pull_request'`. Replaced with a fork-PR guard so fork PRs short-circuit cleanly instead of failing at Azure login.
- Tag derivation uses `bitwarden/gh-actions/sanitize-image-tag@main` - one call for `server_tag`, one for the `server-` prefixed `override_tag`.
- Dispatch payload now includes `server_tag` and `override_tag` alongside `server_branch`.

## Dependencies

Requires the [self-host PR](https://github.com/bitwarden/self-host/pull/530) to merge first; the new self-host inputs (`override_tag`, `server_tag`) aren't accepted until then.

[BRE-1533]: https://bitwarden.atlassian.net/browse/BRE-1533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ