### PR TITLE
[PM-39783] Support policies enabled by default

### DIFF
--- a/src/Core/AdminConsole/Models/Data/Organizations/Policies/PolicyDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/Organizations/Policies/PolicyDetails.cs
@@ -37,3 +37,20 @@ public class PolicyDetails
     public Permissions GetOrganizationUserCustomPermissions()
         => CoreHelpers.LoadClassFromJsonData<Permissions>(OrganizationUserPermissionsData);
 }
+
+/// <summary>
+/// A <see cref="PolicyDetails"/> that also carries the raw enabled state of the underlying policy row, including the
+/// case where no row exists. Used by the query path for policies that are enabled by default so that "no row" can be
+/// distinguished from "disabled".
+/// </summary>
+/// <remarks>
+/// This is an internal repository→query DTO. It is not passed to policy requirement factories: after interpreting
+/// <see cref="Enabled"/>, the query hands factories the base <see cref="PolicyDetails"/>.
+/// </remarks>
+public class PolicyDetailsWithState : PolicyDetails
+{
+    /// <summary>
+    /// The underlying policy row's enabled flag, or null when the organization has no row for this policy type.
+    /// </summary>
+    public bool? Enabled { get; set; }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/PolicyQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/PolicyQuery.cs
@@ -1,11 +1,14 @@
 ﻿using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Utilities;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.Implementations;
 
-public class PolicyQuery(IPolicyRepository policyRepository) : IPolicyQuery
+public class PolicyQuery(
+    IPolicyRepository policyRepository,
+    IEnumerable<IPolicyRequirementFactory<IPolicyRequirement>> factories) : IPolicyQuery
 {
     public async Task<IEnumerable<PolicyStatus>> GetAllAsync(Guid organizationId)
     {
@@ -18,6 +21,12 @@ public class PolicyQuery(IPolicyRepository policyRepository) : IPolicyQuery
             var synthesized = await SynthesizeSendControlsStatusAsync(organizationId);
             results.Add(synthesized);
         }
+
+        // A policy that is enabled by default with no saved row is still enabled for the organization.
+        var missingDefaultOnTypes = DefaultOnPolicyTypes()
+            .Where(type => results.All(r => r.Type != type));
+        results.AddRange(missingDefaultOnTypes
+            .Select(type => new PolicyStatus(organizationId, type) { Enabled = true }));
 
         return results;
     }
@@ -32,8 +41,21 @@ public class PolicyQuery(IPolicyRepository policyRepository) : IPolicyQuery
             return await SynthesizeSendControlsStatusAsync(organizationId);
         }
 
+        // A policy that is enabled by default with no saved row is enabled for the organization. An explicitly
+        // disabled row still yields Enabled = false via the PolicyStatus constructor.
+        if (dbPolicy == null && IsEnabledByDefault(policyType))
+        {
+            return new PolicyStatus(organizationId, policyType) { Enabled = true };
+        }
+
         return new PolicyStatus(organizationId, policyType, dbPolicy);
     }
+
+    private bool IsEnabledByDefault(PolicyType policyType)
+        => factories.Any(f => f.PolicyType == policyType && f.DefaultState == PolicyDefaultState.Enabled);
+
+    private IEnumerable<PolicyType> DefaultOnPolicyTypes()
+        => factories.Where(f => f.DefaultState == PolicyDefaultState.Enabled).Select(f => f.PolicyType);
 
     /// <summary>
     /// When no SendControls policy row exists in the database, synthesizes a PolicyStatus

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/PolicyRequirementQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/Implementations/PolicyRequirementQuery.cs
@@ -21,10 +21,21 @@ public class PolicyRequirementQuery(
             throw new NotImplementedException("No Requirement Factory found for " + typeof(T));
         }
 
-        var policyDetails = await policyRepository.GetPolicyDetailsByUserIdAndPolicyTypeAsync(userId, factory.PolicyType);
-        var enforcedPolicyDetails = policyDetails.Where(factory.Enforce);
+        IEnumerable<PolicyDetails> policyDetails;
+        if (factory.DefaultState == PolicyDefaultState.Enabled)
+        {
+            // Policies that are enabled by default read the raw state and treat "no row" the same as enabled;
+            // an explicitly disabled row (Enabled == false) is excluded.
+            var policyDetailsWithState =
+                await policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(userId, factory.PolicyType);
+            policyDetails = policyDetailsWithState.Where(x => x.Enabled != false);
+        }
+        else
+        {
+            policyDetails = await policyRepository.GetPolicyDetailsByUserIdAndPolicyTypeAsync(userId, factory.PolicyType);
+        }
 
-        return factory.Create(enforcedPolicyDetails);
+        return factory.Create(policyDetails.Where(factory.Enforce));
     }
 
     public async Task<IEnumerable<(Guid UserId, T Requirement)>> GetAsync<T>(IEnumerable<Guid> userIds) where T : IPolicyRequirement
