### PR TITLE
[PM-39554] Create default collection for demoted admin

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -464,7 +464,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
         var existingUserType = organizationUser.Type;
 
         await _updateOrganizationUserCommand.UpdateUserAsync(model.ToOrganizationUser(organizationUser), existingUserType, userId,
-            collectionsToSave, groupsToSave);
+            collectionsToSave, groupsToSave, model.DefaultUserCollectionName);
     }
 
     [HttpPost("{id}")]

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -109,6 +109,8 @@ public class OrganizationUserUpdateRequestModel
 
     [StringLength(50)]
     public string? Name { get; set; }
+
+    public string? DefaultUserCollectionName { get; set; }
 #nullable disable
 
     public OrganizationUser ToOrganizationUser(OrganizationUser existingUser)

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IUpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/Interfaces/IUpdateOrganizationUserCommand.cs
@@ -8,5 +8,6 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interface
 public interface IUpdateOrganizationUserCommand
 {
     Task UpdateUserAsync(OrganizationUser organizationUser, OrganizationUserType existingUserType, Guid? savingUserId,
-        List<CollectionAccessSelection>? collectionAccess, IEnumerable<Guid>? groupAccess);
+        List<CollectionAccessSelection>? collectionAccess, IEnumerable<Guid>? groupAccess,
+        string? defaultUserCollectionName = null);
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Pricing;
@@ -27,6 +29,7 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
     private readonly IHasConfirmedOwnersExceptQuery _hasConfirmedOwnersExceptQuery;
     private readonly IPricingClient _pricingClient;
     private readonly TimeProvider _timeProvider;
+    private readonly IPolicyRequirementQuery _policyRequirementQuery;
 
     public UpdateOrganizationUserCommand(
         IEventService eventService,
@@ -39,7 +42,8 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
         IGroupRepository groupRepository,
         IHasConfirmedOwnersExceptQuery hasConfirmedOwnersExceptQuery,
         IPricingClient pricingClient,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        IPolicyRequirementQuery policyRequirementQuery)
     {
         _eventService = eventService;
         _organizationService = organizationService;
@@ -52,6 +56,7 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
         _hasConfirmedOwnersExceptQuery = hasConfirmedOwnersExceptQuery;
         _pricingClient = pricingClient;
         _timeProvider = timeProvider;
+        _policyRequirementQuery = policyRequirementQuery;
     }
 
     /// <summary>
@@ -148,7 +153,11 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
 
         var isDemotedFromPrivilegedRole = existingUserType is OrganizationUserType.Admin or OrganizationUserType.Owner
             && organizationUser.Type is not (OrganizationUserType.Admin or OrganizationUserType.Owner);
-        if (isDemotedFromPrivilegedRole && !string.IsNullOrWhiteSpace(defaultUserCollectionName))
+        if (isDemotedFromPrivilegedRole
+            && organizationUser.UserId.HasValue
+            && organization.UseMyItems
+            && !string.IsNullOrWhiteSpace(defaultUserCollectionName)
+            && (await _policyRequirementQuery.GetAsync<OrganizationDataOwnershipPolicyRequirement>(organizationUser.UserId.Value)).State == OrganizationDataOwnershipState.Enabled)
         {
             await _collectionRepository.CreateDefaultCollectionsAsync(
                 organizationUser.OrganizationId,

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
@@ -65,7 +65,8 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
     /// <exception cref="BadRequestException"></exception>
     public async Task UpdateUserAsync(OrganizationUser organizationUser, OrganizationUserType existingUserType,
         Guid? savingUserId,
-        List<CollectionAccessSelection>? collectionAccess, IEnumerable<Guid>? groupAccess)
+        List<CollectionAccessSelection>? collectionAccess, IEnumerable<Guid>? groupAccess,
+        string? defaultUserCollectionName = null)
     {
         // Avoid multiple enumeration
         var collectionAccessList = collectionAccess?.ToList() ?? [];
@@ -143,6 +144,16 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
         if (groupAccess != null)
         {
             await _organizationUserRepository.UpdateGroupsAsync(organizationUser.Id, groupAccess, _timeProvider.GetUtcNow().UtcDateTime);
+        }
+
+        var isDemotedFromPrivilegedRole = existingUserType is OrganizationUserType.Admin or OrganizationUserType.Owner
+            && organizationUser.Type is not (OrganizationUserType.Admin or OrganizationUserType.Owner);
+        if (isDemotedFromPrivilegedRole && !string.IsNullOrWhiteSpace(defaultUserCollectionName))
+        {
+            await _collectionRepository.CreateDefaultCollectionsAsync(
+                organizationUser.OrganizationId,
+                [organizationUser.Id],
+                defaultUserCollectionName);
         }
 
         await _eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Updated);

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
@@ -58,7 +58,8 @@ public class OrganizationUserControllerPutTests
             savingUserId,
             Arg.Is<List<CollectionAccessSelection>>(cas =>
                 cas.All(c => model.Collections.Any(m => m.Id == c.Id))),
-            model.Groups);
+            model.Groups,
+            model.DefaultUserCollectionName);
     }
 
     [Theory]
