### PR TITLE
[PM-33046] Remove legacy cache DI registration in Events

### DIFF
--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -57,15 +57,6 @@ public class Startup
         services.AddOrganizationAbilityCache(globalSettings);
         services.AddProviderAbilityCache(globalSettings);
 
-        if (usingServiceBusAppCache)
-        {
-            services.AddSingleton<IVCurrentInMemoryApplicationCacheService, InMemoryServiceBusApplicationCacheService>();
-        }
-        else
-        {
-            services.AddSingleton<IVCurrentInMemoryApplicationCacheService, InMemoryApplicationCacheService>();
-        }
-
         services.AddEventWriteServices(globalSettings);
         services.AddScoped<IEventService, EventService>();
 


### PR DESCRIPTION
## 🎯 Objective
Part of removing the legacy in-memory application cache system (**PM-33046**). 

Ticket: https://bitwarden.atlassian.net/browse/PM-33046


## ⚠️ Merge order (important)
This is one atomic removal split into 4 stacked-by-dependency PRs, all based on `main`. To keep `main` compiling and runtime-safe, they must merge in this order:

1. `events-di` (Data Insights & Reporting) — remove DI consumer in Events
2. [`core-services`](https://github.com/bitwarden/server/pull/7959) (Core / platform) — delete cache service impls + SharedWeb DI
3. [`admin-console-repos`](https://github.com/bitwarden/server/pull/7960) (Admin Console) — delete cache interface + `GetManyAbilitiesAsync` repo methods
4. [`dbops-drop-procs`](https://github.com/bitwarden/server/pull/7961) (DB Ops) — drop the stored procedures the Dapper code called

👉 **This PR is step 1 of 4.**


## 📋 Code Changes
- `src/Events/Startup.cs` — remove the in-memory app cache service registration