@@ -33,6 +44,14 @@ public class PolicyRequirementQuery(
         if (factory is null)
         {
             throw new NotImplementedException("No Requirement Factory found for " + typeof(T));
+        }
+
+        if (factory.DefaultState == PolicyDefaultState.Enabled)
+        {
+            // The batch query does not yet support enabled-by-default policies (it would miss organizations with no
+            // policy row). Use GetAsyncVNext for these until a batch state-aware query exists.
+            throw new NotImplementedException(
+                "Enabled-by-default policies must be queried via GetAsyncVNext, not the batch overload: " + typeof(T));
         }
 
         var userIdList = userIds.ToList();

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/BasePolicyRequirementFactory.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/BasePolicyRequirementFactory.cs
@@ -34,6 +34,10 @@ public abstract class BasePolicyRequirementFactory<T> : IPolicyRequirementFactor
     /// <inheritdoc />
     public abstract PolicyType PolicyType { get; }
 
+    /// <inheritdoc />
+    /// <remarks>Defaults to <see cref="PolicyDefaultState.Disabled"/>; override for a policy that is on by default.</remarks>
+    public virtual PolicyDefaultState DefaultState => PolicyDefaultState.Disabled;
+
     public bool Enforce(PolicyDetails policyDetails)
         => !policyDetails.HasRole(ExemptRoles) &&
             !policyDetails.HasStatus(ExemptStatuses) &&

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/IPolicyRequirementFactory.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/IPolicyRequirementFactory.cs
@@ -21,6 +21,12 @@ public interface IPolicyRequirementFactory<out T> where T : IPolicyRequirement
     PolicyType PolicyType { get; }
 
     /// <summary>
+    /// Whether the policy is enabled or disabled by default. When <see cref="PolicyDefaultState.Enabled"/>, an
+    /// organization that has never saved a policy row is treated as having the policy enabled.
+    /// </summary>
+    PolicyDefaultState DefaultState { get; }
+
+    /// <summary>
     /// A predicate that determines whether a policy should be enforced against the user.
     /// </summary>
     /// <remarks>Use this to exempt users based on their role, status or other attributes.</remarks>

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/PolicyDefaultState.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/PolicyDefaultState.cs
@@ -1,4 +1,4 @@
-namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
+﻿namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 
 /// <summary>
 /// Whether a policy is enabled or disabled by default: it determines how the policy domain interprets the absence of a

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/PolicyDefaultState.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyRequirements/PolicyDefaultState.cs
@@ -1,0 +1,19 @@
+namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
+
+/// <summary>
+/// Whether a policy is enabled or disabled by default: it determines how the policy domain interprets the absence of a
+/// <see cref="Bit.Core.AdminConsole.Entities.Policy"/> row for an organization.
+/// </summary>
+public enum PolicyDefaultState : byte
+{
+    /// <summary>
+    /// The policy is off unless an organization explicitly enables it (the default for all policies). A missing row
+    /// reads as disabled.
+    /// </summary>
+    Disabled = 0,
+
+    /// <summary>
+    /// The policy is on unless an organization explicitly disables it. A missing row reads as enabled.
+    /// </summary>
+    Enabled = 1,
+}

--- a/src/Core/AdminConsole/Repositories/IPolicyRepository.cs
+++ b/src/Core/AdminConsole/Repositories/IPolicyRepository.cs
@@ -73,4 +73,19 @@ public interface IPolicyRepository : IRepository<Policy, Guid>
     /// the policy information associated with the specified user and policy type.
     /// </returns>
     Task<IEnumerable<PolicyDetails>> GetPolicyDetailsByUserIdAndPolicyTypeAsync(Guid userId, PolicyType policyType);
+
+    /// <summary>
+    /// Retrieves policy details for a single user filtered by the specified policy type, along with the raw enabled
+    /// state of each organization's policy row, for use by policies that are enabled by default.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="GetPolicyDetailsByUserIdAndPolicyTypeAsync"/>, this returns a row for every organization the
+    /// user belongs to that supports policies (via a LEFT JOIN) regardless of whether the policy is enabled, disabled,
+    /// or has no row. <see cref="PolicyDetailsWithState.Enabled"/> is null when no row exists. Callers interpret the
+    /// state (e.g. treat "no row" as enabled for a default-on policy). This includes both confirmed users (matched by
+    /// UserId) and invited users (matched by email); provider users are identified via the IsProvider flag.
+    /// </remarks>
+    /// <param name="userId">The user identifier for which policy details are to be fetched.</param>
+    /// <param name="policyType">The type of policy for which the details are required.</param>
+    Task<IEnumerable<PolicyDetailsWithState>> GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(Guid userId, PolicyType policyType);
 }

--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/PolicyRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/PolicyRepository.cs
@@ -116,4 +116,19 @@ public class PolicyRepository : Repository<Policy, Guid>, IPolicyRepository
 
         return results.ToList();
     }
