### PR TITLE
chore(ci): add platform-community code-review signal

### DIFF
--- a/.github/platform-community-paths.yml
+++ b/.github/platform-community-paths.yml
@@ -1,0 +1,2 @@
+matched:
+  - "src/Core/Platform/Mail/**"

--- a/.github/workflows/platform-community-signal.yml
+++ b/.github/workflows/platform-community-signal.yml
@@ -1,0 +1,17 @@
+name: Platform community signal
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions: {}
+
+jobs:
+  signal:
+    name: Signal platform-community review
+    uses: bitwarden/gh-actions/.github/workflows/_platform-community-signal.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      config_path: .github/platform-community-paths.yml


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37517

## 📔 Objective

Uses the reusable workflow declared on https://github.com/bitwarden/gh-actions/pull/836 to start signaling during code review when a domain is owned by platform, but is not a domain we have a lot of current experience in. I added a single directory to start for testing, with the idea being that we'd fill this list in together once the workflow is up and running.

## 📸 Screenshots

A screen shot from the already merged client implementation https://github.com/bitwarden/clients/pull/21751:

<img width="994" height="325" alt="Screenshot 2026-07-09 at 10 04 10 AM" src="https://github.com/user-attachments/assets/d3b5d03f-1774-47a2-8883-0db457d763d5" />
