### PR TITLE
[PM-38000] Convert text feilds for email to email fields for form validation

### DIFF
--- a/src/Admin/AdminConsole/Models/CreateBusinessUnitProviderModel.cs
+++ b/src/Admin/AdminConsole/Models/CreateBusinessUnitProviderModel.cs
@@ -5,12 +5,14 @@ using System.ComponentModel.DataAnnotations;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
 using Bit.Core.Billing.Enums;
+using Bit.Core.Utilities;
 using Bit.SharedWeb.Utilities;
 
 namespace Bit.Admin.AdminConsole.Models;
 
 public class CreateBusinessUnitProviderModel : IValidatableObject
 {
+    [StrictEmailAddress]
     [Display(Name = "Owner Email")]
     public string OwnerEmail { get; set; }
 

--- a/src/Admin/AdminConsole/Models/CreateMspProviderModel.cs
+++ b/src/Admin/AdminConsole/Models/CreateMspProviderModel.cs
@@ -4,12 +4,14 @@
 using System.ComponentModel.DataAnnotations;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.Utilities;
 using Bit.SharedWeb.Utilities;
 
 namespace Bit.Admin.AdminConsole.Models;
 
 public class CreateMspProviderModel : IValidatableObject
 {
+    [StrictEmailAddress]
     [Display(Name = "Owner Email")]
     public string OwnerEmail { get; set; }
 

--- a/src/Admin/AdminConsole/Models/CreateResellerProviderModel.cs
+++ b/src/Admin/AdminConsole/Models/CreateResellerProviderModel.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel.DataAnnotations;
 using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.AdminConsole.Enums.Provider;
+using Bit.Core.Utilities;
 using Bit.SharedWeb.Utilities;
 
 namespace Bit.Admin.AdminConsole.Models;
@@ -16,6 +17,7 @@ public class CreateResellerProviderModel : IValidatableObject
     [Display(Name = "Business Name")]
     public string BusinessName { get; set; }
 
+    [StrictEmailAddress]
     [Display(Name = "Primary Billing Email")]
     public string BillingEmail { get; set; }
 

--- a/src/Admin/AdminConsole/Models/OrganizationViewModel.cs
+++ b/src/Admin/AdminConsole/Models/OrganizationViewModel.cs
@@ -6,7 +6,6 @@ using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
-using Bit.Core.Utilities;
 using Bit.Core.Vault.Entities;
 
 namespace Bit.Admin.AdminConsole.Models;
@@ -59,7 +58,6 @@ public class OrganizationViewModel
     public Organization Organization { get; set; }
     public Provider Provider { get; set; }
     public IEnumerable<OrganizationConnection> Connections { get; set; }
-    [StrictEmailAddress]
     public string Owners { get; set; }
     public string Admins { get; set; }
     public int UserInvitedCount { get; set; }

--- a/src/Admin/AdminConsole/Models/OrganizationViewModel.cs
+++ b/src/Admin/AdminConsole/Models/OrganizationViewModel.cs
@@ -6,6 +6,7 @@ using Bit.Core.AdminConsole.Entities.Provider;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
+using Bit.Core.Utilities;
 using Bit.Core.Vault.Entities;
 
 namespace Bit.Admin.AdminConsole.Models;
@@ -58,6 +59,7 @@ public class OrganizationViewModel
     public Organization Organization { get; set; }
     public Provider Provider { get; set; }
     public IEnumerable<OrganizationConnection> Connections { get; set; }
+    [StrictEmailAddress]
     public string Owners { get; set; }
     public string Admins { get; set; }
     public int UserInvitedCount { get; set; }

--- a/src/Admin/AdminConsole/Views/Organizations/Index.cshtml
+++ b/src/Admin/AdminConsole/Views/Organizations/Index.cshtml
@@ -12,7 +12,7 @@
     </div>
     <div class="col-12">
         <label class="visually-hidden" asp-for="UserEmail">User email</label>
-        <input type="text" class="form-control" placeholder="User email" asp-for="UserEmail" name="userEmail">
+        <input type="email" class="form-control" placeholder="User email" asp-for="UserEmail" name="userEmail">
     </div>
     @if(!Model.SelfHosted)
     {

--- a/src/Admin/AdminConsole/Views/Providers/CreateBusinessUnit.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/CreateBusinessUnit.cshtml
@@ -13,7 +13,7 @@
         <div asp-validation-summary="All" class="alert alert-danger"></div>
         <div class="mb-3">
             <label asp-for="OwnerEmail" class="form-label"></label>
-            <input type="text" class="form-control" asp-for="OwnerEmail">
+            <input type="email" class="form-control" asp-for="OwnerEmail">
         </div>
         <div class="row">
             <div class="col-sm">

--- a/src/Admin/AdminConsole/Views/Providers/CreateMsp.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/CreateMsp.cshtml
@@ -11,7 +11,7 @@
         <div asp-validation-summary="All" class="alert alert-danger"></div>
         <div class="mb-3">
             <label asp-for="OwnerEmail" class="form-label"></label>
-            <input type="text" class="form-control" asp-for="OwnerEmail">
+            <input type="email" class="form-control" asp-for="OwnerEmail">
         </div>
         <div class="mb-3">
             @{

--- a/src/Admin/AdminConsole/Views/Providers/CreateReseller.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/CreateReseller.cshtml
@@ -18,7 +18,7 @@
         </div>
         <div class="mb-3">
             <label asp-for="BillingEmail" class="form-label"></label>
-            <input type="text" class="form-control" asp-for="BillingEmail">
+            <input type="email" class="form-control" asp-for="BillingEmail">
         </div>
         <button type="submit" class="btn btn-primary mb-2">Create Provider</button>
     </form>

--- a/src/Admin/AdminConsole/Views/Providers/Index.cshtml
+++ b/src/Admin/AdminConsole/Views/Providers/Index.cshtml
@@ -18,7 +18,7 @@
     </div>
     <div class="col-12">
         <label class="visually-hidden" asp-for="UserEmail">User email</label>
-        <input type="text" class="form-control" placeholder="User email" asp-for="UserEmail" name="userEmail">
+        <input type="email" class="form-control" placeholder="User email" asp-for="UserEmail" name="userEmail">
     </div>
     <div class="col-12">
         <button type="submit" class="btn btn-primary" title="Search">

--- a/src/Admin/AdminConsole/Views/Shared/_OrganizationForm.cshtml
+++ b/src/Admin/AdminConsole/Views/Shared/_OrganizationForm.cshtml
@@ -47,11 +47,12 @@
                         <label class="form-label">Client Owner Email</label>
                         @if (!string.IsNullOrWhiteSpace(Model.Owners))
                         {
-                            <input type="text" class="form-control" asp-for="Owners" readonly>
+                            <input type="email" class="form-control" asp-for="Owners" readonly>
                         }
                         else
                         {
-                            <input type="text" class="form-control" asp-for="Owners" required>
+                            <input type="email" class="form-control" asp-for="Owners" required>
+                            <span asp-validation-for="Owners" class="invalid-feedback"></span>
                         }
                         <div class="form-text mt-0">This user should be independent of the Provider. If the Provider is disassociated with the organization, this user will maintain ownership of the organization.</div>
                     </div>

--- a/src/Admin/Views/Users/Index.cshtml
+++ b/src/Admin/Views/Users/Index.cshtml
@@ -8,7 +8,7 @@
 <form class="row row-cols-lg-auto g-3 align-items-center mb-2" method="get">
     <div class="col-12">
         <label class="visually-hidden" asp-for="Email">Email</label>
-        <input type="text" class="form-control" placeholder="Email" asp-for="Email" name="email">
+        <input type="email" class="form-control" placeholder="Email" asp-for="Email" name="email">
     </div>
     <div class="col-12">
         <button type="submit" class="btn btn-primary" title="Search">


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-38000
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
There are various text input fields in the admin portal that are used for emails that don't have any validation. The end result being you can submit invalid emails in these fields. One such example is the owner email for a reseller organization. You can make the owner email "foobar@email .com" and there's no way to edit it after the fact. Since the email is invalid, you can't accept the setup email and enter an impassable state.

Various text input fields in the portal have been converted to email fields for the properties on the view model they are for, backed by the [StrictEmailAddress] decorator to ensure at least some basic level of form validation is done to prevent invalid email address entries.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
