### PR TITLE
[BRE-1907] Add artifact manifest to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -622,7 +622,9 @@ jobs:
     name: Trigger K8s deploy
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
-    needs: build-artifacts
+    needs:
+      - build-artifacts
+      - image-manifest
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,6 +286,29 @@ jobs:
           push: true
           tags: ${{ steps.image-tags.outputs.tags }}
 
+      - name: Generate image manifest fragment
+        env:
+          PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          DIGEST: ${{ steps.build-artifacts.outputs.digest }}
+        run: |
+          mkdir -p image-manifest-fragments
+          jq -n \
+            --arg name "$PROJECT_NAME" \
+            --arg registry "$_AZ_REGISTRY" \
+            --arg image "$PROJECT_NAME" \
+            --arg tag "$IMAGE_TAG" \
+            --arg digest "$DIGEST" \
+            '{($name): {type: "container_image", registry: $registry, image: $image, tag: $tag, digest: $digest}}' \
+            > "image-manifest-fragments/${PROJECT_NAME}.json"
+
+      - name: Upload image manifest fragment
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: image-manifest-fragment-${{ steps.setup.outputs.project_name }}
+          path: image-manifest-fragments/${{ steps.setup.outputs.project_name }}.json
+          if-no-files-found: error
+
       - name: Install Cosign
         if: github.event_name != 'pull_request' && env.is_publish_branch == 'true'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -326,6 +349,36 @@ jobs:
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+  image-manifest:
+    name: Build image manifest
+    runs-on: ubuntu-22.04
+    needs: build-artifacts
+    permissions:
+      contents: read
+    steps:
+      - name: Download image manifest fragments
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: image-manifest-fragment-*
+          path: image-manifest-fragments
+          merge-multiple: true
+
+      - name: Combine image manifest fragments
+        id: combine
+        run: |
+          additional_artifacts=$(jq -s 'add' image-manifest-fragments/*.json)
+          {
+            echo "additional_artifacts<<EOF"
+            echo "$additional_artifacts"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and upload artifact manifest
+        uses: bitwarden/gh-actions/artifact-manifest@main
+        with:
+          mode: upload
+          additional_artifacts: ${{ steps.combine.outputs.additional_artifacts }}
 
   upload:
     name: Upload


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-1907](https://bitwarden.atlassian.net/browse/BRE-1907)

## 📔 Objective
This PR is one of 3 across the [server](https://github.com/bitwarden/server/pull/7920), [deploy](https://github.com/bitwarden/deploy/pull/231), and [devops](https://github.com/bitwarden/devops/pull/4813) repos. The overall goal of these is to provide the final deployment workflow in `devops` with the SHAs of the images that need to be deployed. The current logic uses image tags in the deploy workflow, which are mutable. Deploying using the immutable SHAs from the build step ensures the intended images are deployed.

This PR adds steps to `.github/workflows/build.yml` that builds and uploads a manifest as an artifact to the run. The manifest contains digests of all the container images built in the run so that downstream workflows can use a given `build.yml` run's ID as a key to retrieve and deploy the exact images built in that run. The manifest follows the standard outlined in [this](https://github.com/bitwarden/gh-actions/tree/main/artifact-manifest) action.


[BRE-1907]: https://bitwarden.atlassian.net/browse/BRE-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