### PR TITLE
PM-39866 - Enhance seeder to seed archive and deleted ciphers

### DIFF
--- a/test/SeederApi.IntegrationTest/CipherComposerTests.cs
+++ b/test/SeederApi.IntegrationTest/CipherComposerTests.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Seeder.Data.Distributions;
+﻿using Bit.Core.Vault.Entities;
+using Bit.Seeder.Data.Distributions;
 using Bit.Seeder.Data.Enums;
 using Bit.Seeder.Data.Static;
 using Bit.Seeder.Factories;
@@ -107,6 +108,119 @@ public class CipherComposerTests
 
         Assert.Single(history);
         Assert.False(string.IsNullOrEmpty(history[0].Password));
+    }
+
+    [Fact]
+    public void BuildArchivesJson_ProducesExpectedShape()
+    {
+        // Uses a lowercase GUID with hex letters (not just digits) so the assertion actually
+        // exercises ToUpperInvariant() rather than passing regardless of casing.
+        var userId = Guid.Parse("aabbccdd-eeff-1122-3344-5566778899aa");
+        var archivedDate = new DateTime(2026, 1, 2, 3, 4, 5, 678, DateTimeKind.Utc);
+
+        var json = CipherComposer.BuildArchivesJson(userId, archivedDate);
+
+        Assert.Equal(
+            "{\"AABBCCDD-EEFF-1122-3344-5566778899AA\":\"2026-01-02T03:04:05.678Z\"}",
+            json);
+    }
+
+    [Theory]
+    [InlineData(7, 14)]
+    [InlineData(15, 90)]
+    public void DaysAgo_AlwaysWithinRequestedRange(int minDaysAgo, int maxDaysAgo)
+    {
+        var now = DateTime.UtcNow;
+
+        for (var index = 0; index < 200; index++)
+        {
+            var result = CipherComposer.DaysAgo(index, minDaysAgo, maxDaysAgo);
+            var daysAgo = (now - result).TotalDays;
+
+            Assert.True(daysAgo >= minDaysAgo - 0.01 && daysAgo <= maxDaysAgo + 0.01,
+                $"index {index}: expected {minDaysAgo}-{maxDaysAgo} days ago, got {daysAgo:F2}.");
+        }
+    }
+
+    [Fact]
+    public void DaysAgo_ArchivedOnlyRangeNeverOverlapsDeletedRange()
+    {
+        // The 15-90 (archived-only) and 7-14 (deleted) windows must never overlap, so an archived
+        // date is always chronologically before a deleted date for the same index — required for
+        // "both" ciphers where DeletedDate must postdate the Archives timestamp.
+        for (var index = 0; index < 200; index++)
+        {
+            var archivedDate = CipherComposer.DaysAgo(index, 15, 90);
+            var deletedDate = CipherComposer.DaysAgo(index, 7, 14);
+
+            Assert.True(archivedDate < deletedDate,
+                $"index {index}: archivedDate ({archivedDate:o}) must be before deletedDate ({deletedDate:o}).");
+        }
+    }
+
+    [Fact]
+    public void AssignArchiveOrDeleteState_IsBoth_SetsAllFourFields_ArchivedDateBeforeDeletedDate()
+    {
+        var cipher = new Cipher { CreationDate = DateTime.UtcNow };
+        var ownerId = Guid.NewGuid();
+        var selection = new ArchiveDeleteSets(
+            Archived: [3], Both: [3], DeletedOnly: [], ArchivedOrder: [3]);
+
+        CipherComposer.AssignArchiveOrDeleteState(cipher, 3, selection, _ => ownerId);
+
+        Assert.NotNull(cipher.Archives);
+        Assert.NotNull(cipher.DeletedDate);
+        Assert.Equal(cipher.DeletedDate, cipher.RevisionDate);
+        Assert.True(cipher.CreationDate < cipher.DeletedDate);
+        Assert.Contains(ownerId.ToString().ToUpperInvariant(), cipher.Archives);
+    }
+
+    [Fact]
+    public void AssignArchiveOrDeleteState_ArchivedOnly_SetsArchivesButLeavesDeletedDateNull()
+    {
+        var cipher = new Cipher { CreationDate = DateTime.UtcNow };
+        var ownerId = Guid.NewGuid();
+        var selection = new ArchiveDeleteSets(
+            Archived: [3], Both: [], DeletedOnly: [], ArchivedOrder: [3]);
+
+        CipherComposer.AssignArchiveOrDeleteState(cipher, 3, selection, _ => ownerId);
+
+        Assert.NotNull(cipher.Archives);
+        Assert.Null(cipher.DeletedDate);
+        Assert.Equal(cipher.CreationDate, cipher.RevisionDate);
+    }
+
+    [Fact]
+    public void AssignArchiveOrDeleteState_DeletedOnly_SetsDeletedDateButLeavesArchivesNull()
+    {
+        var cipher = new Cipher { CreationDate = DateTime.UtcNow };
+        var selection = new ArchiveDeleteSets(
+            Archived: [], Both: [], DeletedOnly: [3], ArchivedOrder: []);
+
+        CipherComposer.AssignArchiveOrDeleteState(
+            cipher, 3, selection, _ => throw new InvalidOperationException("must not be called"));
+
+        Assert.Null(cipher.Archives);
+        Assert.NotNull(cipher.DeletedDate);
+        Assert.Equal(cipher.DeletedDate, cipher.RevisionDate);
+    }
+
+    [Fact]
+    public void AssignArchiveOrDeleteState_UntouchedIndex_MutatesNothing()
+    {
+        var originalCreationDate = DateTime.UtcNow;
+        var cipher = new Cipher { CreationDate = originalCreationDate };
+        var originalRevisionDate = cipher.RevisionDate;
+        var selection = new ArchiveDeleteSets(
+            Archived: [], Both: [], DeletedOnly: [], ArchivedOrder: []);
+
+        CipherComposer.AssignArchiveOrDeleteState(
+            cipher, 3, selection, _ => throw new InvalidOperationException("must not be called"));
+
+        Assert.Equal(originalCreationDate, cipher.CreationDate);
+        Assert.Equal(originalRevisionDate, cipher.RevisionDate);
+        Assert.Null(cipher.Archives);
+        Assert.Null(cipher.DeletedDate);
     }
 
     private static PasswordStrength ClassifyStrength(string password)

