### PR TITLE
[PM-38773] Require org membership before logging org audit events via /collect

### DIFF
--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -149,7 +149,18 @@ public class CollectController : Controller
                 case EventType.Organization_AutoConfirmEnabled_Admin:
                 case EventType.Organization_AutoConfirmDisabled_Admin:
                 case EventType.Organization_InviteLinkClientCopied:
-                    if (!eventModel.OrganizationId.HasValue)
+                    if (!eventModel.OrganizationId.HasValue || !_currentContext.UserId.HasValue)
+                    {
+                        continue;
+                    }
+
+                    // Verify the caller is a member of the target organization before logging.
+                    // Without this guard any authenticated user could forge these audit-log
+                    // events into any organization (see PM-38773). Mirrors the membership check
+                    // used by the Organization_ItemOrganization_* and PhishingBlocker_* branches.
+                    var orgMembership = await _organizationUserRepository.GetByOrganizationAsync(
+                        eventModel.OrganizationId.Value, _currentContext.UserId.Value);
+                    if (orgMembership == null)
                     {
                         continue;
                     }

--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -154,10 +154,7 @@ public class CollectController : Controller
                         continue;
                     }
 
-                    // Verify the caller is a member of the target organization before logging.
-                    // Without this guard any authenticated user could forge these audit-log
-                    // events into any organization (see PM-38773). Mirrors the membership check
-                    // used by the Organization_ItemOrganization_* and PhishingBlocker_* branches.
+                    // Drop the event if the caller is not a member of the target organization.
                     var orgMembership = await _organizationUserRepository.GetByOrganizationAsync(
                         eventModel.OrganizationId.Value, _currentContext.UserId.Value);
                     if (orgMembership == null)

--- a/test/Events.Test/Controllers/CollectControllerTests.cs
+++ b/test/Events.Test/Controllers/CollectControllerTests.cs
@@ -936,37 +936,11 @@ public class CollectControllerTests
     }
 
     [Theory]
-    [AutoData]
-    public async Task Post_OrganizationClientExportedVault_NonMember_SkipsEvent(
-        Guid userId, Guid orgId, Organization organization)
-    {
-        _currentContext.UserId.Returns(userId);
-        organization.Id = orgId;
-        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
-        // Caller is NOT a member of the org.
-        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns((OrganizationUser)null);
-        var events = new List<EventModel>
-        {
-            new EventModel
-            {
-                Type = EventType.Organization_ClientExportedVault,
-                OrganizationId = orgId,
-                Date = DateTime.UtcNow
-            }
-        };
-
-        var result = await _sut.Post(events);
-
-        Assert.IsType<OkResult>(result);
-        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
-        await _organizationRepository.DidNotReceiveWithAnyArgs().GetByIdAsync(default);
-        await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationEventAsync(default, default, default);
-    }
-
-    [Theory]
+    [BitAutoData(EventType.Organization_ClientExportedVault)]
     [BitAutoData(EventType.Organization_AutoConfirmEnabled_Admin)]
     [BitAutoData(EventType.Organization_AutoConfirmDisabled_Admin)]