+
+    public async Task<IEnumerable<PolicyDetailsWithState>> GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(Guid userId, PolicyType policyType)
+    {
+        await using var connection = new SqlConnection(ConnectionString);
+        var results = await connection.QueryAsync<PolicyDetailsWithState>(
+            $"[{Schema}].[PolicyDetails_ReadWithStateByUserIdPolicyType]",
+            new
+            {
+                UserId = userId,
+                PolicyType = (byte)policyType
+            },
+            commandType: CommandType.StoredProcedure);
+
+        return results.ToList();
+    }
 }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/PolicyRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/PolicyRepository.cs
@@ -299,4 +299,56 @@ public class PolicyRepository : Repository<AdminConsoleEntities.Policy, Policy, 
 
         return await query.ToListAsync();
     }
+
+    public async Task<IEnumerable<PolicyDetailsWithState>> GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(Guid userId, PolicyType policyType)
+    {
+        using var scope = ServiceScopeFactory.CreateScope();
+        var dbContext = GetDatabaseContext(scope);
+
+        // Get user email for invited user matching
+        var userEmail = await dbContext.Users
+            .Where(u => u.Id == userId)
+            .Select(u => u.Email)
+            .FirstOrDefaultAsync();
+
+        // Get provider relationships
+        var providerOrganizationIds = await (from pu in dbContext.ProviderUsers
+                                             join po in dbContext.ProviderOrganizations on pu.ProviderId equals po.ProviderId
+                                             where pu.UserId == userId
+                                             select po.OrganizationId)
+            .Distinct()
+            .ToListAsync();
+
+        var providerSet = new HashSet<Guid>(providerOrganizationIds);
+
+        // Get organization users (both confirmed/accepted/revoked and invited)
+        var orgUsersQuery = dbContext.OrganizationUsers
+            .Where(ou => (((ou.Status == OrganizationUserStatusType.Accepted ||
+                            ou.Status == OrganizationUserStatusType.Confirmed ||
+                            ou.Status == OrganizationUserStatusType.Revoked) && ou.UserId == userId) ||
+                         (ou.Status == OrganizationUserStatusType.Invited && ou.Email == userEmail && userEmail != null)));
+
+        // LEFT JOIN policies so a row is returned for every organization the user belongs to that supports policies,
+        // regardless of whether the policy is enabled, disabled, or has no row. Enabled is null when no row exists.
+        var query = from orgUser in orgUsersQuery
+                    join org in dbContext.Organizations on orgUser.OrganizationId equals org.Id
+                    where org.Enabled && org.UsePolicies
+                    join policy in dbContext.Policies.Where(p => p.Type == policyType)
+                        on org.Id equals policy.OrganizationId into policyGroup
+                    from policy in policyGroup.DefaultIfEmpty()
+                    select new PolicyDetailsWithState
+                    {
+                        OrganizationUserId = orgUser.Id,
+                        OrganizationId = org.Id,
+                        PolicyType = policyType,
+                        PolicyData = policy != null ? policy.Data : null,
+                        OrganizationUserType = orgUser.Type,
+                        OrganizationUserStatus = orgUser.Status,
+                        OrganizationUserPermissionsData = orgUser.Permissions,
+                        IsProvider = providerSet.Contains(org.Id),
+                        Enabled = policy != null ? policy.Enabled : (bool?)null
+                    };
+
+        return await query.ToListAsync();
+    }
 }