--- a/test/SeederApi.IntegrationTest/DensityModel/ArchiveAndDeleteRateTests.cs
+++ b/test/SeederApi.IntegrationTest/DensityModel/ArchiveAndDeleteRateTests.cs
@@ -1,0 +1,275 @@
+﻿using Bit.Seeder.Data.Distributions;
+using Xunit;
+
+namespace Bit.SeederApi.IntegrationTest.DensityModel;
+
+/// <summary>
+/// Validates the archived/deleted/"both" target math (shared by GeneratePersonalCiphersStep and
+/// GenerateCiphersStep) and the index-selection/round-robin-attribution behavior in
+/// <see cref="ArchiveDeleteDistribution"/> — the actual production selection algorithm, not a
+/// reimplementation of it.
+/// </summary>
+public sealed class ArchiveAndDeleteRateTests
+{
+    [Fact]
+    public void ArchivedTarget_RespectsRate_BeforeCeiling()
+    {
+        var (archivedTarget, _, _, _) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 500, archivedRate: 0.06, deletedRate: 0, overlapRate: 0, maxArchived: 50, maxDeleted: 25);
+
+        Assert.Equal(30, archivedTarget);
+    }
+
+    [Fact]
+    public void ArchivedTarget_CeilingWins_WhenRateExceedsCap()
+    {
+        var (archivedTarget, _, _, _) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 10_000, archivedRate: 0.06, deletedRate: 0, overlapRate: 0, maxArchived: 50, maxDeleted: 25);
+
+        Assert.Equal(50, archivedTarget);
+    }
+
+    [Fact]
+    public void DeletedTarget_CeilingWins_WhenRateExceedsCap()
+    {
+        var (_, deletedTarget, _, _) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 10_000, archivedRate: 0, deletedRate: 0.035, overlapRate: 0, maxArchived: 50, maxDeleted: 25);
+
+        Assert.Equal(25, deletedTarget);
+    }
+
+    /// <summary>
+    /// Regression test: bothTarget must clamp against MaxDeletedCiphers, not just archivedTarget.
+    /// </summary>
+    [Fact]
+    public void BothTarget_NeverExceedsMaxDeletedCiphers_EvenWhenArchivedCeilingIsHigher()
+    {
+        var (archivedTarget, deletedTarget, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 10_000, archivedRate: 0.06, deletedRate: 0.035, overlapRate: 0.02, maxArchived: 50, maxDeleted: 25);
+
+        Assert.Equal(50, archivedTarget);
+        Assert.Equal(25, deletedTarget);
+        Assert.Equal(25, bothTarget);
+        Assert.Equal(0, deletedOnlyTarget);
+
+        var totalDeleted = bothTarget + deletedOnlyTarget;
+        Assert.Equal(25, totalDeleted);
+        Assert.True(totalDeleted <= 25, $"Total deleted ({totalDeleted}) must not exceed MaxDeletedCiphers (25).");
+    }
+
+    [Fact]
+    public void BothTarget_NeverExceedsArchivedTarget()
+    {
+        // Overlap rate alone would compute 100, but archivedTarget caps it at 40.
+        var (archivedTarget, _, bothTarget, _) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 2_000, archivedRate: 0.02, deletedRate: 0, overlapRate: 0.05, maxArchived: 50, maxDeleted: 25);
+
+        Assert.Equal(40, archivedTarget);
+        Assert.True(bothTarget <= archivedTarget);
+    }
+
+    [Fact]
+    public void ZeroRates_ProduceZeroTargets()
+    {
+        var (archivedTarget, deletedTarget, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 10_000, archivedRate: 0, deletedRate: 0, overlapRate: 0, maxArchived: 50, maxDeleted: 25);
+
+        Assert.Equal(0, archivedTarget);
+        Assert.Equal(0, deletedTarget);
+        Assert.Equal(0, bothTarget);
+        Assert.Equal(0, deletedOnlyTarget);
+    }
+
+    [Fact]
+    public void DeletedOrgTarget_ComputedIndependently_FromOwnPoolAndOwnCeiling()
+    {
+        // Mirrors GenerateCiphersStep's org-only delete sizing: independent of the personal pool.
+        const int orgCipherCount = 10_000;
+        const double deletedRate = 0.035;
+        const int maxDeleted = 25;
+
+        var deletedOrgTarget = deletedRate > 0
+            ? Math.Min((int)(orgCipherCount * deletedRate), maxDeleted)
+            : 0;
+
+        Assert.Equal(25, deletedOrgTarget);
+
+        var selection = ArchiveDeleteDistribution.Select(orgCipherCount, archivedTarget: 0, bothTarget: 0, deletedOnlyTarget: deletedOrgTarget);
+
+        Assert.Equal(maxDeleted, selection.DeletedOnly.Count);
+    }
+
+    [Fact]
+    public void OrgPool_ArchivedTarget_ComputedIndependently_FromPersonalPoolAndOwnCeiling()
+    {
+        // GenerateCiphersStep now archives org ciphers too (for a round-robin-selected org member,
+        // per DensityProfile.ArchivedCipherRate's doc comment) using this same formula against the
+        // org-cipher count instead of the personal expectedTotal, with its own independent cap.
+        var (archivedTarget, deletedTarget, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 5_000, archivedRate: 0.06, deletedRate: 0.03, overlapRate: 0.02, maxArchived: 50, maxDeleted: 25);
+
+        Assert.Equal(50, archivedTarget);
+        Assert.Equal(25, deletedTarget);
+        Assert.Equal(25, bothTarget);
+        Assert.Equal(0, deletedOnlyTarget);
+    }
+
+    [Theory]
+    [InlineData(0, 0.03, 0)]   // archived rate 0 while delete rate is set
+    [InlineData(0.06, 0, 0)]  // delete rate 0 while archived rate is set
+    [InlineData(0.06, 0.03, 0)] // overlap rate 0 while the other two are set
+    public void Select_GuardsAgainstZeroTarget_NoException(double archivedRate, double deletedRate, double overlapRate)
+    {
+        var (archivedTarget, _, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 1_000, archivedRate: archivedRate, deletedRate: deletedRate, overlapRate: overlapRate,
+            maxArchived: 50, maxDeleted: 25);
+
+        // The point of this test: this call must not throw.
+        ArchiveDeleteDistribution.Select(1_000, archivedTarget, bothTarget, deletedOnlyTarget);
+    }
+
+    [Fact]
+    public void Select_IsBoth_ImpliesIsArchived_ForAllSelectedIndices()
+    {
+        const int total = 10_000;
+        var (archivedTarget, _, bothTarget, _) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: total, archivedRate: 0.06, deletedRate: 0.035, overlapRate: 0.02, maxArchived: 50, maxDeleted: 25);
+
+        var selection = ArchiveDeleteDistribution.Select(total, archivedTarget, bothTarget, deletedOnlyTarget: 0);
+
+        Assert.True(selection.Both.IsSubsetOf(selection.Archived));
+    }
+
+    [Fact]
+    public void Select_DeletedOnly_NeverOverlapsArchived()
+    {
+        const int total = 10_000;
+        var (archivedTarget, _, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: total, archivedRate: 0.06, deletedRate: 0.035, overlapRate: 0.02, maxArchived: 50, maxDeleted: 25);
+
+        var selection = ArchiveDeleteDistribution.Select(total, archivedTarget, bothTarget, deletedOnlyTarget);
+
+        Assert.Empty(selection.Archived.Intersect(selection.DeletedOnly));
+    }
+
+    /// <summary>
+    /// Regression test: the old stride formula overshot the target when poolSize wasn't an exact
+    /// multiple of it.
+    /// </summary>
+    [Fact]
+    public void Select_ProducesExactArchivedCount_EvenWhenPoolSizeDoesNotDivideEvenly()
+    {
+        var selection = ArchiveDeleteDistribution.Select(poolSize: 2_909, archivedTarget: 50, bothTarget: 25, deletedOnlyTarget: 0);
+
+        Assert.Equal(50, selection.Archived.Count);
+        Assert.Equal(25, selection.Both.Count);
+    }
+
+    /// <summary>
+    /// Regression test: the old stride algorithm could starve deleted-only ciphers when their
+    /// candidate indices collided with already-claimed archived indices.
+    /// </summary>
+    [Fact]
+    public void Select_ProducesExactDeletedOnlyCount_EvenWhenItWouldCollideWithArchivedStride()
+    {
+        var selection = ArchiveDeleteDistribution.Select(poolSize: 200, archivedTarget: 8, bothTarget: 2, deletedOnlyTarget: 2);
+
+        Assert.Equal(8, selection.Archived.Count);
+        Assert.Equal(2, selection.Both.Count);
+        Assert.Equal(2, selection.DeletedOnly.Count);
+        Assert.Empty(selection.Archived.Intersect(selection.DeletedOnly));
+    }
+
+    /// <summary>
+    /// Regression test: ArchivedOrder[0] must never land in Both when there's an archive-only
+    /// position available — otherwise a client that hides deleted items from Archive would show
+    /// nothing for whichever user is pointed at it.
+    /// </summary>
+    [Fact]
+    public void Select_ArchivedOrderFirst_IsNeverBoth_WhenNotEveryArchivedCipherIsAlsoDeleted()
+    {
+        var selection = ArchiveDeleteDistribution.Select(poolSize: 2_909, archivedTarget: 50, bothTarget: 25, deletedOnlyTarget: 0);
+
+        Assert.DoesNotContain(selection.ArchivedOrder[0], selection.Both);
+    }
+
+    [Fact]
+    public void Select_ArchivedOrderFirst_CanBeBoth_WhenEveryArchivedCipherIsAlsoDeleted()
+    {
+        // No archive-only ciphers exist at all in this configuration — there's nothing to reserve.
+        var selection = ArchiveDeleteDistribution.Select(poolSize: 1_000, archivedTarget: 25, bothTarget: 25, deletedOnlyTarget: 0);
+
+        Assert.Contains(selection.ArchivedOrder[0], selection.Both);
+        Assert.Equal(25, selection.Both.Count);
+    }
+
+    [Fact]
+    public void EvenlySpacedIndices_ReturnsDistinctAscendingIndices()
+    {
+        var indices = ArchiveDeleteDistribution.EvenlySpacedIndices(poolSize: 17, target: 5);
+
+        Assert.Equal(5, indices.Count);
+        Assert.Equal(indices.Distinct().Count(), indices.Count);
+        Assert.Equal(indices.OrderBy(i => i), indices);
+        Assert.All(indices, i => Assert.InRange(i, 0, 16));
+    }
+
+    [Fact]
+    public void EvenlySpacedIndices_ClampsTarget_WhenTargetExceedsPoolSize()
+    {
+        var indices = ArchiveDeleteDistribution.EvenlySpacedIndices(poolSize: 5, target: 50);
+
+        Assert.Equal(5, indices.Count);
+        Assert.Equal([0, 1, 2, 3, 4], indices);
+    }
+
+    /// <summary>
+    /// Regression test: index-based modulo attribution collapses to gcd(stride, userCount) distinct
+    /// users; assignment-count attribution must spread evenly regardless.
+    /// </summary>
+    [Fact]
+    public void AssignRoundRobinUserPositions_SpreadsAcrossAllUsers_RegardlessOfGcdWithUserCount()
+    {
+        var selection = ArchiveDeleteDistribution.Select(poolSize: 5_000, archivedTarget: 50, bothTarget: 25, deletedOnlyTarget: 0);
+
+        var positions = ArchiveDeleteDistribution.AssignRoundRobinUserPositions(selection.ArchivedOrder, userCount: 250);
+
+        Assert.Equal(50, positions.Values.Distinct().Count());
+    }
+
+    [Fact]
+    public void AssignRoundRobinUserPositions_FirstArchivedCipher_AlwaysGoesToPositionZero()
+    {
+        // CreateOwnerStep always adds the Owner to UserDigests first, so userDigests[0] is the
+        // Owner — position 0 in this map is therefore always the Owner's slot.
+        var selection = ArchiveDeleteDistribution.Select(poolSize: 200, archivedTarget: 8, bothTarget: 2, deletedOnlyTarget: 0);
+
+        var positions = ArchiveDeleteDistribution.AssignRoundRobinUserPositions(selection.ArchivedOrder, userCount: 7);
+
+        Assert.Equal(0, positions[selection.ArchivedOrder[0]]);
+    }
+
+    [Fact]
+    public void AssignRoundRobinUserPositions_WrapsAround_WhenMoreArchivedThanUsers()
+    {
+        var selection = ArchiveDeleteDistribution.Select(poolSize: 100, archivedTarget: 10, bothTarget: 0, deletedOnlyTarget: 0);
+
+        var positions = ArchiveDeleteDistribution.AssignRoundRobinUserPositions(selection.ArchivedOrder, userCount: 3);
+
+        Assert.All(positions.Values, p => Assert.InRange(p, 0, 2));
+        Assert.Equal(3, positions.Values.Distinct().Count());
+    }
+
+    [Fact]
+    public void ComputeTargets_CanArchiveFalse_ZeroesArchivedAndBothTargets_ButNotDeletedOnlyTarget()
+    {
+        var (archivedTarget, deletedTarget, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
+            poolSize: 10_000, archivedRate: 0.06, deletedRate: 0.035, overlapRate: 0.02, maxArchived: 50, maxDeleted: 25,
+            canArchive: false);
+
+        Assert.Equal(0, archivedTarget);
+        Assert.Equal(0, bothTarget);
+        Assert.Equal(25, deletedTarget);
+        Assert.Equal(25, deletedOnlyTarget);
+    }
+}

