### PR TITLE
[PM-32699] Utilize cache to check ability of useMyItems if available

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/OrganizationDataOwnershipPolicyEventHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/OrganizationDataOwnershipPolicyEventHandler.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
@@ -12,6 +13,7 @@ public class OrganizationDataOwnershipPolicyEventHandler(
     IPolicyRepository policyRepository,
     ICollectionRepository collectionRepository,
     IOrganizationRepository organizationRepository,
+    IOrganizationAbilityCacheService organizationAbilityCacheService,
     IEnumerable<IPolicyRequirementFactory<IPolicyRequirement>> factories)
     : OrganizationPolicyEventHandler(policyRepository, factories), IOnPolicyPostUpdateEvent
 {
@@ -44,16 +46,7 @@ public class OrganizationDataOwnershipPolicyEventHandler(
 
     private async Task UpsertDefaultCollectionsForUsersAsync(PolicyUpdate policyUpdate, string defaultCollectionName)
     {
-        // FIXME: we should use the organizationAbility cache here, but it is currently flaky
-        // and it's not obvious how to handle a cache failure.
-        // https://bitwarden.atlassian.net/browse/PM-32699
-        var organization = await organizationRepository.GetByIdAsync(policyUpdate.OrganizationId);
-        if (organization == null)
-        {
-            throw new InvalidOperationException($"Organization with ID {policyUpdate.OrganizationId} not found.");
-        }
-
-        if (!organization.UseMyItems)
+        if (!await OrganizationUsesMyItemsAsync(policyUpdate.OrganizationId))
         {
             return;
         }
@@ -75,5 +68,22 @@ public class OrganizationDataOwnershipPolicyEventHandler(
             policyUpdate.OrganizationId,
             userOrgIds,
             defaultCollectionName);
+    }
+
+    private async Task<bool> OrganizationUsesMyItemsAsync(Guid organizationId)
+    {
+        var organizationAbility = await organizationAbilityCacheService.GetOrganizationAbilityAsync(organizationId);
+        if (organizationAbility != null)
+        {
+            return organizationAbility.UseMyItems;
+        }
+
+        var organization = await organizationRepository.GetByIdAsync(organizationId);
+        if (organization == null)
+        {
+            throw new InvalidOperationException($"Organization with ID {organizationId} not found.");
+        }
+
+        return organization.UseMyItems;
     }
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/OrganizationDataOwnershipPolicyEventHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/OrganizationDataOwnershipPolicyEventHandler.cs
@@ -5,6 +5,7 @@ using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyUpdateEvents.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandlers;
@@ -12,7 +13,6 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandler
 public class OrganizationDataOwnershipPolicyEventHandler(
     IPolicyRepository policyRepository,
     ICollectionRepository collectionRepository,
-    IOrganizationRepository organizationRepository,
     IOrganizationAbilityCacheService organizationAbilityCacheService,
     IEnumerable<IPolicyRequirementFactory<IPolicyRequirement>> factories)
     : OrganizationPolicyEventHandler(policyRepository, factories), IOnPolicyPostUpdateEvent
@@ -73,17 +73,11 @@ public class OrganizationDataOwnershipPolicyEventHandler(
     private async Task<bool> OrganizationUsesMyItemsAsync(Guid organizationId)
     {
         var organizationAbility = await organizationAbilityCacheService.GetOrganizationAbilityAsync(organizationId);
-        if (organizationAbility != null)
+        if (organizationAbility == null)
         {
-            return organizationAbility.UseMyItems;
+            throw new NotFoundException($"Organization with ID {organizationId} not found.");
         }
 
-        var organization = await organizationRepository.GetByIdAsync(organizationId);
-        if (organization == null)
-        {
-            throw new InvalidOperationException($"Organization with ID {organizationId} not found.");
-        }
-
-        return organization.UseMyItems;
+        return organizationAbility.UseMyItems;
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/OrganizationDataOwnershipPolicyEventHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/OrganizationDataOwnershipPolicyEventHandlerTests.cs
@@ -1,10 +1,12 @@
-﻿using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandlers;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Repositories;
 using Bit.Core.Test.AdminConsole.AutoFixture;
 using Bit.Test.Common.AutoFixture;
@@ -255,7 +257,13 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
                 Id = callInfo.Arg<Guid>(),
                 UseMyItems = useMyItems
             });
-        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, [factory]);
+
+        // Default the ability cache to a miss so the handler falls back to the organization repository
+        var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(Arg.Any<Guid>())
+            .Returns((OrganizationAbility?)null);
+
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
         return sut;
     }
 