--- a/src/Sql/dbo/Stored Procedures/PolicyDetails_ReadWithStateByUserIdPolicyType.sql
+++ b/src/Sql/dbo/Stored Procedures/PolicyDetails_ReadWithStateByUserIdPolicyType.sql
@@ -1,0 +1,77 @@
+CREATE PROCEDURE [dbo].[PolicyDetails_ReadWithStateByUserIdPolicyType]
+    @UserId UNIQUEIDENTIFIER,
+    @PolicyType TINYINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DECLARE @UserEmail NVARCHAR(256)
+    SELECT @UserEmail = Email
+    FROM
+        [dbo].[UserView]
+    WHERE
+        Id = @UserId
+
+    ;WITH OrgUsers AS
+    (
+        -- Non-invited, non-staged users: direct UserId match
+        SELECT
+            OU.[Id],
+            OU.[OrganizationId],
+            OU.[Type],
+            OU.[Status],
+            OU.[Permissions]
+        FROM
+            [dbo].[OrganizationUserView] OU
+        WHERE
+            OU.[Status] IN (-1, 1, 2)
+            AND OU.[UserId] = @UserId
+
+        UNION ALL
+
+        -- Invited users (Status = 0): email match
+        SELECT
+            OU.[Id],
+            OU.[OrganizationId],
+            OU.[Type],
+            OU.[Status],
+            OU.[Permissions]
+        FROM
+            [dbo].[OrganizationUserView] OU
+        WHERE
+            OU.[Status] = 0
+            AND OU.[Email] = @UserEmail
+            AND @UserEmail IS NOT NULL
+    ),
+    Providers AS
+    (
+        SELECT
+            OrganizationId
+        FROM
+            [dbo].[UserProviderAccessView]
+        WHERE
+            UserId = @UserId
+    )
+    SELECT
+        OU.[Id] AS OrganizationUserId,
+        O.[Id] AS OrganizationId,
+        @PolicyType AS PolicyType,
+        P.[Data] AS PolicyData,
+        OU.[Type] AS OrganizationUserType,
+        OU.[Status] AS OrganizationUserStatus,
+        OU.[Permissions] AS OrganizationUserPermissionsData,
+        CASE WHEN PR.[OrganizationId] IS NULL THEN 0 ELSE 1 END AS IsProvider,
+        -- Raw policy state: NULL when the organization has no row for this type
+        P.[Enabled] AS [Enabled]
+    FROM
+        OrgUsers OU
+    INNER JOIN
+        [dbo].[OrganizationView] O ON OU.[OrganizationId] = O.[Id]
+    LEFT JOIN
+        [dbo].[PolicyView] P ON P.[OrganizationId] = O.[Id] AND P.[Type] = @PolicyType
+    LEFT JOIN
+        Providers PR ON PR.[OrganizationId] = OU.[OrganizationId]
+    WHERE
+        O.[Enabled] = 1
+        AND O.[UsePolicies] = 1
+END

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirementFixtures.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirementFixtures.cs
@@ -12,9 +12,13 @@ public class TestPolicyRequirement : IPolicyRequirement
     public IEnumerable<PolicyDetails> Policies { get; init; } = [];
 }
 