--- a/test/SeederApi.IntegrationTest/DensityModel/ArchiveAndDeleteRateTests.cs
+++ b/test/SeederApi.IntegrationTest/DensityModel/ArchiveAndDeleteRateTests.cs
@@ -88,9 +88,7 @@ public sealed class ArchiveAndDeleteRateTests
         const double deletedRate = 0.035;
         const int maxDeleted = 25;
 
-        var deletedOrgTarget = deletedRate > 0
-            ? Math.Min((int)(orgCipherCount * deletedRate), maxDeleted)
-            : 0;
+        var deletedOrgTarget = Math.Min((int)(orgCipherCount * deletedRate), maxDeleted);
 
         Assert.Equal(25, deletedOrgTarget);
 

--- a/util/Seeder/CLAUDE.md
+++ b/util/Seeder/CLAUDE.md
@@ -98,6 +98,10 @@ Steps accept an optional `DensityProfile` that controls relationship patterns be
 
 **Verification**: SQL queries for validating density algorithms are in `Seeds/docs/verification.md`.
 
+## Data/ File Organization
+
+New files under `Data/` belong in the matching subfolder (`Distributions/`, `Enums/`, `Generators/`, `Static/`) — never loose at the top level. See `Data/README.md` for what each subfolder holds. If a new file's concern doesn't fit an existing subfolder, that's a signal to create one, not to drop it loose.
+
 ## The Recipe Contract
 
 Recipes follow strict rules:

--- a/util/Seeder/Data/Distributions/ArchiveDeleteDistribution.cs
+++ b/util/Seeder/Data/Distributions/ArchiveDeleteDistribution.cs
@@ -1,0 +1,105 @@
+﻿namespace Bit.Seeder.Data.Distributions;
+
+/// <summary>
+/// The archived, both-archived-and-deleted, and deleted-only cipher index sets for a pool.
+/// <see cref="Both"/> is a subset of <see cref="Archived"/>. <see cref="DeletedOnly"/> is disjoint
+/// from <see cref="Archived"/>. <see cref="ArchivedOrder"/> holds the same indices as
+/// <see cref="Archived"/>, ascending, for callers that need a stable position rather than just
+/// membership.
+/// </summary>
+internal readonly record struct ArchiveDeleteSets(
+    HashSet<int> Archived, HashSet<int> Both, HashSet<int> DeletedOnly, IReadOnlyList<int> ArchivedOrder);
+
+/// <summary>
+/// Computes archived/deleted lifecycle-state target counts and selects which cipher indices receive them.
+/// </summary>
+internal static class ArchiveDeleteDistribution
+{
+    /// <summary>
+    /// Computes archived/deleted/both/delete-only target counts from density rates and caps.
+    /// <paramref name="canArchive"/> gates only the archived (and therefore both) target to 0 — used by
+    /// org ciphers, which need a user to attribute archiving to; personal ciphers always have one
+    /// (their own owner), so it defaults to true.
+    /// </summary>
+    internal static (int ArchivedTarget, int DeletedTarget, int BothTarget, int DeletedOnlyTarget) ComputeTargets(
+        int poolSize, double archivedRate, double deletedRate, double overlapRate, int maxArchived, int maxDeleted, bool canArchive = true)
+    {
+        var archivedTarget = canArchive && archivedRate > 0
+            ? Math.Min((int)(poolSize * archivedRate), maxArchived)
+            : 0;
+        var deletedTarget = deletedRate > 0
+            ? Math.Min((int)(poolSize * deletedRate), maxDeleted)
+            : 0;
+        var bothTarget = overlapRate > 0
+            ? Math.Min(Math.Min((int)(poolSize * overlapRate), archivedTarget), maxDeleted)
+            : 0;
+        var deletedOnlyTarget = Math.Max(0, deletedTarget - bothTarget);
+
+        return (archivedTarget, deletedTarget, bothTarget, deletedOnlyTarget);
+    }
+
+    /// <summary>
+    /// Selects the archived/both/deleted-only index sets for a pool of <paramref name="poolSize"/>
+    /// ciphers. Deleted-only positions are drawn from ciphers NOT selected as archived, so they can
+    /// never collide with (or be starved by) the archived selection. Each set has exactly
+    /// min(target, remaining pool) members. <c>ArchivedOrder[0]</c> is kept out of
+    /// <see cref="ArchiveDeleteSets.Both"/> whenever there's room to (bothTarget &lt; archived.Count),
+    /// so it's always safe to point a specific user (e.g. the org Owner) at it for manual QA.
+    /// </summary>
+    internal static ArchiveDeleteSets Select(int poolSize, int archivedTarget, int bothTarget, int deletedOnlyTarget)
+    {
+        var archived = EvenlySpacedIndices(poolSize, archivedTarget);
+        var archivedSet = new HashSet<int>(archived);
+        var bothCandidates = bothTarget < archived.Count ? archived.Skip(1).ToList() : archived;
+        var bothPositions = EvenlySpacedIndices(bothCandidates.Count, bothTarget);
+        var bothSet = new HashSet<int>(bothPositions.Select(position => bothCandidates[position]));
+        var remaining = new List<int>(poolSize - archivedSet.Count);
+        for (var i = 0; i < poolSize; i++)
+        {
+            if (!archivedSet.Contains(i))
+            {
+                remaining.Add(i);
+            }
+        }
+        var deletedOnlyPositions = EvenlySpacedIndices(remaining.Count, deletedOnlyTarget);
+        var deletedOnlySet = new HashSet<int>(deletedOnlyPositions.Select(position => remaining[position]));
+        return new ArchiveDeleteSets(archivedSet, bothSet, deletedOnlySet, archived);
+    }
+
+    /// <summary>
+    /// Maps each archived cipher index to a round-robin position in [0, userCount), one user per
+    /// cipher, wrapping back to 0 after userCount assignments. Cycling by assignment count (not by
+    /// the cipher index itself) guarantees every user slot is visited evenly.
+    /// </summary>
+    internal static Dictionary<int, int> AssignRoundRobinUserPositions(IReadOnlyList<int> archivedIndicesInOrder, int userCount)
+    {
+        var assignments = new Dictionary<int, int>(archivedIndicesInOrder.Count);
+        for (var k = 0; k < archivedIndicesInOrder.Count; k++)
+        {
+            assignments[archivedIndicesInOrder[k]] = userCount > 0 ? k % userCount : 0;
+        }
+
+        return assignments;
+    }
+
+    /// <summary>
+    /// Returns exactly min(target, poolSize) distinct, ascending indices in [0, poolSize), spread
+    /// as evenly as possible via <c>k * poolSize / target</c> — the standard "distribute k items
+    /// across n slots" formula. Guaranteed strictly increasing (no duplicates) whenever
+    /// target &lt;= poolSize.
+    /// </summary>
+    internal static List<int> EvenlySpacedIndices(int poolSize, int target)
+    {
+        if (target <= 0 || poolSize <= 0)
+        {
+            return [];
+        }
+        target = Math.Min(target, poolSize);
+        var result = new List<int>(target);
+        for (var k = 0; k < target; k++)
+        {
+            result.Add((int)((long)k * poolSize / target));
+        }
+        return result;
+    }
+}

