### PR TITLE
[PM-40128] Adjust enforcement message when Send is noncompliant with …

### DIFF
--- a/src/Core/Tools/SendFeatures/Services/SendValidationService.cs
+++ b/src/Core/Tools/SendFeatures/Services/SendValidationService.cs
@@ -112,7 +112,18 @@ public class SendValidationService : ISendValidationService
         // We allow for up to a minute of skew in the difference between the deletion date and the creation date
         if (sendControlsRequirement.DeletionHours != null && (send.DeletionDate.AddMinutes(-1) - send.CreationDate).TotalHours > sendControlsRequirement.DeletionHours.Value)
         {
-            throw new BadRequestException($"Due to an Enterprise policy your Sends must have a deletion date no more than {sendControlsRequirement.DeletionHours} hours from its creation date");
+            var duration = sendControlsRequirement.DeletionHours.Value;
+            var units = "hour";
+            if (duration >= 24)
+            {
+                units = "day";
+                duration /= 24;
+            }
+            if (duration > 1)
+            {
+                units += "s";
+            }
+            throw new BadRequestException($"Due to an Enterprise policy your Sends must have deletion dates no more than {duration} {units} from their creation dates");
         }
     }
 

--- a/test/Core.Test/Tools/Services/SendValidationServiceTests.cs
+++ b/test/Core.Test/Tools/Services/SendValidationServiceTests.cs
@@ -290,18 +290,29 @@ public class SendValidationServiceTests
     public async Task ValidateUserCanSaveAsync_SendDeletionDateExceedsDeletionHours_ThrowsBadRequest(
         SutProvider<SendValidationService> sutProvider, Send send, Guid userId)
     {
-        send.DeletionDate = send.CreationDate.AddDays(7);
-
         sutProvider.GetDependency<IPolicyRequirementQuery>().GetAsync<DisableSendPolicyRequirement>(userId)
             .Returns(new DisableSendPolicyRequirement { DisableSend = false });
 
         sutProvider.GetDependency<IPolicyRequirementQuery>().GetAsync<SendOptionsPolicyRequirement>(userId)
             .Returns(new SendOptionsPolicyRequirement { DisableHideEmail = false });
 
-        sutProvider.GetDependency<IPolicyRequirementQuery>().GetAsync<SendControlsPolicyRequirement>(userId)
-            .Returns(new SendControlsPolicyRequirement { DisableSend = false, DisableHideEmail = false, DeletionHours = 72 });
+        var cases = new Dictionary<int, string>(){
+            { 1, "1 hour" },
+            { 24, "1 day" },
+            { 48, "2 days" },
+            { 72, "3 days" },
+            { 168, "7 days" },
+            { 336, "14 days" },
+            { 720, "30 days" }
+        };
+        foreach (var kvp in cases)
+        {
+            sutProvider.GetDependency<IPolicyRequirementQuery>().GetAsync<SendControlsPolicyRequirement>(userId)
+                .Returns(new SendControlsPolicyRequirement { DisableSend = false, DisableHideEmail = false, DeletionHours = kvp.Key });
+            send.DeletionDate = send.CreationDate.AddHours(kvp.Key + 5);
+            var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.ValidateUserCanSaveAsync(userId, send));
+            Assert.Equal($"Due to an Enterprise policy your Sends must have deletion dates no more than {kvp.Value} from their creation dates", exception.Message);
+        }
 
-        await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.ValidateUserCanSaveAsync(userId, send));
     }
 }


### PR DESCRIPTION
…deletion date policy

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40128

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adjusts the error message that is returned when trying to create a Send with a deletion date that is later than the limit that is applied by policy. Instead of always saying the limit in hours it will convert anything above 24 hours to its equivalent days (and handle singulars vs plurals)