### PR TITLE
[PM-40152] feat: Require verified email to accept organization invite link

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommand.cs
@@ -59,6 +59,11 @@ public class AcceptOrganizationInviteLinkCommand(
             return new InviteLinkNotAvailable();
         }
 
+        if (!user.EmailVerified)
+        {
+            return new EmailNotVerified();
+        }
+
         if (!InviteLinkDomainValidator.IsEmailDomainAllowed(user.Email, link.GetAllowedDomains()))
         {
             return new EmailDomainNotAllowed();

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
@@ -14,6 +14,9 @@ public record InviteLinkNotAvailable()
 public record InviteLinkNotFound()
     : NotFoundError("Invite link not found.");
 
+public record EmailNotVerified()
+    : BadRequestError("You must verify your email address before joining an organization.");
+
 public record EmailDomainNotAllowed()
     : BadRequestError("Your email domain is not allowed to join this organization.");
 

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommandTests.cs
@@ -127,6 +127,31 @@ public class AcceptOrganizationInviteLinkCommandTests
     }
 
     [Theory, BitAutoData]
+    public async Task AcceptAsync_WithUnverifiedEmail_ReturnsEmailNotVerified(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<AcceptOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        user.EmailVerified = false;
+
+        var request = new AcceptOrganizationInviteLinkRequest { Code = inviteLink.Code, User = user };
+        var result = await sutProvider.Sut.AcceptAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<EmailNotVerified>(result.AsError);
+
+        // Guard runs in the validation phase - no membership should be created.
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .CreateAsync(default!);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceAsync(default!);
+    }
+
+    [Theory, BitAutoData]
     public async Task AcceptAsync_WithRevokedMember_ReturnsOrganizationAccessRevoked(
         Organization organization,
         OrganizationInviteLink inviteLink,
@@ -770,6 +795,7 @@ public class AcceptOrganizationInviteLinkCommandTests
         link.OrganizationId = org.Id;
         link.AllowedDomains = "[\"example.com\"]";
         user.Email = "user@example.com";
+        user.EmailVerified = true;
 
         sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
             .GetByCodeAsync(link.Code)


### PR DESCRIPTION
## 🎟️ Tracking

Resolves [PM-40152](https://bitwarden.atlassian.net/browse/PM-40152)

## 📔 Objective

The invite-link accept flow (`AcceptOrganizationInviteLinkCommand`) gated organization membership on the accepting user's email **domain** being in the link's `AllowedDomains`, but never asserted the email was **verified**. Unlike the email-invite flow — where the token delivered to the mailbox proves ownership — the invite link carries no per-email token, so the domain allowlist was the only binding between the user and an allowed domain. An account holding an unverified email at an allowed domain could therefore join the organization.

This PR adds a `!user.EmailVerified` guard in the read-only validation phase of the accept command, before any `OrganizationUser` is created or seat is consumed. Unverified users receive a new `EmailNotVerified` error (HTTP 400). New unit tests cover the rejection and confirm no membership/seat side effects occur.

SSO JIT-provisioned users are not affected: the JIT flow creates an org user in an invited state and accepts them via `IAcceptOrgUserCommand` (through the MP, TDE, or Key Connector paths), never through `AcceptOrganizationInviteLinkCommand`.

Surfaced by the AppSec review of the invite-link tech breakdown.

[PM-40152]: https://bitwarden.atlassian.net/browse/PM-40152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