### PR TITLE
[PM-40085] Remove initial delay on self-hosted database migration

### DIFF
--- a/src/Admin/HostedServices/DatabaseMigrationHostedService.cs
+++ b/src/Admin/HostedServices/DatabaseMigrationHostedService.cs
@@ -18,9 +18,6 @@ public class DatabaseMigrationHostedService : IHostedService, IDisposable
 
     public virtual async Task StartAsync(CancellationToken cancellationToken)
     {
-        // Wait 20 seconds to allow database to come online
-        await Task.Delay(20000, cancellationToken);
-
         var maxMigrationAttempts = 10;
         for (var i = 1; i <= maxMigrationAttempts; i++)
         {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40085

## 📔 Objective

Remove the 20-second delay before database migrations run on self-hosted deployments.

For Helm deployments, the migration is handled via other processes, and the unnecessary 20-second delay cause delays in the deployments.  We will instead rely on the failure of the migration to signal that it is not ready and trigger a delay if necessary, rather than forcing a delay on every deployment.

Any connection `Exception` would throw and be handled by the retry logic, except for a specific error around script mode, which is handled by its [own](https://github.com/bitwarden/server/blob/1468443ddeafc5d8fb4817b0042808846ef1cb8b/util/Migrator/DbMigrator.cs#L51-L63) retry.