--- a/util/Seeder/Data/README.md
+++ b/util/Seeder/Data/README.md
@@ -19,7 +19,8 @@ Seeded, deterministic data generation for cipher content. Orchestrated by `Gener
 
 ## Distributions
 
-Percentage-based deterministic selection via `Distribution<T>.Select(index, total)`.
+Percentage-based deterministic selection — `Distribution<T>.Select(index, total)` for typed buckets, or
+index-set selection like `ArchiveDeleteDistribution.Select(...)` for lifecycle-state assignment.
 
 ## Current Capabilities
 

--- a/util/Seeder/Factories/CipherComposer.cs
+++ b/util/Seeder/Factories/CipherComposer.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Vault.Entities;
+﻿using System.Globalization;
+using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Enums;
 using Bit.Seeder.Data;
 using Bit.Seeder.Data.Distributions;
@@ -215,6 +216,45 @@ internal static class CipherComposer
     }
 
     /// <summary>
+    /// Applies archived/deleted lifecycle state to a composed cipher per its membership in
+    /// <paramref name="selection"/>. No-op if <paramref name="index"/> is in none of the sets.
+    /// <paramref name="resolveArchiveOwner"/> is invoked only when the cipher is archived (alone or
+    /// both), so callers can defer lookups (e.g. a dictionary keyed only by archived indices) that
+    /// would otherwise be unsafe to evaluate eagerly.
+    /// </summary>
+    internal static void AssignArchiveOrDeleteState(Cipher cipher, int index, ArchiveDeleteSets selection, Func<int, Guid> resolveArchiveOwner)
+    {
+        var isBoth = selection.Both.Contains(index);
+        var isArchived = isBoth || selection.Archived.Contains(index);
+
+        // CreationDate must predate ArchivedDate/DeletedDate — Compose stamps it to UtcNow, which is
+        // otherwise later than these backdated values.
+        if (isBoth)
+        {
+            var archivedDate = DaysAgo(index, 15, 90);
+            var deletedDate = DaysAgo(index, 7, 14);
+            cipher.CreationDate = archivedDate;
+            cipher.Archives = BuildArchivesJson(resolveArchiveOwner(index), archivedDate);
+            cipher.DeletedDate = deletedDate;
+            cipher.RevisionDate = deletedDate;
+        }
+        else if (isArchived)
+        {
+            var archivedDate = DaysAgo(index, 15, 90);
+            cipher.CreationDate = archivedDate;
+            cipher.Archives = BuildArchivesJson(resolveArchiveOwner(index), archivedDate);
+            cipher.RevisionDate = archivedDate;
+        }
+        else if (selection.DeletedOnly.Contains(index))
+        {
+            var deletedDate = DaysAgo(index, 7, 14);
+            cipher.CreationDate = deletedDate;
+            cipher.DeletedDate = deletedDate;
+            cipher.RevisionDate = deletedDate;
+        }
+    }
+
+    /// <summary>
     /// Builds the Folders JSON column value from a set of (userId, folderId) pairs.
     /// Produces <c>{"USERID1":"FOLDERID1","USERID2":"FOLDERID2"}</c> with uppercase GUIDs.
     /// </summary>
@@ -234,5 +274,27 @@ internal static class CipherComposer
         var entries = userIds.Select(id =>
             $"\"{id.ToString().ToUpperInvariant()}\":true");
         return $"{{{string.Join(",", entries)}}}";
+    }
+
+    /// <summary>
+    /// Builds the Archives JSON column value for a single user. Mirrors the JSON_MODIFY shape
+    /// produced by Cipher_Archive.sql. Produces <c>{"USERID":"yyyy-MM-ddTHH:mm:ss.fffZ"}</c>
+    /// with an uppercase GUID key.
+    /// </summary>
+    internal static string BuildArchivesJson(Guid userId, DateTime archivedDateUtc)
+    {
+        var timestamp = archivedDateUtc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+        return $"{{\"{userId.ToString().ToUpperInvariant()}\":\"{timestamp}\"}}";
+    }
+
+    /// <summary>
+    /// Deterministic "N days ago" timestamp within [minDaysAgo, maxDaysAgo], varied by index.
+    /// Mirrors the existing BuildPasswordHistory precedent of AddDays(-7 * k) — no RNG needed.
+    /// </summary>
+    internal static DateTime DaysAgo(int index, int minDaysAgo, int maxDaysAgo)
+    {
+        var range = maxDaysAgo - minDaysAgo + 1;
+        var days = minDaysAgo + (index % range);
+        return DateTime.UtcNow.AddDays(-days);
     }
 }

--- a/util/Seeder/Models/SeedPresetDensity.cs
+++ b/util/Seeder/Models/SeedPresetDensity.cs
@@ -122,4 +122,14 @@ internal record SeedPresetCipherAssignment
     public double? MultiCollectionRate { get; init; }
 
     public int? MaxCollectionsPerCipher { get; init; }
+
+    public double? ArchivedRate { get; init; }
+
+    public double? DeletedRate { get; init; }
+
+    public double? ArchivedAndDeletedOverlapRate { get; init; }
+
+    public int? MaxArchivedCiphers { get; init; }
+
+    public int? MaxDeletedCiphers { get; init; }
 }

--- a/util/Seeder/Options/DensityProfile.cs
+++ b/util/Seeder/Options/DensityProfile.cs
@@ -105,4 +105,33 @@ public class DensityProfile
     /// Folder count distribution override. When null, uses FolderCountDistributions.Realistic.
     /// </summary>
     public Distribution<(int Min, int Max)>? FolderDistribution { get; init; }
+
+    /// <summary>
+    /// Fraction of ciphers that get an archived state.
+    /// Applies independently to both the personal-cipher pool and the org-cipher pool — each pool
+    /// enforces this rate against its own size and its own MaxArchivedCiphers cap.
+    /// </summary>
+    public double ArchivedCipherRate { get; init; }
+
+    /// <summary>
+    /// Fraction of personal-vault and org ciphers that get DeletedDate set.
+    /// Applies independently to both ownership types, each against its own pool size and cap.
+    /// </summary>
+    public double DeletedCipherRate { get; init; }
+
+    /// <summary>
+    /// Fraction of the eligible cipher pool (personal or org, computed independently per pool)
+    /// deliberately made both archived and deleted.
+    /// </summary>
+    public double ArchivedAndDeletedOverlapRate { get; init; }
+
+    /// <summary>
+    /// Absolute cap on archived ciphers produced per pool (personal, org) in a single seed run.
+    /// </summary>
+    public int MaxArchivedCiphers { get; init; } = 50;
+
+    /// <summary>
+    /// Absolute cap on deleted ciphers produced per pool (personal, org) in a single seed run.
+    /// </summary>
+    public int MaxDeletedCiphers { get; init; } = 25;
 }

--- a/util/Seeder/Pipeline/PresetLoader.cs
+++ b/util/Seeder/Pipeline/PresetLoader.cs
@@ -240,6 +240,11 @@ internal static class PresetLoader
             CipherTypeDistribution = ParseCipherTypes(preset.CipherTypes),
             PersonalCipherDistribution = ParsePersonalCipherDistribution(preset.PersonalCiphers?.Shape),
             FolderDistribution = ParseFolderDistribution(preset.Folders?.Shape),
+            ArchivedCipherRate = preset.CipherAssignment?.ArchivedRate ?? 0,
+            DeletedCipherRate = preset.CipherAssignment?.DeletedRate ?? 0,
+            ArchivedAndDeletedOverlapRate = preset.CipherAssignment?.ArchivedAndDeletedOverlapRate ?? 0,
+            MaxArchivedCiphers = preset.CipherAssignment?.MaxArchivedCiphers ?? 50,
+            MaxDeletedCiphers = preset.CipherAssignment?.MaxDeletedCiphers ?? 25,
         };
     }
 

--- a/util/Seeder/Scenes/LoginCipherScene.cs
+++ b/util/Seeder/Scenes/LoginCipherScene.cs
@@ -30,6 +30,7 @@ public abstract class LoginCipherScene<TRequest>(IManglerService manglerService)
         public string? Notes { get; set; }
         public bool Reprompt { get; set; }
         public bool Deleted { get; set; }
+        public bool Archived { get; set; }
         public bool Favorite { get; set; }
         public Guid? FolderId { get; set; }
         public IEnumerable<FieldRequest>? Fields { get; set; }
@@ -100,6 +101,10 @@ public abstract class LoginCipherScene<TRequest>(IManglerService manglerService)
         if (request.Deleted)
         {
             cipher.DeletedDate = DateTime.UtcNow.AddDays(-1);
+        }
+        if (request.Archived)
+        {
+            cipher.Archives = CipherComposer.BuildArchivesJson(request.UserId, DateTime.UtcNow.AddDays(-1));
         }
         if (request.Favorite)
         {

--- a/util/Seeder/Seeds/docs/presets.md
+++ b/util/Seeder/Seeds/docs/presets.md
@@ -73,6 +73,7 @@ dotnet run -- preset --name scale.{name} --mangle
 - **Cipher types**: Most use `realistic` (60% Login, 15% SecureNote, 12% Card, 10% Identity, 3% SSHKey). Umbrella Corp uses `documentationHeavy` (40/40 Login/SecureNote). Tyrell Corp uses `developerFocused` (50% Login, 20% SSHKey).
 - **Personal ciphers**: Sterling Cooper and Wayne Enterprises use `realistic` distribution. Weyland-Yutani uses `lightUsage`. Use `heavyUsage` only for small/mid orgs — at XL scale it produces 300K+ ciphers and will timeout.
 - **Folders**: Wayne Enterprises uses `enterprise` folder distribution. Weyland-Yutani uses `minimal`.
+- **Archive & delete**: All nine presets set `cipherAssignment.deletedRate` (2-5%, capped at 25) and `archivedRate` (4-8%, capped at 50), tuned to each org's orphan-rate/permission story — tidier orgs (Central Perk) trend lower, locked-down/hierarchical orgs (Bluth Company, Tyrell Corp) and Initech's high-orphan mega-dump trend higher. Both rates apply to org ciphers (archived-for a round-robin-selected org member); the three presets with personal ciphers enabled (Sterling Cooper, Wayne Enterprises, Weyland-Yutani) apply the same rates a second time against their personal-cipher pool, so those three seed archived/deleted items in both places.
 
 For per-preset expected values and verification queries, see [verification.md](verification.md).
 

--- a/util/Seeder/Seeds/docs/verification.md
+++ b/util/Seeder/Seeds/docs/verification.md
@@ -198,6 +198,63 @@ FROM (
 ) T;
 ```
 
