### PR TITLE
[BRE-1907] Corrected artifact manifest container image format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,19 +291,27 @@ jobs:
           PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
           IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
           DIGEST: ${{ steps.build-artifacts.outputs.digest }}
+          TAGS: ${{ steps.image-tags.outputs.tags }}
         run: |
+          fragment='{}'
+          IFS=',' read -r -a tags_array <<< "$TAGS"
+          for tag in "${tags_array[@]}"; do
+            image_uri="${tag%:*}"   # strip ":tag" -> full repo URI, e.g. ghcr.io/bitwarden/api
+            host="${tag%%/*}"       # registry host, e.g. bitwardenprod.azurecr.io / ghcr.io
+            base_domain=$(echo "$host" | awk -F. 'NF>=2{printf "%s.%s",$(NF-1),$NF} NF<2{printf "%s",$0}')
+            fragment=$(echo "$fragment" | jq \
+              --arg k "${PROJECT_NAME}-${base_domain}" \
+              --arg image "$image_uri" \
+              --arg tag "$IMAGE_TAG" \
+              --arg digest "$DIGEST" \
+              '. + {($k): {type: "container_image", image: $image, tag: $tag, digest: $digest}}')
+          done
+
           mkdir -p image-manifest-fragments
-          jq -n \
-            --arg name "$PROJECT_NAME" \
-            --arg registry "$_AZ_REGISTRY" \
-            --arg image "$PROJECT_NAME" \
-            --arg tag "$IMAGE_TAG" \
-            --arg digest "$DIGEST" \
-            '{($name): {type: "container_image", registry: $registry, image: $image, tag: $tag, digest: $digest}}' \
-            > "image-manifest-fragments/${PROJECT_NAME}.json"
+          echo "$fragment" > "image-manifest-fragments/${PROJECT_NAME}.json"
 
       - name: Upload image manifest fragment
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image-manifest-fragment-${{ steps.setup.outputs.project_name }}
           path: image-manifest-fragments/${{ steps.setup.outputs.project_name }}.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,6 +364,7 @@ jobs:
     needs: build-artifacts
     permissions:
       contents: read
+      actions: write # delete the intermediate fragment artifacts after aggregating
     steps:
       - name: Download image manifest fragments
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -387,6 +388,19 @@ jobs:
         with:
           mode: upload
           additional_artifacts: ${{ steps.combine.outputs.additional_artifacts }}
+
+      - name: Delete intermediate fragment artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for f in image-manifest-fragments/*.json; do
+            name="image-manifest-fragment-$(basename "$f" .json)"
+            id=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts?name=${name}" --jq '.artifacts[0].id // empty')
+            if [ -n "$id" ]; then
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}"
+              echo "Deleted fragment artifact ${name} (${id})"
+            fi
+          done
 
   upload:
     name: Upload


### PR DESCRIPTION
## 🎟️ Tracking
Followup to [this](https://github.com/bitwarden/server/pull/7920) PR
[BRE-1907](https://bitwarden.atlassian.net/browse/BRE-1907)

## 📔 Objective
This PR is a followup to the one linked above. Specifically, it changes the format of the artifact manifest so that each image/registry combination is a unique entry in the manifest. It also adds a cleanup step to remove the temporary artifacts.


[BRE-1907]: https://bitwarden.atlassian.net/browse/BRE-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