### PR TITLE
Relax cert check on development builds

### DIFF
--- a/src/SharedWeb/Utilities/DataProtectionServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/DataProtectionServiceCollectionExtensions.cs
@@ -29,9 +29,7 @@ public static class DataProtectionServiceCollectionExtensions
             if (CoreHelpers.SettingHasValue(globalSettings.DataProtection.CertificateThumbprint))
             {
                 dataProtectionCert = CoreHelpers.GetCertificate(
-                    globalSettings.DataProtection.CertificateThumbprint)
-                    ?? throw new InvalidOperationException(
-                        $"No data protection certificate could be found with thumbprint '{globalSettings.DataProtection.CertificateThumbprint}'.");
+                    globalSettings.DataProtection.CertificateThumbprint);
             }
             else if (CoreHelpers.SettingHasValue(globalSettings.DataProtection.CertificatePassword))
             {
@@ -48,7 +46,10 @@ public static class DataProtectionServiceCollectionExtensions
             {
                 if (dataProtectionCert is null)
                 {
-                    throw new InvalidOperationException("A data protection certificate could not be acquired and one is required when running in non-development cloud environments. Please make sure your configuration has a valid connection string to azure blob storage.");
+                    var message = CoreHelpers.SettingHasValue(globalSettings.DataProtection.CertificateThumbprint)
+                        ? $"No data protection certificate could be found with thumbprint '{globalSettings.DataProtection.CertificateThumbprint}'. Verify the certificate is installed in the current user's certificate store."
+                        : "A data protection certificate could not be acquired and one is required when running in non-development cloud environments. Please make sure your configuration has a valid connection string to azure blob storage.";
+                    throw new InvalidOperationException(message);
                 }
 
                 builder

--- a/test/SharedWeb.Test/DataProtectionServicesTests.cs
+++ b/test/SharedWeb.Test/DataProtectionServicesTests.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Azure;
 using Azure.Storage.Blobs;

--- a/test/SharedWeb.Test/DataProtectionServicesTests.cs
+++ b/test/SharedWeb.Test/DataProtectionServicesTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Azure;
 using Azure.Storage.Blobs;
@@ -447,6 +447,51 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
     }
 
     [Fact]
+    public void ThumbprintPlaceholder_InDevelopment_DoesNotThrow()
+    {
+        // In local development, developers often have a placeholder thumbprint like "____"
+        // in their config because no real cert exists on their machine. The previous
+        // implementation threw InvalidOperationException at startup whenever GetCertificate
+        // returned null, even in Development — making local development impossible with a
+        // thumbprint configured. The current implementation defers the null check to the
+        // non-development guard further down, so Development environments start up cleanly
+        // and data protection simply uses its ephemeral default storage.
+        using var services = CreateApp(
+            new Dictionary<string, string?>
+            {
+                { "GlobalSettings:Storage:ConnectionString", "UseDevelopmentStorage=true" },
+                { "GlobalSettings:DataProtection:CertificateThumbprint", "___________" },
+            },
+            environmentName: "Development"
+        );
+
+        // No exception during startup; a protector can be successfully created.
+        var protector = services.GetRequiredService<IDataProtectionProvider>().CreateProtector("Test");
+        var roundTripped = protector.Unprotect(protector.Protect("hello"));
+        Assert.Equal("hello", roundTripped);
+    }
+
+    [Fact]
+    public void ThumbprintNotFound_InProduction_ThrowsWithThumbprintHint()
+    {
+        // When a thumbprint is configured in a non-development environment but the certificate
+        // is not present in the current user's certificate store, the error message should
+        // name the missing thumbprint so operators can tell immediately what to install rather
+        // than being directed to check the blob storage connection string (which is irrelevant
+        // to the thumbprint path).
+        var exception = Assert.Throws<InvalidOperationException>(() => CreateApp(
+            new Dictionary<string, string?>
+            {
+                { "GlobalSettings:Storage:ConnectionString", "UseDevelopmentStorage=true" },
+                { "GlobalSettings:DataProtection:CertificateThumbprint", "___________" },
+            },
+            environmentName: "Production"
+        ));
+        Assert.Contains("___________", exception.Message);
+        Assert.Contains("certificate store", exception.Message);
+    }
+
+    [Fact]
     public async Task ProtectionCertificatePasswordIncorrect_Throws()
     {
         // The previous implementation swallowed the X509 load failure and returned null, which
@@ -534,14 +579,14 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
         test(runContext);
     }
 
-    private static ServiceProvider CreateApp(Dictionary<string, string?> initialData)
+    private static ServiceProvider CreateApp(Dictionary<string, string?> initialData, string environmentName = "Production")
     {
         var configurationBuilder = new ConfigurationBuilder()
             .AddInMemoryCollection(initialData);
-        return CreateApp(configurationBuilder);
+        return CreateApp(configurationBuilder, environmentName);
     }
 
-    private static ServiceProvider CreateApp(IConfigurationBuilder configurationBuilder)
+    private static ServiceProvider CreateApp(IConfigurationBuilder configurationBuilder, string environmentName = "Production")
     {
         var services = new ServiceCollection();
 
@@ -551,7 +596,7 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
         configuration.GetSection("GlobalSettings").Bind(globalSettings);
 
         var environment = Substitute.For<IWebHostEnvironment>();
-        environment.EnvironmentName.Returns("Production");
+        environment.EnvironmentName.Returns(environmentName);
 
         services.AddCustomDataProtectionServices(
             environment,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Relates to: #7837 

I wanted to have a different error message for if the protection cert couldn't be found in the user cert store vs from not having enough settings for it to be retrieved at all but right now a lot of developers have a stub thumbprint of `______` from when we used to have to set that setting. But development environments don't need any data protection setup. I am going to be removing that stubbed value but I can also relax the exception to actually only happen when that unprotect cert is needed (non-development). 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
