### PR TITLE
fix(codeowners): Reorder Docker rules to fix owner override

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,13 +7,6 @@
 # CODEOWNERS owners
 .github/CODEOWNERS @bitwarden/tech-leads
 
-## Docker-related files
-**/Dockerfile @bitwarden/team-appsec @bitwarden/dept-shot
-**/*.Dockerfile @bitwarden/team-appsec @bitwarden/dept-shot
-**/*.dockerignore @bitwarden/team-appsec @bitwarden/dept-shot
-**/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-shot
-**/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-shot
-
 # Scanning tools
 .checkmarx/ @bitwarden/team-appsec
 
@@ -116,6 +109,13 @@ bitwarden_license/test/Services/Pam.Test @bitwarden/team-pam-dev
 
 # SDK
 util/RustSdk @bitwarden/team-sdk-sme
+
+## Docker-related files
+**/Dockerfile @bitwarden/team-appsec @bitwarden/dept-shot
+**/*.Dockerfile @bitwarden/team-appsec @bitwarden/dept-shot
+**/*.dockerignore @bitwarden/team-appsec @bitwarden/dept-shot
+**/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-shot
+**/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-shot
 
 # Multiple owners - DO NOT REMOVE (BRE)
 **/packages.lock.json


### PR DESCRIPTION

## 🎟️ Tracking

null

## 📔 Objective

CODEOWNERS resolves ownership by last-match-wins, so any team/path-specific pattern declared after the Docker-related files section silently overrode it. This caused Dockerfile changes (e.g. util/MsSqlMigratorUtility/gov.Dockerfile) to route only to that path's owning team instead of team-appsec/dept-shot.

* Move the Docker-related files section below all team and path-specific ownership rules
* Keep it above the "Multiple owners - DO NOT REMOVE (BRE)" block so the explicit no-owner overrides for dev/docker-compose.yml and .devcontainer/** still take precedence


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
