### PR TITLE
[PM-40047] Detect blob ciphers via format_version probe

### DIFF
--- a/src/Core/Vault/Entities/Cipher.cs
+++ b/src/Core/Vault/Entities/Cipher.cs
@@ -35,6 +35,13 @@ public class Cipher : ITableObject<Guid>, ICloneable
 
     public bool IsDataBlobEncrypted()
     {
+        // Blob-encrypted data is a JSON object carrying a top-level "format_version"
+        // key; legacy field-level CipherData JSON never contains it.
+        return HasTopLevelProperty("format_version");
+    }
+
+    private bool HasTopLevelProperty(string propertyName)
+    {
         if (string.IsNullOrWhiteSpace(Data))
         {
             return false;
@@ -44,9 +51,7 @@ public class Cipher : ITableObject<Guid>, ICloneable
         {
             var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(Data));
 
-            // Blob-encrypted data is a JSON object carrying a top-level "format_version"
-            // key; legacy field-level CipherData JSON never contains it. Probe only the
-            // top-level properties rather than materializing the whole document.
+            // Probe only the top-level properties rather than materializing the whole document.
             if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
             {
                 return false;
@@ -54,7 +59,7 @@ public class Cipher : ITableObject<Guid>, ICloneable
 
             while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
             {
-                if (reader.ValueTextEquals("format_version"))
+                if (reader.ValueTextEquals(propertyName))
                 {
                     return true;
                 }

--- a/src/Core/Vault/Entities/Cipher.cs
+++ b/src/Core/Vault/Entities/Cipher.cs
@@ -1,6 +1,7 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using System.Text;
 using System.Text.Json;
 using Bit.Core.Entities;
 using Bit.Core.Utilities;
@@ -39,8 +40,34 @@ public class Cipher : ITableObject<Guid>, ICloneable
             return false;
         }
 
-        var span = Data.AsSpan().TrimStart();
-        return span.Length > 0 && span[0] != '{';
+        try
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(Data));
+
+            // Blob-encrypted data is a JSON object carrying a top-level "format_version"
+            // key; legacy field-level CipherData JSON never contains it. Probe only the
+            // top-level properties rather than materializing the whole document.
+            if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+            {
+                return false;
+            }
+
+            while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+            {
+                if (reader.ValueTextEquals("format_version"))
+                {
+                    return true;
+                }
+
+                reader.Skip();
+            }
+
+            return false;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     public Dictionary<string, CipherAttachment.MetaData> GetAttachments()

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -63,17 +63,18 @@ public class CiphersControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task Put_OpaqueLoginCipherWithOldClient_SkipsFido2VersionCheck(
+    public async Task Put_BlobEncryptedLoginCipherWithOldClient_SkipsFido2VersionCheck(
         User user,
         SutProvider<CiphersController> sutProvider)
     {
+        const string blob = "{\"format_version\":1,\"wrapped_cek\":\"abc\",\"envelope\":\"def\"}";
         var cipherId = Guid.NewGuid();
         var cipherDetails = new CipherDetails
         {
             Id = cipherId,
             UserId = user.Id,
             Type = CipherType.Login,
-            Data = "2.iv|ct|mac",
+            Data = blob,
             Edit = true,
             ViewPassword = true,
         };
@@ -92,13 +93,13 @@ public class CiphersControllerTests
         {
             Type = CipherType.Login,
             Name = "2.name|encrypted",
-            Data = "2.iv|ct|mac",
+            Data = blob,
         };
 
         var response = await sutProvider.Sut.Put(cipherId, model);
 
         Assert.NotNull(response);
-        Assert.Equal("2.iv|ct|mac", response.Data);
+        Assert.Equal(blob, response.Data);
         Assert.Null(response.Login);
         await sutProvider.GetDependency<ICipherService>()
             .Received(1)

--- a/test/Api.Test/Vault/Models/Response/CipherResponseModelTests.cs
+++ b/test/Api.Test/Vault/Models/Response/CipherResponseModelTests.cs
@@ -279,14 +279,14 @@ public class CipherResponseModelTests
     [InlineData(CipherType.BankAccount)]
     [InlineData(CipherType.DriversLicense)]
     [InlineData(CipherType.Passport)]
-    public void Constructor_OpaqueData_DoesNotThrowAndSkipsLegacyFields(CipherType type)
+    public void Constructor_BlobEncryptedData_DoesNotThrowAndSkipsLegacyFields(CipherType type)
     {
-        const string opaque = "2.iv|ct|mac";
+        const string blob = "{\"format_version\":1,\"wrapped_cek\":\"abc\",\"envelope\":\"def\"}";
         var cipher = new Cipher
         {
             Id = Guid.NewGuid(),
             Type = type,
-            Data = opaque,
+            Data = blob,
             RevisionDate = DateTime.UtcNow,
             CreationDate = DateTime.UtcNow,
         };
@@ -294,7 +294,7 @@ public class CipherResponseModelTests
         var response = new CipherMiniResponseModel(cipher, _globalSettings, false);
 
         Assert.Equal(type, response.Type);
-        Assert.Equal(opaque, response.Data);
+        Assert.Equal(blob, response.Data);
         Assert.Null(response.Name);
         Assert.Null(response.Notes);
         Assert.Null(response.Login);

--- a/test/Core.Test/Vault/Models/CipherTests.cs
+++ b/test/Core.Test/Vault/Models/CipherTests.cs
@@ -30,17 +30,21 @@ public class CipherTests
     [InlineData("   ")]
     [InlineData("{\"Name\":\"x\"}")]
     [InlineData("   { \"Name\": \"x\" }")]
-    public void IsDataBlobEncrypted_LegacyOrEmpty_ReturnsFalse(string? data)
+    [InlineData("2.iv|ct|mac")]
+    [InlineData("plain string")]
+    [InlineData("   2.iv|ct|mac")]
+    [InlineData("{\"other_key\":1}")]
+    [InlineData("\"format_version\"")]
+    public void IsDataBlobEncrypted_LegacyEmptyOrInvalid_ReturnsFalse(string? data)
     {
         var cipher = new Cipher { Data = data! };
         Assert.False(cipher.IsDataBlobEncrypted());
     }
 
     [Theory]
-    [InlineData("2.iv|ct|mac")]
-    [InlineData("plain string")]
-    [InlineData("   2.iv|ct|mac")]
-    public void IsDataBlobEncrypted_OpaqueData_ReturnsTrue(string data)
+    [InlineData("{\"format_version\":1,\"wrapped_cek\":\"abc\",\"envelope\":\"def\"}")]
+    [InlineData("   { \"format_version\": 1, \"wrapped_cek\": \"abc\", \"envelope\": \"def\" }")]
+    public void IsDataBlobEncrypted_BlobData_ReturnsTrue(string data)
     {
         var cipher = new Cipher { Data = data };
         Assert.True(cipher.IsDataBlobEncrypted());


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40047

## 📔 Objective

The SDK now stores blob-encrypted cipher payloads as JSON, which starts with `{` and collides with the leading-byte heuristic previously used to tell blob from legacy field-level `CipherData`. This replaces that heuristic in `Cipher.IsDataBlobEncrypted()` with a top-level `format_version` property probe (via `Utf8JsonReader`, so large payloads aren't fully materialized), matching the SDK. Tests updated. Paired with the sdk-internal change for PM-40047.