-    public async Task Post_OrganizationAutoConfirmAdmin_NonMember_SkipsEvent(
+    [BitAutoData(EventType.Organization_InviteLinkClientCopied)]
+    public async Task Post_OrganizationEvent_NonMember_SkipsEvent(
         EventType eventType, Guid userId, Guid orgId, Organization organization)
     {
         _currentContext.UserId.Returns(userId);
@@ -979,34 +953,6 @@ public class CollectControllerTests
             new EventModel
             {
                 Type = eventType,
-                OrganizationId = orgId,
-                Date = DateTime.UtcNow
-            }
-        };
-
-        var result = await _sut.Post(events);
-
-        Assert.IsType<OkResult>(result);
-        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
-        await _organizationRepository.DidNotReceiveWithAnyArgs().GetByIdAsync(default);
-        await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationEventAsync(default, default, default);
-    }
-
-    [Theory]
-    [AutoData]
-    public async Task Post_OrganizationClientCopiedInviteLink_NonMember_SkipsEvent(
-        Guid userId, Guid orgId, Organization organization)
-    {
-        _currentContext.UserId.Returns(userId);
-        organization.Id = orgId;
-        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
-        // Caller is NOT a member of the org.
-        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns((OrganizationUser)null);
-        var events = new List<EventModel>
-        {
-            new EventModel
-            {
-                Type = EventType.Organization_InviteLinkClientCopied,
                 OrganizationId = orgId,
                 Date = DateTime.UtcNow
             }

--- a/test/Events.Test/Controllers/CollectControllerTests.cs
+++ b/test/Events.Test/Controllers/CollectControllerTests.cs
@@ -612,10 +612,12 @@ public class CollectControllerTests
     [Theory]
     [AutoData]
     public async Task Post_OrganizationClientExportedVault_WithValidOrg_LogsOrgEvent(
-        Guid userId, Guid orgId, Organization organization)
+        Guid userId, Guid orgId, Organization organization, OrganizationUser orgUser)
     {
         _currentContext.UserId.Returns(userId);
         organization.Id = orgId;
+        orgUser.OrganizationId = orgId;
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns(orgUser);
         _organizationRepository.GetByIdAsync(orgId).Returns(organization);
         var eventDate = DateTime.UtcNow;
         var events = new List<EventModel>
@@ -631,6 +633,7 @@ public class CollectControllerTests
         var result = await _sut.Post(events);
 
         Assert.IsType<OkResult>(result);
+        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _organizationRepository.Received(1).GetByIdAsync(orgId);
         await _eventService.Received(1).LogOrganizationEventAsync(organization, EventType.Organization_ClientExportedVault, eventDate);
     }
@@ -659,9 +662,12 @@ public class CollectControllerTests
 
     [Theory]
     [AutoData]
-    public async Task Post_OrganizationClientExportedVault_WithNullOrg_SkipsEvent(Guid userId, Guid orgId)
+    public async Task Post_OrganizationClientExportedVault_WithNullOrg_SkipsEvent(
+        Guid userId, Guid orgId, OrganizationUser orgUser)
     {
         _currentContext.UserId.Returns(userId);
+        orgUser.OrganizationId = orgId;
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns(orgUser);
         _organizationRepository.GetByIdAsync(orgId).Returns((Organization)null);
         var events = new List<EventModel>
         {
@@ -703,12 +709,14 @@ public class CollectControllerTests
     [Theory]
     [AutoData]
     public async Task Post_MixedEventTypes_ProcessesAllEvents(
-        Guid userId, Guid cipherId, Guid orgId, CipherDetails cipherDetails, Organization organization)
+        Guid userId, Guid cipherId, Guid orgId, CipherDetails cipherDetails, Organization organization, OrganizationUser orgUser)
     {
         _currentContext.UserId.Returns(userId);
         cipherDetails.Id = cipherId;
         organization.Id = orgId;
+        orgUser.OrganizationId = orgId;
         _cipherRepository.GetByIdAsync(cipherId, userId).Returns(cipherDetails);
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns(orgUser);
         _organizationRepository.GetByIdAsync(orgId).Returns(organization);
         var events = new List<EventModel>
         {
@@ -799,10 +807,12 @@ public class CollectControllerTests
     [BitAutoData(EventType.Organization_AutoConfirmEnabled_Admin)]
     [BitAutoData(EventType.Organization_AutoConfirmDisabled_Admin)]
     public async Task Post_OrganizationAutoConfirmAdmin_WithValidOrg_LogsOrgEvent(
-        EventType eventType, Guid userId, Guid orgId, Organization organization)
+        EventType eventType, Guid userId, Guid orgId, Organization organization, OrganizationUser orgUser)
     {
         _currentContext.UserId.Returns(userId);
         organization.Id = orgId;
+        orgUser.OrganizationId = orgId;
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns(orgUser);
         _organizationRepository.GetByIdAsync(orgId).Returns(organization);
         var eventDate = DateTime.UtcNow;
         var events = new List<EventModel>
@@ -818,6 +828,7 @@ public class CollectControllerTests
         var result = await _sut.Post(events);
 
         Assert.IsType<OkResult>(result);
+        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _organizationRepository.Received(1).GetByIdAsync(orgId);
         await _eventService.Received(1).LogOrganizationEventAsync(organization, eventType, eventDate);
     }
@@ -850,9 +861,11 @@ public class CollectControllerTests
     [BitAutoData(EventType.Organization_AutoConfirmEnabled_Admin)]
     [BitAutoData(EventType.Organization_AutoConfirmDisabled_Admin)]
     public async Task Post_OrganizationAutoConfirmAdmin_WithNullOrg_SkipsEvent(
-        EventType eventType, Guid userId, Guid orgId)
+        EventType eventType, Guid userId, Guid orgId, OrganizationUser orgUser)
     {
         _currentContext.UserId.Returns(userId);
+        orgUser.OrganizationId = orgId;
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns(orgUser);
         _organizationRepository.GetByIdAsync(orgId).Returns((Organization)null);
         var events = new List<EventModel>
         {
@@ -874,10 +887,12 @@ public class CollectControllerTests
     [Theory]
     [AutoData]
     public async Task Post_OrganizationClientCopiedInviteLink_WithValidOrg_LogsOrgEvent(
-        Guid userId, Guid orgId, Organization organization)
+        Guid userId, Guid orgId, Organization organization, OrganizationUser orgUser)
     {
         _currentContext.UserId.Returns(userId);
         organization.Id = orgId;
+        orgUser.OrganizationId = orgId;
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns(orgUser);
         _organizationRepository.GetByIdAsync(orgId).Returns(organization);
         var eventDate = DateTime.UtcNow;
         var events = new List<EventModel>
@@ -893,6 +908,7 @@ public class CollectControllerTests
         var result = await _sut.Post(events);
 
         Assert.IsType<OkResult>(result);
+        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _organizationRepository.Received(1).GetByIdAsync(orgId);
         await _eventService.Received(1).LogOrganizationEventAsync(organization, EventType.Organization_InviteLinkClientCopied, eventDate);
     }
@@ -915,6 +931,91 @@ public class CollectControllerTests
         var result = await _sut.Post(events);
 
         Assert.IsType<OkResult>(result);
+        await _organizationRepository.DidNotReceiveWithAnyArgs().GetByIdAsync(default);
+        await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationEventAsync(default, default, default);
+    }
+
+    [Theory]
+    [AutoData]
+    public async Task Post_OrganizationClientExportedVault_NonMember_SkipsEvent(
+        Guid userId, Guid orgId, Organization organization)
+    {
+        _currentContext.UserId.Returns(userId);
+        organization.Id = orgId;
+        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        // Caller is NOT a member of the org.
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns((OrganizationUser)null);
+        var events = new List<EventModel>
+        {
+            new EventModel
+            {
+                Type = EventType.Organization_ClientExportedVault,
+                OrganizationId = orgId,
+                Date = DateTime.UtcNow
+            }
+        };
+
+        var result = await _sut.Post(events);
+
+        Assert.IsType<OkResult>(result);
+        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
+        await _organizationRepository.DidNotReceiveWithAnyArgs().GetByIdAsync(default);
+        await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationEventAsync(default, default, default);
+    }
+
+    [Theory]
+    [BitAutoData(EventType.Organization_AutoConfirmEnabled_Admin)]
+    [BitAutoData(EventType.Organization_AutoConfirmDisabled_Admin)]
+    public async Task Post_OrganizationAutoConfirmAdmin_NonMember_SkipsEvent(
+        EventType eventType, Guid userId, Guid orgId, Organization organization)
+    {
+        _currentContext.UserId.Returns(userId);
+        organization.Id = orgId;
+        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        // Caller is NOT a member of the org.
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns((OrganizationUser)null);
+        var events = new List<EventModel>
+        {
+            new EventModel
+            {
+                Type = eventType,
+                OrganizationId = orgId,
+                Date = DateTime.UtcNow
+            }
+        };
+
+        var result = await _sut.Post(events);
+
+        Assert.IsType<OkResult>(result);
+        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
+        await _organizationRepository.DidNotReceiveWithAnyArgs().GetByIdAsync(default);
+        await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationEventAsync(default, default, default);
+    }
+
+    [Theory]
+    [AutoData]
+    public async Task Post_OrganizationClientCopiedInviteLink_NonMember_SkipsEvent(
+        Guid userId, Guid orgId, Organization organization)
+    {
+        _currentContext.UserId.Returns(userId);
+        organization.Id = orgId;
+        _organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        // Caller is NOT a member of the org.
+        _organizationUserRepository.GetByOrganizationAsync(orgId, userId).Returns((OrganizationUser)null);
+        var events = new List<EventModel>
+        {
+            new EventModel
+            {
+                Type = EventType.Organization_InviteLinkClientCopied,
+                OrganizationId = orgId,
+                Date = DateTime.UtcNow
+            }
+        };
+
+        var result = await _sut.Post(events);
+
+        Assert.IsType<OkResult>(result);
+        await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _organizationRepository.DidNotReceiveWithAnyArgs().GetByIdAsync(default);
         await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationEventAsync(default, default, default);
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38773

## 📔 Objective

The Events `POST /collect` endpoint logged four organization audit-log event types (`Organization_ClientExportedVault`, `Organization_AutoConfirmEnabled_Admin`, `Organization_AutoConfirmDisabled_Admin`, `Organization_InviteLinkClientCopied`) without verifying the caller was a member of the target organization. It loaded the organization by id and logged the event, so any authenticated account (including one that belongs to no organization) could forge, and backdate, these audit-log entries into any organization identified by its id, and those entries fan out to that organization's configured event integrations.

This adds the same membership guard the sibling `Organization_ItemOrganization_*` and `PhishingBlocker_*` branches already use: look up the caller's membership with `GetByOrganizationAsync(organizationId, userId)` and silently drop the event when the caller is not a member. Legitimate members are unaffected (the event is still logged via `LogOrganizationEventAsync`), and the endpoint continues to return 200. Unit tests cover both the member (logged) and non-member (dropped) paths for all four event types.

## 📸 Screenshots

Not applicable, no UI changes (server-side authorization fix).