@@ -110,7 +111,8 @@ public class OrganizationUserControllerPutTests
             Arg.Is<List<CollectionAccessSelection>>(cas =>
                 cas.All(c => model.Collections.Any(m => m.Id == c.Id))),
             // Main assertion: groups are not updated (are null)
-            null);
+            null,
+            model.DefaultUserCollectionName);
     }
 
     [Theory]
@@ -146,7 +148,8 @@ public class OrganizationUserControllerPutTests
             savingUserId,
             Arg.Is<List<CollectionAccessSelection>>(cas =>
                 cas.All(c => model.Collections.Any(m => m.Id == c.Id))),
-            model.Groups);
+            model.Groups,
+            model.DefaultUserCollectionName);
     }
 
     [Theory]
@@ -227,7 +230,8 @@ public class OrganizationUserControllerPutTests
                 cas.First(c => c.Id == editedCollectionId).Manage == true &&
                 cas.First(c => c.Id == editedCollectionId).ReadOnly == false &&
                 cas.First(c => c.Id == editedCollectionId).HidePasswords == false),
-            model.Groups);
+            model.Groups,
+            model.DefaultUserCollectionName);
     }
 
     [Theory]

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
@@ -2,6 +2,8 @@
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Entities;
@@ -285,7 +287,7 @@ public class UpdateOrganizationUserCommandTests
     [Theory]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.Owner)]
-    public async Task UpdateUserAsync_WhenDemotingPrivilegedUserToUser_WithDefaultCollectionName_CreatesDefaultCollection(
+    public async Task UpdateUserAsync_WhenDemotingPrivilegedUserToUser_WithDefaultCollectionName_AndUseMyItemsEnabled_AndPolicyEnabled_CreatesDefaultCollection(
         OrganizationUserType existingUserType,
         Organization organization,
         OrganizationUser oldUserData,
@@ -293,8 +295,10 @@ public class UpdateOrganizationUserCommandTests
         string defaultUserCollectionName,
         SutProvider<UpdateOrganizationUserCommand> sutProvider)
     {
+        organization.UseMyItems = true;
         newUserData.Type = OrganizationUserType.User;
         Setup(sutProvider, organization, newUserData, oldUserData);
+        SetupDataOwnershipPolicy(sutProvider, newUserData.UserId!.Value, OrganizationDataOwnershipState.Enabled);
 
         await sutProvider.Sut.UpdateUserAsync(newUserData, existingUserType, null, null, null, defaultUserCollectionName);
 
@@ -302,6 +306,49 @@ public class UpdateOrganizationUserCommandTests
             newUserData.OrganizationId,
             Arg.Is<IEnumerable<Guid>>(ids => ids.Contains(newUserData.Id)),
             defaultUserCollectionName);
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    public async Task UpdateUserAsync_WhenDemotingPrivilegedUserToUser_WithDefaultCollectionName_AndUseMyItemsDisabled_DoesNotCreateDefaultCollection(
+        OrganizationUserType existingUserType,
+        Organization organization,
+        OrganizationUser oldUserData,
+        OrganizationUser newUserData,
+        string defaultUserCollectionName,
+        SutProvider<UpdateOrganizationUserCommand> sutProvider)
+    {
+        organization.UseMyItems = false;
+        newUserData.Type = OrganizationUserType.User;
+        Setup(sutProvider, organization, newUserData, oldUserData);
+
+        await sutProvider.Sut.UpdateUserAsync(newUserData, existingUserType, null, null, null, defaultUserCollectionName);
+
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceive().CreateDefaultCollectionsAsync(
+            Arg.Any<Guid>(), Arg.Any<IEnumerable<Guid>>(), Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    public async Task UpdateUserAsync_WhenDemotingPrivilegedUserToUser_WithDefaultCollectionName_AndPolicyDisabled_DoesNotCreateDefaultCollection(
+        OrganizationUserType existingUserType,
+        Organization organization,
+        OrganizationUser oldUserData,
+        OrganizationUser newUserData,
+        string defaultUserCollectionName,
+        SutProvider<UpdateOrganizationUserCommand> sutProvider)
+    {
+        organization.UseMyItems = true;
+        newUserData.Type = OrganizationUserType.User;
+        Setup(sutProvider, organization, newUserData, oldUserData);
+        SetupDataOwnershipPolicy(sutProvider, newUserData.UserId!.Value, OrganizationDataOwnershipState.Disabled);
+
+        await sutProvider.Sut.UpdateUserAsync(newUserData, existingUserType, null, null, null, defaultUserCollectionName);
+
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceive().CreateDefaultCollectionsAsync(
+            Arg.Any<Guid>(), Arg.Any<IEnumerable<Guid>>(), Arg.Any<string>());
     }
 
     [Theory]
@@ -361,5 +408,14 @@ public class UpdateOrganizationUserCommandTests
                 oldUser.OrganizationId,
                 Arg.Is<IEnumerable<Guid>>(i => i.Contains(oldUser.Id)))
             .Returns(true);
+    }
+
+    private void SetupDataOwnershipPolicy(SutProvider<UpdateOrganizationUserCommand> sutProvider,
+        Guid userId, OrganizationDataOwnershipState state)
+    {
+        var requirement = new OrganizationDataOwnershipPolicyRequirement(state, []);
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<OrganizationDataOwnershipPolicyRequirement>(userId)
+            .Returns(requirement);
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
@@ -282,6 +282,67 @@ public class UpdateOrganizationUserCommandTests
         );
     }
 