@@ -438,7 +446,12 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
         // Return null to simulate organization not found
         organizationRepository.GetByIdAsync(Arg.Any<Guid>()).Returns((Organization?)null);
 
-        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, [factory]);
+        // Simulate a cache miss so the handler falls back to the organization repository
+        var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(Arg.Any<Guid>())
+            .Returns((OrganizationAbility?)null);
+
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
         var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
 
         // Act & Assert
@@ -478,5 +491,133 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
                 Arg.Any<Guid>(),
                 Arg.Any<IEnumerable<Guid>>(),
                 Arg.Any<string>());
+    }
+
+    [Theory]
+    [BitMemberAutoData(nameof(ShouldUpsertDefaultCollectionsTestCases))]
+    public async Task ExecutePostUpsertSideEffectAsync_CacheHitUseMyItemsEnabled_UsesCacheAndSkipsOrganizationRepository(
+        Policy postUpdatedPolicy,
+        Policy? previousPolicyState,
+        [PolicyUpdate(PolicyType.OrganizationDataOwnership)] PolicyUpdate policyUpdate,
+        [OrganizationPolicyDetails(PolicyType.OrganizationDataOwnership)] IEnumerable<OrganizationPolicyDetails> orgPolicyDetails,
+        OrganizationDataOwnershipPolicyRequirementFactory factory)
+    {
+        // Arrange
+        var orgPolicyDetailsList = orgPolicyDetails.ToList();
+        foreach (var policyDetail in orgPolicyDetailsList)
+        {
+            policyDetail.OrganizationId = policyUpdate.OrganizationId;
+        }
+
+        var policyRepository = ArrangePolicyRepository(orgPolicyDetailsList);
+        var collectionRepository = Substitute.For<ICollectionRepository>();
+        var organizationRepository = Substitute.For<IOrganizationRepository>();
+
+        var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(policyUpdate.OrganizationId)
+            .Returns(new OrganizationAbility { Id = policyUpdate.OrganizationId, UseMyItems = true });
+
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
+        var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
+
+        // Act
+        await sut.ExecutePostUpsertSideEffectAsync(policyRequest, postUpdatedPolicy, previousPolicyState);
+
+        // Assert - Should trust the cached value and never hit the organization repository
+        await organizationRepository
+            .DidNotReceiveWithAnyArgs()
+            .GetByIdAsync(default);
+
+        await collectionRepository
+            .Received(1)
+            .CreateDefaultCollectionsBulkAsync(
+                policyUpdate.OrganizationId,
+                Arg.Is<IEnumerable<Guid>>(ids => ids.Count() == 3),
+                _defaultUserCollectionName);
+    }
+
+    [Theory]
+    [BitMemberAutoData(nameof(ShouldUpsertDefaultCollectionsTestCases))]
+    public async Task ExecutePostUpsertSideEffectAsync_CacheHitUseMyItemsDisabled_ShortcutsWithoutHittingOrganizationRepository(
+        Policy postUpdatedPolicy,
+        Policy? previousPolicyState,
+        [PolicyUpdate(PolicyType.OrganizationDataOwnership)] PolicyUpdate policyUpdate,
+        [OrganizationPolicyDetails(PolicyType.OrganizationDataOwnership)] IEnumerable<OrganizationPolicyDetails> orgPolicyDetails,
+        OrganizationDataOwnershipPolicyRequirementFactory factory)
+    {
+        // Arrange
+        var orgPolicyDetailsList = orgPolicyDetails.ToList();
+        foreach (var policyDetail in orgPolicyDetailsList)
+        {
+            policyDetail.OrganizationId = policyUpdate.OrganizationId;
+        }
+
+        var policyRepository = ArrangePolicyRepository(orgPolicyDetailsList);
+        var collectionRepository = Substitute.For<ICollectionRepository>();
+        var organizationRepository = Substitute.For<IOrganizationRepository>();
+
+        var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(policyUpdate.OrganizationId)
+            .Returns(new OrganizationAbility { Id = policyUpdate.OrganizationId, UseMyItems = false });
+
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
+        var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
+
+        // Act
+        await sut.ExecutePostUpsertSideEffectAsync(policyRequest, postUpdatedPolicy, previousPolicyState);
+
+        // Assert - Should shortcut based on the cached value alone, without ever calling the organization repository
+        await organizationRepository
+            .DidNotReceiveWithAnyArgs()
+            .GetByIdAsync(default);
+
+        await collectionRepository
+            .DidNotReceiveWithAnyArgs()
+            .CreateDefaultCollectionsBulkAsync(default, default, default);
+    }
+
+    [Theory]
+    [BitMemberAutoData(nameof(ShouldUpsertDefaultCollectionsTestCases))]
+    public async Task ExecutePostUpsertSideEffectAsync_CacheMiss_FallsBackToOrganizationRepository(
+        Policy postUpdatedPolicy,
+        Policy? previousPolicyState,
+        [PolicyUpdate(PolicyType.OrganizationDataOwnership)] PolicyUpdate policyUpdate,
+        [OrganizationPolicyDetails(PolicyType.OrganizationDataOwnership)] IEnumerable<OrganizationPolicyDetails> orgPolicyDetails,
+        OrganizationDataOwnershipPolicyRequirementFactory factory)
+    {
+        // Arrange
+        var orgPolicyDetailsList = orgPolicyDetails.ToList();
+        foreach (var policyDetail in orgPolicyDetailsList)
+        {
+            policyDetail.OrganizationId = policyUpdate.OrganizationId;
+        }
+
+        var policyRepository = ArrangePolicyRepository(orgPolicyDetailsList);
+        var collectionRepository = Substitute.For<ICollectionRepository>();
+        var organizationRepository = Substitute.For<IOrganizationRepository>();
+        organizationRepository.GetByIdAsync(policyUpdate.OrganizationId)
+            .Returns(new Organization { Id = policyUpdate.OrganizationId, UseMyItems = true });
+
+        var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(policyUpdate.OrganizationId)
+            .Returns((OrganizationAbility?)null);
+
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
+        var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
+
+        // Act
+        await sut.ExecutePostUpsertSideEffectAsync(policyRequest, postUpdatedPolicy, previousPolicyState);
+
+        // Assert - On a cache miss, the organization repository should be consulted as the source of truth
+        await organizationRepository
+            .Received(1)
+            .GetByIdAsync(policyUpdate.OrganizationId);
+
+        await collectionRepository
+            .Received(1)
+            .CreateDefaultCollectionsBulkAsync(
+                policyUpdate.OrganizationId,
+                Arg.Is<IEnumerable<Guid>>(ids => ids.Count() == 3),
+                _defaultUserCollectionName);
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/OrganizationDataOwnershipPolicyEventHandlerTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/OrganizationDataOwnershipPolicyEventHandlerTests.cs
@@ -6,6 +6,7 @@ using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandlers;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Exceptions;
 using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Repositories;
 using Bit.Core.Test.AdminConsole.AutoFixture;
@@ -34,10 +35,6 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
         previousPolicyState.OrganizationId = policyUpdate.OrganizationId;
         organization.Id = policyUpdate.OrganizationId;
 
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(policyUpdate.OrganizationId)
-            .Returns(organization);
-
         var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
 
         // Act
@@ -61,10 +58,6 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
         previousPolicyState.OrganizationId = policyUpdate.OrganizationId;
         postUpdatedPolicy.OrganizationId = policyUpdate.OrganizationId;
         organization.Id = policyUpdate.OrganizationId;
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(policyUpdate.OrganizationId)
-            .Returns(organization);
 
         var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
 
@@ -218,10 +211,6 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
         policyUpdate.Enabled = true;
         organization.Id = policyUpdate.OrganizationId;
 
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(policyUpdate.OrganizationId)
-            .Returns(organization);
-
         var policyRequest = new SavePolicyModel(policyUpdate, metadata);
 
         // Act
@@ -249,21 +238,16 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
         ICollectionRepository collectionRepository,
         bool useMyItems = true)
     {
-        var organizationRepository = Substitute.For<IOrganizationRepository>();
         // Default to UseMyItems = true for existing tests
-        organizationRepository.GetByIdAsync(Arg.Any<Guid>())
-            .Returns(callInfo => new Organization
+        var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(Arg.Any<Guid>())
+            .Returns(callInfo => new OrganizationAbility
             {
                 Id = callInfo.Arg<Guid>(),
                 UseMyItems = useMyItems
             });
 
-        // Default the ability cache to a miss so the handler falls back to the organization repository
-        var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
-        organizationAbilityCacheService.GetOrganizationAbilityAsync(Arg.Any<Guid>())
-            .Returns((OrganizationAbility?)null);
-
-        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationAbilityCacheService, [factory]);
         return sut;
     }
 