+### Q9: Deleted Org Ciphers
+
+Verifies `cipherAssignment.deletedRate` and `maxDeletedCiphers`. Applies to org ciphers in every Scale preset.
+
+```sql
+DECLARE @OrgId UNIQUEIDENTIFIER = 'PASTE_ORG_ID_HERE';
+
+SELECT
+    COUNT(*) AS TotalOrgCiphers,
+    SUM(CASE WHEN DeletedDate IS NOT NULL THEN 1 ELSE 0 END) AS DeletedCiphers
+FROM [dbo].[Cipher] WITH (NOLOCK)
+WHERE OrganizationId = @OrgId;
+```
+
+### Q10: Archived & Deleted Personal Ciphers
+
+Verifies `cipherAssignment.archivedRate`, `deletedRate`, and `archivedAndDeletedOverlapRate` against the
+personal (non-org) cipher pool — see Q11 for the same rates verified against the org pool, which is archived
+independently. Only applies to presets with `density.personalCiphers` set (Sterling Cooper, Wayne Enterprises,
+Weyland-Yutani). Personal ciphers aren't tied to `OrganizationId`, so this joins through `OrganizationUser` to
+scope to the seeded org's users. Follows the same JSON-path pattern used to compute `ArchivedDate` in
+`dbo.CipherDetails`.
+
+```sql
+DECLARE @OrgId UNIQUEIDENTIFIER = 'PASTE_ORG_ID_HERE';
+
+SELECT
+    COUNT(*) AS TotalPersonalCiphers,
+    SUM(CASE WHEN JSON_VALUE(C.[Archives], CONCAT('$."', UPPER(CONVERT(VARCHAR(36), C.UserId)), '"')) IS NOT NULL THEN 1 ELSE 0 END) AS ArchivedCiphers,
+    SUM(CASE WHEN C.DeletedDate IS NOT NULL THEN 1 ELSE 0 END) AS DeletedCiphers,
+    SUM(CASE WHEN C.DeletedDate IS NOT NULL AND JSON_VALUE(C.[Archives], CONCAT('$."', UPPER(CONVERT(VARCHAR(36), C.UserId)), '"')) IS NOT NULL THEN 1 ELSE 0 END) AS BothArchivedAndDeleted
+FROM [dbo].[Cipher] C WITH (NOLOCK)
+WHERE C.OrganizationId IS NULL
+    AND C.UserId IN (
+        SELECT OU.UserId FROM [dbo].[OrganizationUser] OU WITH (NOLOCK) WHERE OU.OrganizationId = @OrgId
+    );
+```
+
+### Q11: Archived & Deleted Org Ciphers
+
+Verifies `cipherAssignment.archivedRate`/`deletedRate`/`archivedAndDeletedOverlapRate` against org ciphers.
+Applies to every Scale preset — org ciphers are archived independently of the personal pool, "for" a
+round-robin-selected org member (see `GenerateCiphersStep`), so an existence check on `Archives` is enough
+(no need to scope to a specific user like Q10 does for personal ciphers).
+
+```sql
+DECLARE @OrgId UNIQUEIDENTIFIER = 'PASTE_ORG_ID_HERE';
+
+SELECT
+    COUNT(*) AS TotalOrgCiphers,
+    SUM(CASE WHEN Archives IS NOT NULL THEN 1 ELSE 0 END) AS ArchivedCiphers,
+    SUM(CASE WHEN DeletedDate IS NOT NULL THEN 1 ELSE 0 END) AS DeletedCiphers,
+    SUM(CASE WHEN DeletedDate IS NOT NULL AND Archives IS NOT NULL THEN 1 ELSE 0 END) AS BothArchivedAndDeleted
+FROM [dbo].[Cipher] WITH (NOLOCK)
+WHERE OrganizationId = @OrgId;
+```
+
 ---
 
 ## Scale Preset Expected Values
