### PR TITLE
[PM-36505] Finalize Send Controls policy, add second feature flag to enable/disable logic

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendControlsSyncPolicyEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendControlsSyncPolicyEvent.cs
@@ -5,6 +5,7 @@ using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyUpdateEvents.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Exceptions;
+using Bit.Core.Services;
 using Bit.Core.Tools.Entities;
 using Bit.Core.Tools.Enums;
 using Bit.Core.Tools.Repositories;
@@ -19,7 +20,8 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandler
 public class SendControlsSyncPolicyEvent(
     IPolicyRepository policyRepository,
     TimeProvider timeProvider,
-    ISendRepository sendRepository) : IOnPolicyPostUpdateEvent, IPolicyValidationEvent
+    ISendRepository sendRepository,
+    IFeatureService featureService) : IOnPolicyPostUpdateEvent, IPolicyValidationEvent
 {
     public PolicyType Type => PolicyType.SendControls;
 
@@ -44,7 +46,9 @@ public class SendControlsSyncPolicyEvent(
             enabled: postUpsertedPolicyState.Enabled && sendControlsPolicyData.DisableHideEmail,
             policyData: sendOptionsData);
 
-        await UpdateSendsByPolicyAsync(postUpsertedPolicyState, sendControlsPolicyData);
+        if (featureService.IsEnabled(FeatureFlagKeys.SendControlsExistingSends)) {
+            await UpdateSendsByPolicyAsync(postUpsertedPolicyState, sendControlsPolicyData);
+        }
     }
 
     private async Task UpsertLegacyPolicyAsync<T>(
@@ -79,6 +83,7 @@ public class SendControlsSyncPolicyEvent(
         return Task.FromResult(string.Empty);
     }
 
+    // Enable or disable all Sends in an org based on whether they are compliant to org policy
     private async Task UpdateSendsByPolicyAsync(Policy postUpsertedPolicyState, SendControlsPolicyData sendControlsPolicyData)
     {
         var orgSendIds = await sendRepository.GetIdsByOrganizationIdAsync(postUpsertedPolicyState.OrganizationId);

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendControlsSyncPolicyEvent.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendControlsSyncPolicyEvent.cs
@@ -46,7 +46,8 @@ public class SendControlsSyncPolicyEvent(
             enabled: postUpsertedPolicyState.Enabled && sendControlsPolicyData.DisableHideEmail,
             policyData: sendOptionsData);
 
-        if (featureService.IsEnabled(FeatureFlagKeys.SendControlsExistingSends)) {
+        if (featureService.IsEnabled(FeatureFlagKeys.SendControlsExistingSends))
+        {
             await UpdateSendsByPolicyAsync(postUpsertedPolicyState, sendControlsPolicyData);
         }
     }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -248,6 +248,7 @@ public static class FeatureFlagKeys
     public const string SendControls = "pm-31885-send-controls";
     public const string SdkSendsApi = "pm-30110-sdk-sends-api";
     public const string SendEventLogging = "pm-36560-send-event-logging";
+    public const string SendControlsExistingSends = "pm-31885-send-controls-existing-sends";
 
     /* Vault Team */
     public const string CipherKeyEncryption = "cipher-key-encryption";

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendControlsSyncPolicyEventTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/SendControlsSyncPolicyEventTests.cs
@@ -4,6 +4,7 @@ using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandlers;
 using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Services;
 using Bit.Core.Test.AdminConsole.AutoFixture;
 using Bit.Core.Tools.Entities;
 using Bit.Core.Tools.Enums;
@@ -159,6 +160,9 @@ public class SendControlsSyncPolicyEventTests
         sutProvider.GetDependency<IPolicyRepository>()
             .GetByOrganizationIdTypeAsync(policyUpdate.OrganizationId, PolicyType.SendOptions)
             .Returns(existingSendOptionsPolicy);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.SendControlsExistingSends)
+            .Returns(true);
 
         var nonCompliantSend1 = new Send
         {
@@ -205,6 +209,9 @@ public class SendControlsSyncPolicyEventTests
         sutProvider.GetDependency<IPolicyRepository>()
             .GetByOrganizationIdTypeAsync(policyUpdate.OrganizationId, PolicyType.SendOptions)
             .Returns(existingSendOptionsPolicy);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.SendControlsExistingSends)
+            .Returns(true);
 
         var otherwiseCompliantSend1 = new Send
         {
@@ -251,6 +258,9 @@ public class SendControlsSyncPolicyEventTests
         sutProvider.GetDependency<IPolicyRepository>()
             .GetByOrganizationIdTypeAsync(policyUpdate.OrganizationId, PolicyType.SendOptions)
             .Returns(existingSendOptionsPolicy);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.SendControlsExistingSends)
+            .Returns(true);
 
         var compliantSend = new Send
         {
@@ -300,6 +310,9 @@ public class SendControlsSyncPolicyEventTests
         sutProvider.GetDependency<IPolicyRepository>()
             .GetByOrganizationIdTypeAsync(policyUpdate.OrganizationId, PolicyType.SendOptions)
             .Returns(existingSendOptionsPolicy);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.SendControlsExistingSends)
+            .Returns(true);
 
         var compliantSend = new Send
         {
@@ -354,6 +367,9 @@ public class SendControlsSyncPolicyEventTests
         sutProvider.GetDependency<IPolicyRepository>()
             .GetByOrganizationIdTypeAsync(policyUpdate.OrganizationId, PolicyType.SendOptions)
             .Returns(existingSendOptionsPolicy);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.SendControlsExistingSends)
+            .Returns(true);
 
         var compliantSend = new Send
         {
@@ -408,6 +424,9 @@ public class SendControlsSyncPolicyEventTests
         sutProvider.GetDependency<IPolicyRepository>()
             .GetByOrganizationIdTypeAsync(policyUpdate.OrganizationId, PolicyType.SendOptions)
             .Returns(existingSendOptionsPolicy);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.SendControlsExistingSends)
+            .Returns(true);
 
         var compliantSend = new Send
         {
@@ -469,6 +488,10 @@ public class SendControlsSyncPolicyEventTests
         sutProvider.GetDependency<IPolicyRepository>()
             .GetByOrganizationIdTypeAsync(policyUpdate.OrganizationId, PolicyType.SendOptions)
             .Returns(existingSendOptionsPolicy);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.SendControlsExistingSends)
+            .Returns(true);
+
         var compliantSend = new Send
         {
             Id = Guid.NewGuid(),
@@ -517,6 +540,9 @@ public class SendControlsSyncPolicyEventTests
         sutProvider.GetDependency<IPolicyRepository>()
             .GetByOrganizationIdTypeAsync(policyUpdate.OrganizationId, PolicyType.SendOptions)
             .Returns(existingSendOptionsPolicy);
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.SendControlsExistingSends)
+            .Returns(true);
 
         var twoDaysAgo = DateTime.UtcNow.AddDays(-2);
         var nonCompliantSend = new Send


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-36505

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adds a second feature flag for the new Send Controls policy that controls whether the policy will apply its enforcement logic retroactively to all existing Sends in an organization.