@@ -279,10 +263,6 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
         postUpdatedPolicy.OrganizationId = policyUpdate.OrganizationId;
         previousPolicyState.OrganizationId = policyUpdate.OrganizationId;
         organization.Id = policyUpdate.OrganizationId;
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(policyUpdate.OrganizationId)
-            .Returns(organization);
 
         var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
 
@@ -307,10 +287,6 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
         previousPolicyState.OrganizationId = policyUpdate.OrganizationId;
         postUpdatedPolicy.OrganizationId = policyUpdate.OrganizationId;
         organization.Id = policyUpdate.OrganizationId;
-
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(policyUpdate.OrganizationId)
-            .Returns(organization);
 
         var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
 
@@ -408,10 +384,6 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
         policyUpdate.Enabled = true;
         organization.Id = policyUpdate.OrganizationId;
 
-        sutProvider.GetDependency<IOrganizationRepository>()
-            .GetByIdAsync(policyUpdate.OrganizationId)
-            .Returns(organization);
-
         var policyRequest = new SavePolicyModel(policyUpdate, metadata);
 
         // Act
@@ -425,7 +397,7 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
 
     [Theory]
     [BitMemberAutoData(nameof(ShouldUpsertDefaultCollectionsTestCases))]
-    public async Task ExecuteSideEffectsAsync_OrganizationNotFound_ThrowsInvalidOperationException(
+    public async Task ExecuteSideEffectsAsync_OrganizationNotFound_ThrowsNotFoundException(
         Policy postUpdatedPolicy,
         Policy? previousPolicyState,
         [PolicyUpdate(PolicyType.OrganizationDataOwnership)] PolicyUpdate policyUpdate,
@@ -441,21 +413,17 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
 
         var policyRepository = ArrangePolicyRepository(orgPolicyDetailsList);
         var collectionRepository = Substitute.For<ICollectionRepository>();
-        var organizationRepository = Substitute.For<IOrganizationRepository>();
 
-        // Return null to simulate organization not found
-        organizationRepository.GetByIdAsync(Arg.Any<Guid>()).Returns((Organization?)null);
-
-        // Simulate a cache miss so the handler falls back to the organization repository
+        // Simulate the organization not being present in the ability cache
         var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
         organizationAbilityCacheService.GetOrganizationAbilityAsync(Arg.Any<Guid>())
             .Returns((OrganizationAbility?)null);
 
-        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationAbilityCacheService, [factory]);
         var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+        await Assert.ThrowsAsync<NotFoundException>(() =>
             sut.ExecutePostUpsertSideEffectAsync(policyRequest, postUpdatedPolicy, previousPolicyState));
     }
 