@@ -213,6 +270,8 @@ FROM (
 | Direct access ratio   | 0.8 — ~80% of access paths are direct CollectionUser.                         |
 | Collections per user  | Uniform 1-3. Min=1, Max=3, Avg=2.                                             |
 | Multi-collection rate | 20% of 200 non-orphan ciphers in 2 collections. ~40 multi-collection ciphers. |
+| Archived org ciphers  | ~8 of 200 (4% rate, under the 50 cap).                                       |
+| Deleted org ciphers   | ~4 of 200 (2% rate, under the 25 cap). ~2 of those are also archived (1% overlap); ~2 are delete-only. |
 
 ### 2. Planet Express (SM)
 
@@ -225,6 +284,8 @@ FROM (
 | Direct access ratio   | 0.7 — ~70% of access paths are direct CollectionUser.                           |
 | Collections per user  | PowerLaw 1-5 (skew 0.3). First users get up to 5, most get 1-2. CV > 0.3.       |
 | Multi-collection rate | 15% of ~713 non-orphan ciphers in 2 collections. ~107 multi-collection ciphers. |
+| Archived org ciphers  | ~45 of 750 (6% rate, under the 50 cap).                                         |
+| Deleted org ciphers   | ~22 of 750 (3% rate, under the 25 cap). ~15 of those are also archived (2% overlap); ~7 are delete-only. |
 
 ### 3. Bluth Company (SM)
 
@@ -237,6 +298,8 @@ FROM (
 | Direct access ratio   | 0.6 — ~60% of access paths are direct CollectionUser.                          |
 | Collections per user  | Uniform 1-3. Min=1, Max=3, Avg=2.                                              |
 | Multi-collection rate | 10% of ~425 non-orphan ciphers in 2 collections. ~42 multi-collection ciphers. |
+| Archived org ciphers  | ~40 of 500 (8% rate, under the 50 cap).                                        |
+| Deleted org ciphers   | ~20 of 500 (4% rate, under the 25 cap). ~15 of those are also archived (3% overlap); ~5 are delete-only. |
 
 ### 4. Sterling Cooper (MD)
 
@@ -250,6 +313,10 @@ FROM (
 | Empty group rate      | ~26% — ~13 of 50 groups have 0 members due to power-law tail truncation.    |
 | Collections per user  | PowerLaw 1-10 (skew 0.5). First users get up to 10, most get 1-2. CV > 0.5. |
 | Multi-collection rate | 20% of ~4,600 non-orphan ciphers in 2-3 collections. Max 3 per cipher.      |
+| Archived org ciphers  | 50 of 5,000 (6% rate = 300, clamped to the 50 cap).                         |
+| Deleted org ciphers   | 25 of 5,000 (3% rate = 150, clamped to the 25 cap). All 25 are also archived (2% overlap = 100, clamped) — 0 are delete-only. |
+| Archived personal ciphers | 50 of ~3,638 personal ciphers (6% rate = ~218, clamped to the 50 cap).  |
+| Deleted personal ciphers  | 25 of ~3,638 (3% rate clamped to 25). All 25 are also archived (2% overlap = ~73, clamped to `min(archivedTarget, maxDeletedCiphers)` = 25) — 0 are delete-only. See `ArchiveAndDeleteRateTests.BothTarget_NeverExceedsMaxDeletedCiphers_EvenWhenArchivedCeilingIsHigher` for the exact clamp this demonstrates. Sterling Cooper seeds archived/deleted items in *both* the org pool and the personal pool, since `archivedRate`/`deletedRate`/`archivedAndDeletedOverlapRate` apply independently to each. |
 
 ### 5. Umbrella Corp (MD)
 
@@ -262,6 +329,8 @@ FROM (
 | Direct access ratio   | 0.9 — ~90% of access paths are direct CollectionUser.                                  |
 | Collections per user  | PowerLaw 1-15 (skew 0.6). First users get up to 15, most get 1-2. CV > 0.5.            |
 | Multi-collection rate | 25% of ~2,400 non-orphan ciphers in 2-3 collections. Max 3 per cipher.                 |
+| Archived org ciphers  | 50 of 3,000 (8% rate = 240, clamped to the 50 cap).                                    |
+| Deleted org ciphers   | 25 of 3,000 (4% rate = 120, clamped to the 25 cap). All 25 are also archived (3% overlap = 90, clamped) — 0 are delete-only. |
 
 ### 6. Wayne Enterprises (LG)
 
@@ -275,6 +344,10 @@ FROM (
 | Empty group rate      | ~30% — ~30 of 100 groups have 0 members due to power-law tail truncation.      |
 | Collections per user  | PowerLaw 1-25 (skew 0.6). First users get up to 25, most get 1-2. CV > 0.5.    |
 | Multi-collection rate | 25% of ~9,000 non-orphan ciphers in 2-4 collections. Max 4 per cipher.         |
+| Archived org ciphers  | 50 of 10,000 (6% rate = 600, clamped to the 50 cap).                           |
+| Deleted org ciphers   | 25 of 10,000 (3% rate = 300, clamped to the 25 cap). All 25 are also archived (2% overlap = 200, clamped) — 0 are delete-only. |
+| Archived personal ciphers | 50 of ~14,525 personal ciphers (6% rate = ~872, clamped to the 50 cap).   |
+| Deleted personal ciphers  | 25 of ~14,525 (3% rate clamped to 25). All 25 are also archived (2% overlap clamped the same way as Sterling Cooper) — 0 are delete-only. Wayne Enterprises seeds archived/deleted items in *both* the org pool and the personal pool. |
 
 ### 7. Tyrell Corp (LG)
 
@@ -288,6 +361,8 @@ FROM (
 | Empty group rate      | 20% — ~15 of 75 groups have 0 members.                                           |
 | Collections per user  | PowerLaw 1-30 (skew 0.7). First users get up to 30, most get 1-2. CV > 0.5.      |
 | Multi-collection rate | 30% of ~14,450 non-orphan ciphers in 2-4 collections. Max 4 per cipher.          |
+| Archived org ciphers  | 50 of 17,000 (8% rate = 1,360, clamped to the 50 cap).                           |
+| Deleted org ciphers   | 25 of 17,000 (4% rate = 680, clamped to the 25 cap). All 25 are also archived (3% overlap = 510, clamped) — 0 are delete-only. |
 
 ### 8. Weyland-Yutani (XL)
 
@@ -301,6 +376,10 @@ FROM (
 | Empty group rate      | ~68% — ~341 of 500 groups have 0 members due to power-law tail truncation.           |
 | Collections per user  | PowerLaw 1-50 (skew 0.8). First users get up to 50, most get 1-2. CV > 0.5.          |
 | Multi-collection rate | 30% of ~13,500 non-orphan ciphers in 2-5 collections. Max 5 per cipher.              |
+| Archived org ciphers  | 50 of 15,000 (4% rate = 600, clamped to the 50 cap).                                 |
+| Deleted org ciphers   | 25 of 15,000 (3% rate = 450, clamped to the 25 cap). All 25 are also archived (1% overlap = 150, clamped) — 0 are delete-only. |
+| Archived personal ciphers | 50 of ~11,000 personal ciphers (4% rate = 440, clamped to the 50 cap).          |
+| Deleted personal ciphers  | 25 of ~11,000 (3% rate clamped to 25). All 25 are also archived (1% overlap = 110, clamped the same way) — 0 are delete-only. Weyland-Yutani seeds archived/deleted items in *both* the org pool and the personal pool. |
 
 ### 9. Initech (XL)
 
@@ -313,6 +392,8 @@ FROM (
 | Direct access ratio   | 1.0 — 100% of access paths are direct CollectionUser.                                   |
 | Collections per user  | PowerLaw 1-20 (skew 0.5). First users get up to 20, most get 1. CV > 0.2.               |
 | Multi-collection rate | 15% of ~2,250 non-orphan ciphers in 2-3 collections. Max 3 per cipher.                  |
+| Archived org ciphers  | 50 of 15,000 (8% rate = 1,200, clamped to the 50 cap).                                  |
+| Deleted org ciphers   | 25 of 15,000 (5% rate = 750, clamped to the 25 cap). All 25 are also archived (3% overlap = 450, clamped) — 0 are delete-only. |
 
 ---
 

--- a/util/Seeder/Seeds/fixtures/presets/scale/lg-balanced-wayne-enterprises.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/lg-balanced-wayne-enterprises.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 1, "max": 5, "shape": "powerLaw", "emptyGroupRate": 0.15 },
     "directAccessRatio": 0.5,
     "permissions": { "readOnly": 0.82, "readWrite": 0.09, "manage": 0.05, "hidePasswords": 0.04 },
-    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.1, "multiCollectionRate": 0.25, "maxCollectionsPerCipher": 4 },
+    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.1, "multiCollectionRate": 0.25, "maxCollectionsPerCipher": 4, "deletedRate": 0.03, "archivedRate": 0.06, "archivedAndDeletedOverlapRate": 0.02 },
     "userCollections": { "min": 1, "max": 25, "shape": "powerLaw", "skew": 0.6 },
     "personalCiphers": { "shape": "realistic" },
     "folders": { "shape": "enterprise" }

--- a/util/Seeder/Seeds/fixtures/presets/scale/lg-highperm-tyrell-corp.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/lg-highperm-tyrell-corp.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 2, "max": 8, "shape": "powerLaw", "emptyGroupRate": 0.2 },
     "directAccessRatio": 0.6,
     "permissions": { "readOnly": 0.82, "readWrite": 0.09, "manage": 0.05, "hidePasswords": 0.04 },
-    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.15, "multiCollectionRate": 0.30, "maxCollectionsPerCipher": 4 },
+    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.15, "multiCollectionRate": 0.30, "maxCollectionsPerCipher": 4, "deletedRate": 0.04, "archivedRate": 0.08, "archivedAndDeletedOverlapRate": 0.03 },
     "userCollections": { "min": 1, "max": 30, "shape": "powerLaw", "skew": 0.7 },
     "cipherTypes": { "preset": "developerFocused" }
   },

--- a/util/Seeder/Seeds/fixtures/presets/scale/md-balanced-sterling-cooper.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/md-balanced-sterling-cooper.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 1, "max": 5, "shape": "powerLaw", "emptyGroupRate": 0.1 },
     "directAccessRatio": 0.5,
     "permissions": { "readOnly": 0.55, "readWrite": 0.20, "manage": 0.15, "hidePasswords": 0.10 },
-    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.08, "multiCollectionRate": 0.20, "maxCollectionsPerCipher": 3 },
+    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.08, "multiCollectionRate": 0.20, "maxCollectionsPerCipher": 3, "deletedRate": 0.03, "archivedRate": 0.06, "archivedAndDeletedOverlapRate": 0.02 },
     "userCollections": { "min": 1, "max": 10, "shape": "powerLaw", "skew": 0.5 },
     "personalCiphers": { "shape": "realistic" }
   },

--- a/util/Seeder/Seeds/fixtures/presets/scale/md-highcollection-umbrella-corp.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/md-highcollection-umbrella-corp.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 1, "max": 3, "shape": "frontLoaded" },
     "directAccessRatio": 0.9,
     "permissions": { "readWrite": 0.50, "manage": 0.20, "readOnly": 0.20, "hidePasswords": 0.10 },
-    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.2, "multiCollectionRate": 0.25, "maxCollectionsPerCipher": 3 },
+    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.2, "multiCollectionRate": 0.25, "maxCollectionsPerCipher": 3, "deletedRate": 0.04, "archivedRate": 0.08, "archivedAndDeletedOverlapRate": 0.03 },
     "userCollections": { "min": 1, "max": 15, "shape": "powerLaw", "skew": 0.6 },
     "cipherTypes": { "preset": "documentationHeavy" }
   },

--- a/util/Seeder/Seeds/fixtures/presets/scale/sm-balanced-planet-express.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/sm-balanced-planet-express.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 2, "max": 4, "shape": "uniform" },
     "directAccessRatio": 0.7,
     "permissions": { "readOnly": 0.40, "readWrite": 0.30, "manage": 0.25, "hidePasswords": 0.05 },
-    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.05, "multiCollectionRate": 0.15, "maxCollectionsPerCipher": 2 },
+    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.05, "multiCollectionRate": 0.15, "maxCollectionsPerCipher": 2, "deletedRate": 0.03, "archivedRate": 0.06, "archivedAndDeletedOverlapRate": 0.02 },
     "userCollections": { "min": 1, "max": 5, "shape": "powerLaw", "skew": 0.3 }
   },
   "ciphers": { "count": 750 }

--- a/util/Seeder/Seeds/fixtures/presets/scale/sm-highperm-bluth-company.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/sm-highperm-bluth-company.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 1, "max": 5, "shape": "powerLaw" },
     "directAccessRatio": 0.6,
     "permissions": { "readOnly": 0.82, "readWrite": 0.09, "manage": 0.05, "hidePasswords": 0.04 },