-public class TestPolicyRequirementFactory(Func<PolicyDetails, bool> enforce) : IPolicyRequirementFactory<TestPolicyRequirement>
+public class TestPolicyRequirementFactory(
+    Func<PolicyDetails, bool> enforce,
+    PolicyDefaultState defaultState = PolicyDefaultState.Disabled) : IPolicyRequirementFactory<TestPolicyRequirement>
 {
     public PolicyType PolicyType => PolicyType.SingleOrg;
+
+    public PolicyDefaultState DefaultState => defaultState;
 
     public bool Enforce(PolicyDetails policyDetails) => enforce(policyDetails);
 

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirementQueryTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyRequirementQueryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Implementations;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -119,6 +120,102 @@ public class PolicyRequirementQueryTests
         var requirement = await sut.GetAsyncVNext<TestPolicyRequirement>(userId);
 
         Assert.Empty(requirement.Policies);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAsyncVNext_ForDefaultOnFactory_UsesWithStateQueryAndTreatsMissingAsEnabled(Guid userId)
+    {
+        // Arrange raw-state rows: an enabled org, a default (no row) org, and an explicitly disabled org
+        var policyRepository = Substitute.For<IPolicyRepository>();
+        var enabledOrg = new PolicyDetailsWithState { PolicyType = PolicyType.SingleOrg, Enabled = true };
+        var defaultOrg = new PolicyDetailsWithState { PolicyType = PolicyType.SingleOrg, Enabled = null };
+        var disabledOrg = new PolicyDetailsWithState { PolicyType = PolicyType.SingleOrg, Enabled = false };
+        policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(userId, PolicyType.SingleOrg)
+            .Returns([enabledOrg, defaultOrg, disabledOrg]);
+
+        var factory = new TestPolicyRequirementFactory(_ => true, PolicyDefaultState.Enabled);
+        var sut = new PolicyRequirementQuery(policyRepository, [factory]);
+
+        // Act
+        var requirement = await sut.GetAsyncVNext<TestPolicyRequirement>(userId);
+
+        // Assert: enabled and default (missing) orgs are enforced; the disabled org is dropped
+        Assert.Contains(enabledOrg, requirement.Policies);
+        Assert.Contains(defaultOrg, requirement.Policies);
+        Assert.DoesNotContain(disabledOrg, requirement.Policies);
+
+        // The standard query must not be used for a default-on factory
+        await policyRepository.Received(1)
+            .GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(userId, PolicyType.SingleOrg);
+        await policyRepository.DidNotReceive()
+            .GetPolicyDetailsByUserIdAndPolicyTypeAsync(userId, Arg.Any<PolicyType>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAsyncVNext_ForDefaultOnFactory_CallsEnforceCallback(Guid userId)
+    {
+        var policyRepository = Substitute.For<IPolicyRepository>();
+        var thisPolicy = new PolicyDetailsWithState { PolicyType = PolicyType.SingleOrg, Enabled = null };
+        var otherPolicy = new PolicyDetailsWithState { PolicyType = PolicyType.SingleOrg, Enabled = true };
+        policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(userId, PolicyType.SingleOrg)
+            .Returns([thisPolicy, otherPolicy]);
+
+        var callback = Substitute.For<Func<PolicyDetails, bool>>();
+        callback(Arg.Any<PolicyDetails>()).Returns(x => x.Arg<PolicyDetails>() == thisPolicy);
+
+        var factory = new TestPolicyRequirementFactory(callback, PolicyDefaultState.Enabled);
+        var sut = new PolicyRequirementQuery(policyRepository, [factory]);
+
+        var requirement = await sut.GetAsyncVNext<TestPolicyRequirement>(userId);
+
+        Assert.Contains(thisPolicy, requirement.Policies);
+        Assert.DoesNotContain(otherPolicy, requirement.Policies);
+        callback.Received()(Arg.Is<PolicyDetails>(thisPolicy));
+        callback.Received()(Arg.Is<PolicyDetails>(otherPolicy));
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAsyncVNext_ForDefaultOffFactory_UsesStandardQuery(Guid userId)
+    {
+        var policyRepository = Substitute.For<IPolicyRepository>();
+        var policy = new PolicyDetails { PolicyType = PolicyType.SingleOrg };
+        policyRepository.GetPolicyDetailsByUserIdAndPolicyTypeAsync(userId, PolicyType.SingleOrg)
+            .Returns([policy]);
+
+        var factory = new TestPolicyRequirementFactory(_ => true); // DefaultState.Disabled
+        var sut = new PolicyRequirementQuery(policyRepository, [factory]);
+
+        var requirement = await sut.GetAsyncVNext<TestPolicyRequirement>(userId);
+
+        Assert.Contains(policy, requirement.Policies);
+        await policyRepository.Received(1).GetPolicyDetailsByUserIdAndPolicyTypeAsync(userId, PolicyType.SingleOrg);
+        await policyRepository.DidNotReceive()
+            .GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(userId, Arg.Any<PolicyType>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAsync_Batch_ForDefaultOnFactory_Throws(Guid userIdA, Guid userIdB)
+    {
+        var policyRepository = Substitute.For<IPolicyRepository>();
+        var factory = new TestPolicyRequirementFactory(_ => true, PolicyDefaultState.Enabled);
+        var sut = new PolicyRequirementQuery(policyRepository, [factory]);
+
+        var exception = await Assert.ThrowsAsync<NotImplementedException>(()
+            => sut.GetAsync<TestPolicyRequirement>([userIdA, userIdB]));
+        Assert.Contains("GetAsyncVNext", exception.Message);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAsync_SingleUser_ForDefaultOnFactory_Throws(Guid userId)
+    {
+        // The single-user legacy overload delegates to the batch overload, so it inherits the guard.
+        var policyRepository = Substitute.For<IPolicyRepository>();
+        var factory = new TestPolicyRequirementFactory(_ => true, PolicyDefaultState.Enabled);
+        var sut = new PolicyRequirementQuery(policyRepository, [factory]);
+
+        var exception = await Assert.ThrowsAsync<NotImplementedException>(()
+            => sut.GetAsync<TestPolicyRequirement>(userId));
+        Assert.Contains("GetAsyncVNext", exception.Message);
     }
 
     [Theory, BitAutoData]

--- a/test/Core.Test/OrganizationFeatures/Policies/PolicyQueryTests.cs
+++ b/test/Core.Test/OrganizationFeatures/Policies/PolicyQueryTests.cs
@@ -2,7 +2,9 @@
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Implementations;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Test.AdminConsole.OrganizationFeatures.Policies;
 using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -53,6 +55,62 @@ public class PolicyQueryTests
         Assert.Equal(policyType, policyData.Type);
         Assert.False(policyData.Enabled);
         Assert.Null(policyData.Data);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RunAsync_WithNonExistentDefaultOnPolicy_ReturnsEnabled(Guid organizationId)
+    {
+        // Arrange — no saved row for a policy whose factory is enabled by default (SingleOrg here)
+        const PolicyType defaultOnType = PolicyType.SingleOrg;
+        var policyRepository = Substitute.For<IPolicyRepository>();
+        policyRepository.GetByOrganizationIdTypeAsync(organizationId, defaultOnType).ReturnsNull();
+        var factory = new TestPolicyRequirementFactory(_ => true, PolicyDefaultState.Enabled);
+        var sut = new PolicyQuery(policyRepository, [factory]);
+
+        // Act
+        var policyData = await sut.RunAsync(organizationId, defaultOnType);
+
+        // Assert — absence of a row maps to enabled
+        Assert.True(policyData.Enabled);
+        Assert.Equal(defaultOnType, policyData.Type);
+        Assert.Equal(organizationId, policyData.OrganizationId);
+    }
+
+    [Theory, BitAutoData]
+    public async Task RunAsync_WithDisabledDefaultOnPolicy_ReturnsDisabled(Guid organizationId)
+    {
+        // Arrange — an explicitly disabled row exists for a default-on policy
+        const PolicyType defaultOnType = PolicyType.SingleOrg;
+        var disabledPolicy = new Policy { OrganizationId = organizationId, Type = defaultOnType, Enabled = false };
+        var policyRepository = Substitute.For<IPolicyRepository>();
+        policyRepository.GetByOrganizationIdTypeAsync(organizationId, defaultOnType).Returns(disabledPolicy);
+        var factory = new TestPolicyRequirementFactory(_ => true, PolicyDefaultState.Enabled);
+        var sut = new PolicyQuery(policyRepository, [factory]);
+
+        // Act
+        var policyData = await sut.RunAsync(organizationId, defaultOnType);
+
+        // Assert — an explicit disabled row wins over the default
+        Assert.False(policyData.Enabled);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetAllAsync_WithMissingDefaultOnPolicy_SynthesizesEnabledEntry(Guid organizationId)
+    {
+        // Arrange — org has no row for the default-on type (SingleOrg)
+        const PolicyType defaultOnType = PolicyType.SingleOrg;
+        var policyRepository = Substitute.For<IPolicyRepository>();
+        policyRepository.GetManyByOrganizationIdAsync(organizationId).Returns(new List<Policy>());
+        var factory = new TestPolicyRequirementFactory(_ => true, PolicyDefaultState.Enabled);
+        var sut = new PolicyQuery(policyRepository, [factory]);
+
+        // Act
+        var results = (await sut.GetAllAsync(organizationId)).ToList();
+
+        // Assert — an enabled entry is synthesized for the missing default-on policy
+        var synthesized = results.Single(p => p.Type == defaultOnType);
+        Assert.True(synthesized.Enabled);
+        Assert.Equal(organizationId, synthesized.OrganizationId);
     }
 
     [Theory, BitAutoData]

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsWithStateByUserIdAndPolicyTypeTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsWithStateByUserIdAndPolicyTypeTests.cs
@@ -1,0 +1,248 @@
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Repositories;
+using Xunit;
+
+namespace Bit.Infrastructure.IntegrationTest.AdminConsole.Repositories.PolicyRepository;
+
+public class GetPolicyDetailsWithStateByUserIdAndPolicyTypeTests
+{
+    [Theory]
+    [DatabaseData]
+    public async Task GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync_WithNoPolicyRow_ReturnsRowWithNullEnabled(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IPolicyRepository policyRepository)
+    {
+        // Arrange — an org the user belongs to, but no policy row of this type
+        var user = await userRepository.CreateAsync(GetDefaultUser());
+        var org = await CreateEnterpriseOrgAsync(organizationRepository);
+        var orgUser = await organizationUserRepository.CreateAsync(GetConfirmedOrganizationUser(org, user));
+
+        // Act
+        var results = await policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(
+            user.Id,
+            PolicyType.TwoFactorAuthentication);
+
+        // Assert — a row is returned even though no policy exists; Enabled is null and there is no data
+        var result = Assert.Single(results);
+        Assert.Equal(orgUser.Id, result.OrganizationUserId);
+        Assert.Equal(org.Id, result.OrganizationId);
+        Assert.Equal(PolicyType.TwoFactorAuthentication, result.PolicyType);
+        Assert.Null(result.Enabled);
+        Assert.Null(result.PolicyData);
+    }
+
+    [Theory]
+    [DatabaseData]
+    public async Task GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync_WithEnabledPolicy_ReturnsEnabledTrue(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IPolicyRepository policyRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateAsync(GetDefaultUser());
+        var org = await CreateEnterpriseOrgAsync(organizationRepository);
+        var policy = await policyRepository.CreateAsync(new Policy
+        {
+            OrganizationId = org.Id,
+            Type = PolicyType.MasterPassword,
+            Data = "{\"minComplexity\":4}",
+            Enabled = true
+        });
+        await organizationUserRepository.CreateAsync(GetConfirmedOrganizationUser(org, user));
+
+        // Act
+        var results = await policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(
+            user.Id,
+            PolicyType.MasterPassword);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.True(result.Enabled);
+        Assert.Equal(policy.Data, result.PolicyData);
+    }
+
+    [Theory]
+    [DatabaseData]
+    public async Task GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync_WithDisabledPolicy_ReturnsEnabledFalse(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IPolicyRepository policyRepository)
+    {
+        // Arrange — a disabled row must be returned (not filtered out), so callers can distinguish it from "no row"
+        var user = await userRepository.CreateAsync(GetDefaultUser());
+        var org = await CreateEnterpriseOrgAsync(organizationRepository);
+        await policyRepository.CreateAsync(new Policy
+        {
+            OrganizationId = org.Id,
+            Type = PolicyType.SingleOrg,
+            Enabled = false
+        });
+        await organizationUserRepository.CreateAsync(GetConfirmedOrganizationUser(org, user));
+
+        // Act
+        var results = await policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(
+            user.Id,
+            PolicyType.SingleOrg);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.False(result.Enabled);
+    }
+
+    [Theory]
+    [DatabaseData]
+    public async Task GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync_WithInvitedUserAndNoRow_ReturnsRowWithNullEnabled(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IPolicyRepository policyRepository)
+    {
+        // Arrange — invited user matched by email, no policy row
+        var user = await userRepository.CreateAsync(GetDefaultUser());
+        var org = await CreateEnterpriseOrgAsync(organizationRepository);
+        var orgUser = await organizationUserRepository.CreateAsync(GetInvitedOrganizationUser(org, user));
+
+        // Act
+        var results = await policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(
+            user.Id,
+            PolicyType.RequireSso);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Equal(orgUser.Id, result.OrganizationUserId);
+        Assert.Equal(OrganizationUserStatusType.Invited, result.OrganizationUserStatus);
+        Assert.Null(result.Enabled);
+    }
+
+    [Theory]
+    [DatabaseData]
+    public async Task GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync_WithMultipleOrganizations_ReturnsRowPerOrg(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IPolicyRepository policyRepository)
+    {
+        // Arrange — one org has an enabled row, the other has none
+        var user = await userRepository.CreateAsync(GetDefaultUser());
+        var orgWithPolicy = await CreateEnterpriseOrgAsync(organizationRepository);
+        var orgWithoutPolicy = await CreateEnterpriseOrgAsync(organizationRepository);
+
+        await policyRepository.CreateAsync(new Policy
+        {
+            OrganizationId = orgWithPolicy.Id,
+            Type = PolicyType.SingleOrg,
+            Enabled = true
+        });
+
+        await organizationUserRepository.CreateAsync(GetConfirmedOrganizationUser(orgWithPolicy, user));
+        await organizationUserRepository.CreateAsync(GetConfirmedOrganizationUser(orgWithoutPolicy, user));
+
+        // Act
+        var results = (await policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(
+            user.Id,
+            PolicyType.SingleOrg)).ToList();
+
+        // Assert
+        Assert.Equal(2, results.Count);
+        Assert.True(results.First(r => r.OrganizationId == orgWithPolicy.Id).Enabled);
+        Assert.Null(results.First(r => r.OrganizationId == orgWithoutPolicy.Id).Enabled);
+    }
+
+    [Theory]
+    [DatabaseData]
+    public async Task GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync_WithDisabledOrganization_ReturnsEmpty(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IPolicyRepository policyRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateAsync(GetDefaultUser());
+        var org = await organizationRepository.CreateAsync(GetOrganization(usePolicies: true, enabled: false));
+        await organizationUserRepository.CreateAsync(GetConfirmedOrganizationUser(org, user));
+
+        // Act
+        var results = await policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(
+            user.Id,
+            PolicyType.PasswordGenerator);
+
+        // Assert — a disabled organization contributes no rows, even for a default-on policy
+        Assert.Empty(results);
+    }
+
+    [Theory]
+    [DatabaseData]
+    public async Task GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync_WithOrganizationNotUsingPolicies_ReturnsEmpty(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IPolicyRepository policyRepository)
+    {
+        // Arrange
+        var user = await userRepository.CreateAsync(GetDefaultUser());
+        var org = await organizationRepository.CreateAsync(GetOrganization(usePolicies: false, enabled: true));
+        await organizationUserRepository.CreateAsync(GetConfirmedOrganizationUser(org, user));
+
+        // Act
+        var results = await policyRepository.GetPolicyDetailsWithStateByUserIdAndPolicyTypeAsync(
+            user.Id,
+            PolicyType.MaximumVaultTimeout);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    private static async Task<Organization> CreateEnterpriseOrgAsync(IOrganizationRepository orgRepo)
+        => await orgRepo.CreateAsync(GetOrganization(usePolicies: true, enabled: true));
+
+    private static Organization GetOrganization(bool usePolicies, bool enabled) => new()
+    {
+        Name = "Test Organization",
+        BillingEmail = $"billing+{Guid.NewGuid()}@example.com",
+        Plan = "EnterpriseAnnually",
+        PlanType = PlanType.EnterpriseAnnually,
+        Seats = 10,
+        MaxCollections = 10,
+        UsePolicies = usePolicies,
+        UseDirectory = true,
+        UseTotp = true,
+        Use2fa = true,
+        UseApi = true,
+        SelfHost = true,
+        Enabled = enabled
+    };
+
+    private static User GetDefaultUser() => new()
+    {
+        Name = $"Test User {Guid.NewGuid()}",
+        Email = $"test+{Guid.NewGuid()}@example.com",
+        ApiKey = $"test.api.key.{Guid.NewGuid()}"[..30],
+        SecurityStamp = Guid.NewGuid().ToString()
+    };
+
+    private static OrganizationUser GetConfirmedOrganizationUser(Organization organization, User user) => new()
+    {
+        OrganizationId = organization.Id,
+        UserId = user.Id,
+        Status = OrganizationUserStatusType.Confirmed,
+        Type = OrganizationUserType.User
+    };
+
+    private static OrganizationUser GetInvitedOrganizationUser(Organization organization, User user) => new()
+    {
+        OrganizationId = organization.Id,
+        UserId = null, // Invited users don't have UserId
+        Email = user.Email,
+        Status = OrganizationUserStatusType.Invited,
+        Type = OrganizationUserType.User
+    };
+}

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsWithStateByUserIdAndPolicyTypeTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/PolicyRepository/GetPolicyDetailsWithStateByUserIdAndPolicyTypeTests.cs
@@ -1,4 +1,4 @@
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Enums;

--- a/util/Migrator/DbScripts/2026-07-02_00_PolicyDetailsReadWithStateByUserIdPolicyType.sql
+++ b/util/Migrator/DbScripts/2026-07-02_00_PolicyDetailsReadWithStateByUserIdPolicyType.sql
@@ -1,0 +1,78 @@
+CREATE OR ALTER PROCEDURE [dbo].[PolicyDetails_ReadWithStateByUserIdPolicyType]
+    @UserId UNIQUEIDENTIFIER,
+    @PolicyType TINYINT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    DECLARE @UserEmail NVARCHAR(256)
+    SELECT @UserEmail = Email
+    FROM
+        [dbo].[UserView]
+    WHERE
+        Id = @UserId
+
+    ;WITH OrgUsers AS
+    (
+        -- Non-invited, non-staged users: direct UserId match
+        SELECT
+            OU.[Id],
+            OU.[OrganizationId],
+            OU.[Type],
+            OU.[Status],
+            OU.[Permissions]
+        FROM
+            [dbo].[OrganizationUserView] OU
+        WHERE
+            OU.[Status] IN (-1, 1, 2)
+            AND OU.[UserId] = @UserId
+
+        UNION ALL
+
+        -- Invited users (Status = 0): email match
+        SELECT
+            OU.[Id],
+            OU.[OrganizationId],
+            OU.[Type],
+            OU.[Status],
+            OU.[Permissions]
+        FROM
+            [dbo].[OrganizationUserView] OU
+        WHERE
+            OU.[Status] = 0
+            AND OU.[Email] = @UserEmail
+            AND @UserEmail IS NOT NULL
+    ),
+    Providers AS
+    (
+        SELECT
+            OrganizationId
+        FROM
+            [dbo].[UserProviderAccessView]
+        WHERE
+            UserId = @UserId
+    )
+    SELECT
+        OU.[Id] AS OrganizationUserId,
+        O.[Id] AS OrganizationId,
+        @PolicyType AS PolicyType,
+        P.[Data] AS PolicyData,
+        OU.[Type] AS OrganizationUserType,
+        OU.[Status] AS OrganizationUserStatus,
+        OU.[Permissions] AS OrganizationUserPermissionsData,
+        CASE WHEN PR.[OrganizationId] IS NULL THEN 0 ELSE 1 END AS IsProvider,
+        -- Raw policy state: NULL when the organization has no row for this type
+        P.[Enabled] AS [Enabled]
+    FROM
+        OrgUsers OU
+    INNER JOIN
+        [dbo].[OrganizationView] O ON OU.[OrganizationId] = O.[Id]
+    LEFT JOIN
+        [dbo].[PolicyView] P ON P.[OrganizationId] = O.[Id] AND P.[Type] = @PolicyType
+    LEFT JOIN
+        Providers PR ON PR.[OrganizationId] = OU.[OrganizationId]
+    WHERE
+        O.[Enabled] = 1
+        AND O.[UsePolicies] = 1
+END
+GO


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
Tools Team need the new Send policy enabled by default. This is not something we support today:

- PolicyQuery maps a missing policy row to the disabled state
- PolicyRequirements doesn't expose missing policy rows - factories only receive `PolicyDetails` for policies that are actually in the database (due to the db query using an `INNER JOIN`).

We don't want to actually insert rows, so we need to handle the null state in code. Also note that client-side enforcement will be handled by Tools Team and is out of scope.

This is a minimal solution to unblock Tools Team this sprint, without overhauling the domain or impacting other policies.

This is done by:
- adding a new `PolicyDefaultState = ENABLED | DISABLED` property to the `IPolicyRequirementFactory`
- PolicyRequirementsQuery uses this to pivot to a new db query, which LEFT JOINs on policies rather than INNER JOIN. It returns a `PolicyDetailsWithState` subclass so that we can disambiguate between the 3 states (enabled, disabled, null)
- PolicyRequirementsQuery then includes all `PolicyDetails` for both enabled and null policies

The benefit of this is that it doesn't introduce new types to downstream consumers: we don't need to refactor `IPolicyRequirementsFactory` or the `IPolicyRequirement` - they just receive additional `PolicyDetails` to process. The underlying db state is abstracted away, minimizing the blast radius.

`PolicyQuery` also leans on this factory setting to synthesize enabled-by-default policies. This is a new coupling with the Factory, but it means there's a single source of truth. In particular, this is used by the Admin Console policies page, so the default value will flow through when the admin is configuring policies.

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