+    [Theory]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    public async Task UpdateUserAsync_WhenDemotingPrivilegedUserToUser_WithDefaultCollectionName_CreatesDefaultCollection(
+        OrganizationUserType existingUserType,
+        Organization organization,
+        OrganizationUser oldUserData,
+        OrganizationUser newUserData,
+        string defaultUserCollectionName,
+        SutProvider<UpdateOrganizationUserCommand> sutProvider)
+    {
+        newUserData.Type = OrganizationUserType.User;
+        Setup(sutProvider, organization, newUserData, oldUserData);
+
+        await sutProvider.Sut.UpdateUserAsync(newUserData, existingUserType, null, null, null, defaultUserCollectionName);
+
+        await sutProvider.GetDependency<ICollectionRepository>().Received(1).CreateDefaultCollectionsAsync(
+            newUserData.OrganizationId,
+            Arg.Is<IEnumerable<Guid>>(ids => ids.Contains(newUserData.Id)),
+            defaultUserCollectionName);
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.User)]
+    [BitAutoData(OrganizationUserType.Custom)]
+    public async Task UpdateUserAsync_WhenExistingUserIsNotPrivileged_WithDefaultCollectionName_DoesNotCreateDefaultCollection(
+        OrganizationUserType existingUserType,
+        Organization organization,
+        OrganizationUser oldUserData,
+        OrganizationUser newUserData,
+        string defaultUserCollectionName,
+        SutProvider<UpdateOrganizationUserCommand> sutProvider)
+    {
+        newUserData.Type = OrganizationUserType.User;
+        Setup(sutProvider, organization, newUserData, oldUserData);
+
+        await sutProvider.Sut.UpdateUserAsync(newUserData, existingUserType, null, null, null, defaultUserCollectionName);
+
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceive().CreateDefaultCollectionsAsync(
+            Arg.Any<Guid>(), Arg.Any<IEnumerable<Guid>>(), Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    public async Task UpdateUserAsync_WhenDemotingPrivilegedUserToUser_WithoutDefaultCollectionName_DoesNotCreateDefaultCollection(
+        OrganizationUserType existingUserType,
+        Organization organization,
+        OrganizationUser oldUserData,
+        OrganizationUser newUserData,
+        SutProvider<UpdateOrganizationUserCommand> sutProvider)
+    {
+        newUserData.Type = OrganizationUserType.User;
+        Setup(sutProvider, organization, newUserData, oldUserData);
+
+        await sutProvider.Sut.UpdateUserAsync(newUserData, existingUserType, null, null, null);
+
+        await sutProvider.GetDependency<ICollectionRepository>().DidNotReceive().CreateDefaultCollectionsAsync(
+            Arg.Any<Guid>(), Arg.Any<IEnumerable<Guid>>(), Arg.Any<string>());
+    }
+
     private void Setup(SutProvider<UpdateOrganizationUserCommand> sutProvider, Organization organization,
         OrganizationUser newUser, OrganizationUser oldUser)
     {


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-39554
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
This PR fixes an issue when an admin's role is demoted to a user, no "My Items" collection is created for them.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