-    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.15, "multiCollectionRate": 0.10, "maxCollectionsPerCipher": 2 },
+    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.15, "multiCollectionRate": 0.10, "maxCollectionsPerCipher": 2, "deletedRate": 0.04, "archivedRate": 0.08, "archivedAndDeletedOverlapRate": 0.03 },
     "userCollections": { "min": 1, "max": 3, "shape": "uniform" }
   },
   "ciphers": { "count": 500 }

--- a/util/Seeder/Seeds/fixtures/presets/scale/xl-broad-initech.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/xl-broad-initech.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 1, "max": 3, "shape": "frontLoaded" },
     "directAccessRatio": 1.0,
     "permissions": { "manage": 0.30, "readWrite": 0.30, "readOnly": 0.30, "hidePasswords": 0.10 },
-    "cipherAssignment": { "skew": "uniform", "orphanRate": 0.85, "multiCollectionRate": 0.15, "maxCollectionsPerCipher": 3 },
+    "cipherAssignment": { "skew": "uniform", "orphanRate": 0.85, "multiCollectionRate": 0.15, "maxCollectionsPerCipher": 3, "deletedRate": 0.05, "archivedRate": 0.08, "archivedAndDeletedOverlapRate": 0.03 },
     "userCollections": { "min": 1, "max": 20, "shape": "powerLaw", "skew": 0.5 }
   },
   "ciphers": { "count": 15000 }

--- a/util/Seeder/Seeds/fixtures/presets/scale/xl-highperm-weyland-yutani.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/xl-highperm-weyland-yutani.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 1, "max": 3, "shape": "powerLaw", "emptyGroupRate": 0.3 },
     "directAccessRatio": 0.4,
     "permissions": { "readWrite": 0.55, "readOnly": 0.25, "manage": 0.10, "hidePasswords": 0.10 },
-    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.1, "multiCollectionRate": 0.30, "maxCollectionsPerCipher": 5 },
+    "cipherAssignment": { "skew": "heavyRight", "orphanRate": 0.1, "multiCollectionRate": 0.30, "maxCollectionsPerCipher": 5, "deletedRate": 0.03, "archivedRate": 0.04, "archivedAndDeletedOverlapRate": 0.01 },
     "userCollections": { "min": 1, "max": 50, "shape": "powerLaw", "skew": 0.8 },
     "personalCiphers": { "shape": "lightUsage" },
     "folders": { "shape": "minimal" }

--- a/util/Seeder/Seeds/fixtures/presets/scale/xs-central-perk.json
+++ b/util/Seeder/Seeds/fixtures/presets/scale/xs-central-perk.json
@@ -14,7 +14,7 @@
     "collectionFanOut": { "min": 1, "max": 2, "shape": "uniform" },
     "directAccessRatio": 0.8,
     "permissions": { "manage": 0.50, "readWrite": 0.40, "readOnly": 0.10 },
-    "cipherAssignment": { "skew": "uniform", "orphanRate": 0.0, "multiCollectionRate": 0.20, "maxCollectionsPerCipher": 2 },
+    "cipherAssignment": { "skew": "uniform", "orphanRate": 0.0, "multiCollectionRate": 0.20, "maxCollectionsPerCipher": 2, "deletedRate": 0.02, "archivedRate": 0.04, "archivedAndDeletedOverlapRate": 0.01 },
     "userCollections": { "min": 1, "max": 3, "shape": "uniform" }
   },
   "ciphers": { "count": 200 }

--- a/util/Seeder/Seeds/schemas/preset.schema.json
+++ b/util/Seeder/Seeds/schemas/preset.schema.json
@@ -395,6 +395,34 @@
               "minimum": 1,
               "maximum": 10,
               "description": "Maximum number of collections a multi-collection cipher can belong to. Default: 2."
+            },
+            "archivedRate": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0,
+              "description": "Fraction of ciphers that get an archived state. Applies independently to both the personal-vault and org cipher pools, each against its own size and maxArchivedCiphers cap. Default: 0."
+            },
+            "deletedRate": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0,
+              "description": "Fraction of personal-vault and org ciphers that get a deleted (DeletedDate) state, computed independently per pool. Default: 0."
+            },
+            "archivedAndDeletedOverlapRate": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 1.0,
+              "description": "Fraction of the eligible cipher pool (personal or org, computed independently per pool) deliberately made both archived and deleted. Drawn from the archived set. Default: 0."
+            },
+            "maxArchivedCiphers": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Absolute cap on archived ciphers produced in one run. Default: 50."
+            },
+            "maxDeletedCiphers": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Absolute cap on deleted ciphers produced in one run. Default: 25."
             }
           }
         },

--- a/util/Seeder/Steps/GenerateCiphersStep.cs
+++ b/util/Seeder/Steps/GenerateCiphersStep.cs
@@ -57,7 +57,7 @@ internal sealed class GenerateCiphersStep(
         // rather than sharing one combined budget across steps. Org ciphers are archived "for" a
         // round-robin-selected user (there's no single owning user like a personal cipher has), so
         // archiving requires at least one user to exist.
-        var (archivedOrgTarget, deletedOrgTarget, bothOrgTarget, deletedOnlyOrgTarget) = ArchiveDeleteDistribution.ComputeTargets(
+        var (archivedOrgTarget, _, bothOrgTarget, deletedOnlyOrgTarget) = ArchiveDeleteDistribution.ComputeTargets(
             count,
             _density?.ArchivedCipherRate ?? 0, _density?.DeletedCipherRate ?? 0, _density?.ArchivedAndDeletedOverlapRate ?? 0,
             _density?.MaxArchivedCiphers ?? 0, _density?.MaxDeletedCiphers ?? 0,

--- a/util/Seeder/Steps/GenerateCiphersStep.cs
+++ b/util/Seeder/Steps/GenerateCiphersStep.cs
@@ -48,8 +48,30 @@ internal sealed class GenerateCiphersStep(
         var passwordDistribution = pwDist ?? PasswordDistributions.Realistic;
         var companies = Companies.All;
 
-        var userDigests = assignFolders ? context.Registry.UserDigests : null;
+        var userDigests = context.Registry.UserDigests;
         var userFolderIds = assignFolders ? context.Registry.UserFolderIds : null;
+        var canArchive = userDigests is { Count: > 0 };
+
+        // Archive and delete targets/ceilings are computed independently of GeneratePersonalCiphersStep's
+        // personal-cipher pool — each pool enforces its own MaxArchivedCiphers/MaxDeletedCiphers cap
+        // rather than sharing one combined budget across steps. Org ciphers are archived "for" a
+        // round-robin-selected user (there's no single owning user like a personal cipher has), so
+        // archiving requires at least one user to exist.
+        var (archivedOrgTarget, deletedOrgTarget, bothOrgTarget, deletedOnlyOrgTarget) = ArchiveDeleteDistribution.ComputeTargets(
+            count,
+            _density?.ArchivedCipherRate ?? 0, _density?.DeletedCipherRate ?? 0, _density?.ArchivedAndDeletedOverlapRate ?? 0,
+            _density?.MaxArchivedCiphers ?? 0, _density?.MaxDeletedCiphers ?? 0,
+            canArchive);
+
+        var selection = ArchiveDeleteDistribution.Select(count, archivedOrgTarget, bothOrgTarget, deletedOnlyOrgTarget);
+
+        // CreateOwnerStep always adds the Owner to UserDigests before CreateUsersStep runs, so
+        // userDigests[0] is the Owner — meaning the first archived cipher (position 0) is always
+        // archived for the Owner. Positions are precomputed (not indexed by the raw loop variable i)
+        // so the round-robin cycles through every user regardless of how the archived target divides.
+        var archivedUserPositions = canArchive
+            ? ArchiveDeleteDistribution.AssignRoundRobinUserPositions(selection.ArchivedOrder, userDigests.Count)
+            : new Dictionary<int, int>();
 
         var ciphers = new List<Cipher>(count);
         var cipherIds = new List<Guid>(count);
@@ -68,6 +90,8 @@ internal sealed class GenerateCiphersStep(
                 var userDigest = userDigests[i % userDigests.Count];
                 CipherComposer.AssignFolder(cipher, userDigest.UserId, i, userFolderIds);
             }
+
+            CipherComposer.AssignArchiveOrDeleteState(cipher, i, selection, idx => userDigests[archivedUserPositions[idx]].UserId);
 
             ciphers.Add(cipher);
             cipherIds.Add(cipher.Id);
@@ -143,10 +167,42 @@ internal sealed class GenerateCiphersStep(
                     }
                 }
             }
+
+            // Guarantee the Owner always has an archived and a deleted cipher visible in their own
+            // vault sync for manual QA. Visibility requires both the lifecycle-state flag and
+            // collection access under Flexible Collections — neither the round-robin nor the
+            // density-driven collection assignment has any reason to grant both to the same user
+            // otherwise.
+            if (context.OwnerOrgUser is { } ownerOrgUser)
+            {
+                var ownerCollectionId = context.CollectionUsers
+                    .FirstOrDefault(cu => cu.OrganizationUserId == ownerOrgUser.Id)?.CollectionId;
+
+                if (ownerCollectionId is { } collectionId)
+                {
+                    if (selection.ArchivedOrder.Count > 0)
+                    {
+                        EnsureCollectionAssignment(collectionCiphers, ciphers[selection.ArchivedOrder[0]].Id, collectionId);
+                    }
+
+                    if (selection.DeletedOnly.Count > 0)
+                    {
+                        EnsureCollectionAssignment(collectionCiphers, ciphers[selection.DeletedOnly.First()].Id, collectionId);
+                    }
+                }
+            }
         }
 
         context.Ciphers.AddRange(ciphers);
         context.Registry.CipherIds.AddRange(cipherIds);
         context.CollectionCiphers.AddRange(collectionCiphers);
+    }
+
+    private static void EnsureCollectionAssignment(List<CollectionCipher> collectionCiphers, Guid cipherId, Guid collectionId)
+    {
+        if (!collectionCiphers.Any(cc => cc.CipherId == cipherId && cc.CollectionId == collectionId))
+        {
+            collectionCiphers.Add(new CollectionCipher { CipherId = cipherId, CollectionId = collectionId });
+        }
     }
 }

