### PR TITLE
[PM-40245] Add google favicon API to icon service lookups

### DIFF
--- a/src/Icons/IconsSettings.cs
+++ b/src/Icons/IconsSettings.cs
@@ -5,4 +5,5 @@ public class IconsSettings
     public virtual bool CacheEnabled { get; set; }
     public virtual int CacheHours { get; set; }
     public virtual long? CacheSizeLimit { get; set; }
+    public virtual bool GoogleFaviconEnabled { get; set; }
 }

--- a/src/Icons/Services/IconFetchingService.cs
+++ b/src/Icons/Services/IconFetchingService.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using AngleSharp.Html.Parser;
 using Bit.Icons.Extensions;
@@ -8,24 +8,72 @@ namespace Bit.Icons.Services;
 
 public class IconFetchingService : IIconFetchingService
 {
+    private const int GoogleFaviconSize = 64;
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<IIconFetchingService> _logger;
     private readonly IHtmlParser _parser;
     private readonly IUriService _uriService;
+    private readonly IconsSettings _iconsSettings;
 
-    public IconFetchingService(ILogger<IIconFetchingService> logger, IHttpClientFactory httpClientFactory, IHtmlParser parser, IUriService uriService)
+    public IconFetchingService(
+        ILogger<IIconFetchingService> logger,
+        IHttpClientFactory httpClientFactory,
+        IHtmlParser parser,
+        IUriService uriService,
+        IconsSettings iconsSettings)
     {
         _logger = logger;
         _httpClientFactory = httpClientFactory;
         _parser = parser;
         _uriService = uriService;
+        _iconsSettings = iconsSettings;
     }
 
     public async Task<Icon?> GetIconAsync(string domain)
     {
+        if (_iconsSettings.GoogleFaviconEnabled)
+        {
+            var googleIcon = await GetGoogleFaviconAsync(domain);
+            if (googleIcon != null)
+            {
+                return googleIcon;
+            }
+        }
+
         var domainIcons = await DomainIcons.FetchAsync(domain, _logger, _httpClientFactory, _parser, _uriService);
         var result = domainIcons.Where(result => result != null).FirstOrDefault();
         return result ?? await GetFaviconAsync(domain);
+    }
+
+    private async Task<Icon?> GetGoogleFaviconAsync(string domain)
+    {
+        // Google's undocumented favicon endpoint. Returns a PNG, 301-redirects to
+        // t0.gstatic.com/faviconV2.
+        var googleUriBuilder = new UriBuilder
+        {
+            Scheme = "https",
+            Host = "www.google.com",
+            Path = "/s2/favicons",
+            Query = $"domain={Uri.EscapeDataString(domain)}&sz={GoogleFaviconSize}"
+        };
+
+        if (!googleUriBuilder.TryBuild(out var googleUri))
+        {
+            return null;
+        }
+
+        try
+        {
+            // A 404 from Google indicates no favicon exists for the domain; the existing
+            // IconLink/IconHttpRequest pipeline propagates that as a null return.
+            return await new IconLink(googleUri!).FetchAsync(_logger, _httpClientFactory, _uriService);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Google favicon lookup failed for {domain}.", domain);
+            return null;
+        }
     }
 
     private async Task<Icon?> GetFaviconAsync(string domain)

--- a/src/Icons/Services/IconFetchingService.cs
+++ b/src/Icons/Services/IconFetchingService.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 
 using AngleSharp.Html.Parser;
 using Bit.Icons.Extensions;

--- a/src/Icons/appsettings.SelfHosted.json
+++ b/src/Icons/appsettings.SelfHosted.json
@@ -15,5 +15,8 @@
       "internalSso": null,
       "internalScim": null
     }
+  },
+  "iconsSettings": {
+    "googleFaviconEnabled": false
   }
 }

--- a/src/Icons/appsettings.json
+++ b/src/Icons/appsettings.json
@@ -5,7 +5,8 @@
   "iconsSettings": {
     "cacheEnabled": true,
     "cacheHours": 24,
-    "cacheSizeLimit": null
+    "cacheSizeLimit": null,
+    "googleFaviconEnabled": true
   },
   "changePasswordUriSettings": {
     "cacheEnabled": true,

--- a/test/Icons.Test/Services/ServiceTestBase.cs
+++ b/test/Icons.Test/Services/ServiceTestBase.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Icons.Extensions;
+﻿using Bit.Icons;
+using Bit.Icons.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -20,6 +21,7 @@ public class ServiceTestBase
 
         _services.ConfigureHttpClients();
         _services.AddHtmlParsing();
+        _services.AddSingleton(new IconsSettings());
         _services.AddServices();
 
         _provider = _services.BuildServiceProvider();

--- a/test/Icons.Test/Services/ServiceTestBase.cs
+++ b/test/Icons.Test/Services/ServiceTestBase.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Icons;
-using Bit.Icons.Extensions;
+﻿using Bit.Icons.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-40245

## 📔 Objective

- Adds a Google Favicon API check as the first step in the icon-fetching pipeline. When Google has an icon for the domain, we skip the more expensive HTML-scrape-and-scan-for-`<link rel="icon">` flow entirely.
- The check hits `https://www.google.com/s2/favicons?domain={domain}&sz=64`, which 301-redirects through Google's internal `t0.gstatic.com/faviconV2` service and returns a PNG. The existing `IconHttpRequest` pipeline handles the redirect via its SSRF-protected client.
- When Google has no icon for the domain it responds `404`, which propagates through the existing `IconLink.FetchAsync` as a `null` return, dropping cleanly into the existing scrape → `/favicon.ico` fallback.
- Gated behind a new `IconsSettings.GoogleFaviconEnabled` config flag. Enable via `IconsSettings__GoogleFaviconEnabled=true` env var or the equivalent key in `appsettings.json`. On by default.