@@ -495,7 +463,7 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
 
     [Theory]
     [BitMemberAutoData(nameof(ShouldUpsertDefaultCollectionsTestCases))]
-    public async Task ExecutePostUpsertSideEffectAsync_CacheHitUseMyItemsEnabled_UsesCacheAndSkipsOrganizationRepository(
+    public async Task ExecutePostUpsertSideEffectAsync_CacheHitUseMyItemsEnabled_CreatesDefaultCollections(
         Policy postUpdatedPolicy,
         Policy? previousPolicyState,
         [PolicyUpdate(PolicyType.OrganizationDataOwnership)] PolicyUpdate policyUpdate,
@@ -511,23 +479,18 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
 
         var policyRepository = ArrangePolicyRepository(orgPolicyDetailsList);
         var collectionRepository = Substitute.For<ICollectionRepository>();
-        var organizationRepository = Substitute.For<IOrganizationRepository>();
 
         var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
         organizationAbilityCacheService.GetOrganizationAbilityAsync(policyUpdate.OrganizationId)
             .Returns(new OrganizationAbility { Id = policyUpdate.OrganizationId, UseMyItems = true });
 
-        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationAbilityCacheService, [factory]);
         var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
 
         // Act
         await sut.ExecutePostUpsertSideEffectAsync(policyRequest, postUpdatedPolicy, previousPolicyState);
 
-        // Assert - Should trust the cached value and never hit the organization repository
-        await organizationRepository
-            .DidNotReceiveWithAnyArgs()
-            .GetByIdAsync(default);
-
+        // Assert - Should trust the cached value
         await collectionRepository
             .Received(1)
             .CreateDefaultCollectionsBulkAsync(
@@ -538,7 +501,7 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
 
     [Theory]
     [BitMemberAutoData(nameof(ShouldUpsertDefaultCollectionsTestCases))]
-    public async Task ExecutePostUpsertSideEffectAsync_CacheHitUseMyItemsDisabled_ShortcutsWithoutHittingOrganizationRepository(
+    public async Task ExecutePostUpsertSideEffectAsync_CacheHitUseMyItemsDisabled_DoesNotCreateCollections(
         Policy postUpdatedPolicy,
         Policy? previousPolicyState,
         [PolicyUpdate(PolicyType.OrganizationDataOwnership)] PolicyUpdate policyUpdate,
@@ -554,70 +517,20 @@ public class OrganizationDataOwnershipPolicyEventHandlerTests
 
         var policyRepository = ArrangePolicyRepository(orgPolicyDetailsList);
         var collectionRepository = Substitute.For<ICollectionRepository>();
-        var organizationRepository = Substitute.For<IOrganizationRepository>();
 
         var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
         organizationAbilityCacheService.GetOrganizationAbilityAsync(policyUpdate.OrganizationId)
             .Returns(new OrganizationAbility { Id = policyUpdate.OrganizationId, UseMyItems = false });
 
-        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
+        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationAbilityCacheService, [factory]);
         var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
 
         // Act
         await sut.ExecutePostUpsertSideEffectAsync(policyRequest, postUpdatedPolicy, previousPolicyState);
 
-        // Assert - Should shortcut based on the cached value alone, without ever calling the organization repository
-        await organizationRepository
-            .DidNotReceiveWithAnyArgs()
-            .GetByIdAsync(default);
-
+        // Assert - Should shortcut based on the cached value alone
         await collectionRepository
             .DidNotReceiveWithAnyArgs()
             .CreateDefaultCollectionsBulkAsync(default, default, default);
-    }
-
-    [Theory]
-    [BitMemberAutoData(nameof(ShouldUpsertDefaultCollectionsTestCases))]
-    public async Task ExecutePostUpsertSideEffectAsync_CacheMiss_FallsBackToOrganizationRepository(
-        Policy postUpdatedPolicy,
-        Policy? previousPolicyState,
-        [PolicyUpdate(PolicyType.OrganizationDataOwnership)] PolicyUpdate policyUpdate,
-        [OrganizationPolicyDetails(PolicyType.OrganizationDataOwnership)] IEnumerable<OrganizationPolicyDetails> orgPolicyDetails,
-        OrganizationDataOwnershipPolicyRequirementFactory factory)
-    {
-        // Arrange
-        var orgPolicyDetailsList = orgPolicyDetails.ToList();
-        foreach (var policyDetail in orgPolicyDetailsList)
-        {
-            policyDetail.OrganizationId = policyUpdate.OrganizationId;
-        }
-
-        var policyRepository = ArrangePolicyRepository(orgPolicyDetailsList);
-        var collectionRepository = Substitute.For<ICollectionRepository>();
-        var organizationRepository = Substitute.For<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(policyUpdate.OrganizationId)
-            .Returns(new Organization { Id = policyUpdate.OrganizationId, UseMyItems = true });
-
-        var organizationAbilityCacheService = Substitute.For<IOrganizationAbilityCacheService>();
-        organizationAbilityCacheService.GetOrganizationAbilityAsync(policyUpdate.OrganizationId)
-            .Returns((OrganizationAbility?)null);
-
-        var sut = new OrganizationDataOwnershipPolicyEventHandler(policyRepository, collectionRepository, organizationRepository, organizationAbilityCacheService, [factory]);
-        var policyRequest = new SavePolicyModel(policyUpdate, new OrganizationModelOwnershipPolicyModel(_defaultUserCollectionName));
-
-        // Act
-        await sut.ExecutePostUpsertSideEffectAsync(policyRequest, postUpdatedPolicy, previousPolicyState);
-
-        // Assert - On a cache miss, the organization repository should be consulted as the source of truth
-        await organizationRepository
-            .Received(1)
-            .GetByIdAsync(policyUpdate.OrganizationId);
-
-        await collectionRepository
-            .Received(1)
-            .CreateDefaultCollectionsBulkAsync(
-                policyUpdate.OrganizationId,
-                Arg.Is<IEnumerable<Guid>>(ids => ids.Count() == 3),
-                _defaultUserCollectionName);
     }
 }


### PR DESCRIPTION

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32699

## 📔 Objective

Uses useMyItems flag from cache if available, otherwise if null/miss, falls back to checking on the Organization model