--- a/util/Seeder/Steps/GeneratePersonalCiphersStep.cs
+++ b/util/Seeder/Steps/GeneratePersonalCiphersStep.cs
@@ -41,9 +41,6 @@ internal sealed class GeneratePersonalCiphersStep(
         var companies = Companies.All;
         var personalDist = density?.PersonalCipherDistribution;
         var userFolderIds = context.Registry.UserFolderIds;
-        var expectedTotal = personalDist is not null
-            ? EstimateTotal(userDigests.Count, personalDist)
-            : userDigests.Count * countPerUser;
 
         // Force lazy generator init before parallel loop (prevents ??= data race)
         _ = (generator.Username, generator.Card, generator.Identity, generator.SecureNote);
@@ -66,6 +63,37 @@ internal sealed class GeneratePersonalCiphersStep(
             offsets[u] = runningOffset;
             runningOffset += userCount;
         }
+
+        // Guarantee the Owner (always userDigests[0]) has at least one personal cipher to archive
+        // for manual QA. Distribution.Select always assigns index 0 to the first (sparsest) bucket,
+        // and 0 % range always lands on the low end — without this, the Owner would get zero
+        // personal ciphers whenever archiving is configured, regardless of seed.
+        if (userDigests.Count > 0 && userCounts[0] == 0 && density is { ArchivedCipherRate: > 0 })
+        {
+            userCounts[0] = 1;
+            for (var u = 1; u < userDigests.Count; u++)
+            {
+                offsets[u]++;
+            }
+            runningOffset++;
+        }
+
+        var expectedTotal = Math.Max(runningOffset, 1);
+
+        // Archive and delete targets/ceilings are computed independently of GenerateCiphersStep's
+        // org-cipher pool — each pool enforces its own MaxArchivedCiphers/MaxDeletedCiphers cap
+        // rather than sharing one combined budget across steps. bothTarget is clamped by
+        // MaxDeletedCiphers too (not just archivedTarget) since it counts toward the delete ceiling
+        // as well as the archive ceiling.
+        var (archivedTarget, deletedTarget, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
+            expectedTotal,
+            density?.ArchivedCipherRate ?? 0, density?.DeletedCipherRate ?? 0, density?.ArchivedAndDeletedOverlapRate ?? 0,
+            density?.MaxArchivedCiphers ?? 0, density?.MaxDeletedCiphers ?? 0);
+
+        // globalIndex spans the whole personal-cipher pool (not just this user's block), so the
+        // selection is computed once against expectedTotal and shared read-only across the parallel
+        // per-user loop.
+        var selection = ArchiveDeleteDistribution.Select(expectedTotal, archivedTarget, bothTarget, deletedOnlyTarget);
 
         var userCiphers = new Cipher[userDigests.Count][];
 
@@ -94,6 +122,8 @@ internal sealed class GeneratePersonalCiphersStep(
                     var cipher = CipherComposer.Compose(globalIndex, cipherType, userDigest.SymmetricKey, companies, generator, passwordDistribution, userId: userDigest.UserId, reprompt: reprompt);
 
                     CipherComposer.AssignFolder(cipher, userDigest.UserId, i, userFolderIds);
+
+                    CipherComposer.AssignArchiveOrDeleteState(cipher, globalIndex, selection, _ => userDigest.UserId);
 
                     localCiphers[i] = cipher;
                 }
@@ -134,17 +164,5 @@ internal sealed class GeneratePersonalCiphersStep(
         context.Registry.CipherIds.AddRange(cipherIds);
 
         progress?.Report(new PhaseCompleted(SeederPhases.CreatingPersonalCiphers));
-    }
-
-    private static int EstimateTotal(int userCount, Distribution<(int Min, int Max)> dist)
-    {
-        var total = 0;
-        for (var i = 0; i < userCount; i++)
-        {
-            var range = dist.Select(i, userCount);
-            total += range.Min + (i % Math.Max(range.Max - range.Min + 1, 1));
-        }
-
-        return Math.Max(total, 1);
     }
 }

--- a/util/Seeder/Steps/GeneratePersonalCiphersStep.cs
+++ b/util/Seeder/Steps/GeneratePersonalCiphersStep.cs
@@ -85,7 +85,7 @@ internal sealed class GeneratePersonalCiphersStep(
         // rather than sharing one combined budget across steps. bothTarget is clamped by
         // MaxDeletedCiphers too (not just archivedTarget) since it counts toward the delete ceiling
         // as well as the archive ceiling.
-        var (archivedTarget, deletedTarget, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
+        var (archivedTarget, _, bothTarget, deletedOnlyTarget) = ArchiveDeleteDistribution.ComputeTargets(
             expectedTotal,
             density?.ArchivedCipherRate ?? 0, density?.DeletedCipherRate ?? 0, density?.ArchivedAndDeletedOverlapRate ?? 0,
             density?.MaxArchivedCiphers ?? 0, density?.MaxDeletedCiphers ?? 0);


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39866](https://bitwarden.atlassian.net/browse/PM-39866)

## 📔 Objective

Adds archive and delete lifecycle-state generation to the Seeder's density-driven cipher pipeline for both personal and organizational vaults. New `DensityProfile` rate + ceiling fields drive the feature similar to the pre-existing properties. Altered the LoginCipherScene.cs to handle archived ciphers. 

## 🧪 Testing

<details><summary>Expand for details</summary>

### End-to-end via the SeederApi scenes

Drove the SeederApi `/seed` endpoint end-to-end to build a full account graph and confirm the new
archive/delete request flags flow through the scene → factory → encrypted-entity path:

- **`SingleUserScene`** + **`SingleOrganizationScene`** / **`OrganizationUserScene`** — create the
  user, the org, and org membership.
- **`UserLoginCipherScene`** and **`OrganizationLoginCipherScene`** with `Archived: true` and
  `Deleted: true` — create archived and deleted **login** ciphers in both the personal and org
  vaults. `Archived` writes the per-user `Archives` JSON via `CipherComposer.BuildArchivesJson`
  (same shape as `Cipher_Archive.sql`); `Deleted` stamps `DeletedDate`.
- **Various cipher types** via `UserCardCipherScene`, `UserIdentityCipherScene`,
  `UserSecureNoteCipherScene`, `UserBankAccountCipherScene`, `UserDriversLicenseCipherScene`,
  `UserPassportCipherScene`, `UserSshKeyCipherScene` — confirm the mixed-type creation path still
  seeds and encrypts correctly alongside the archived/deleted login ciphers.

Confirmed the seeded archived/deleted login ciphers surface correctly in the web-vault UI (Archive
and Trash tabs) when logged in as the seeded user and org owner.

### Live preset seed + SQL verification

Seeded Scale presets via `dotnet run -- preset --name scale.<name> --mangle` and queried
`[dbo].[Cipher]` directly (verification.md Q9 + Q11) for each. Every count landed exactly on the
configured target/cap — no overshoot, no starvation:

| Preset             | Org ciphers | Deleted (Q9) | Archived (Q11) | Both | Notes                                              |
| ------------------ | ----------- | ------------ | -------------- | ---- | -------------------------------------------------- |
| Central Perk (XS)  | 200         | 4            | 8              | 2    | percentage targets (2% / 4% / 1%)                  |
| Bluth Company (SM) | 500         | 20           | 40             | 15   | percentage targets (4% / 8% / 3%)                  |
| Umbrella Corp (MD) | 3,000       | 25           | 50             | 25   | clamped to 25 / 50 caps; all                       |
| Tyrell Corp (LG)   | 17,000      | 25           | 50             | 25   | clamped to 25 / 50 caps; all deleted also archived |

### Step 4: Owner-visibility guarantee (live)

Logged into the web-vault UI as the seeded org Owner and confirmed the Owner always has at least one
**collection-assigned** archived item and one deleted item visible — the Archive and Trash tabs
render them, matching the SQL counts. Verified for Central Perk and Bluth Company.

</details>


[PM-39866]: https://bitwarden.atlassian.net/browse/PM-39866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