### PR TITLE
[PM-40293] feat: Trim invite-link policies endpoint to Master Password and Account Recovery

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkPoliciesQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkPoliciesQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Utilities.v2.Results;
@@ -37,7 +38,9 @@ public class GetOrganizationInviteLinkPoliciesQuery(
         }
 
         var policies = await policyRepository.GetManyByOrganizationIdAsync(organization.Id);
-        var enabledPolicies = policies.Where(p => p.Enabled).ToList();
+        var enabledPolicies = policies
+            .Where(p => p.Enabled && p.Type is PolicyType.MasterPassword or PolicyType.ResetPassword)
+            .ToList();
 
         return new CommandResult<ICollection<Policy>>(enabledPolicies);
     }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkPoliciesQueryTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkPoliciesQueryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Repositories;
@@ -14,19 +15,22 @@ namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.InviteLinks;
 public class GetOrganizationInviteLinkPoliciesQueryTests
 {
     [Theory, BitAutoData]
-    public async Task GetPoliciesAsync_WithValidInput_ReturnsOnlyEnabledPolicies(
+    public async Task GetPoliciesAsync_WithValidInput_ReturnsMasterPasswordAndResetPasswordOnly(
         Guid code,
         OrganizationInviteLink inviteLink,
         Organization organization,
-        List<Policy> policies,
         SutProvider<GetOrganizationInviteLinkPoliciesQuery> sutProvider)
     {
         organization.UsePolicies = true;
         inviteLink.OrganizationId = organization.Id;
 
-        policies[0].Enabled = true;
-        policies[1].Enabled = false;
-        policies[2].Enabled = true;
+        List<Policy> policies =
+        [
+            new Policy { Type = PolicyType.MasterPassword, Enabled = true },
+            new Policy { Type = PolicyType.ResetPassword, Enabled = true },
+            new Policy { Type = PolicyType.RequireSso, Enabled = false },
+            new Policy { Type = PolicyType.SingleOrg, Enabled = true },
+        ];
 
         SetupMocks(sutProvider, code, inviteLink, organization);
         sutProvider.GetDependency<IPolicyRepository>()
@@ -38,7 +42,8 @@ public class GetOrganizationInviteLinkPoliciesQueryTests
         Assert.True(result.IsSuccess);
         var returned = result.AsSuccess.ToList();
         Assert.Equal(2, returned.Count);
-        Assert.All(returned, p => Assert.True(p.Enabled));
+        Assert.Contains(returned, p => p.Type == PolicyType.MasterPassword);
+        Assert.Contains(returned, p => p.Type == PolicyType.ResetPassword);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40293

## 📔 Objective

GetOrganizationInviteLinkPoliciesQuery returns every enabled policy to unauthenticated callers holding an org invite link, via the anonymous `POST /organizations/invite-link/policies` endpoint. This leaks the org's full security posture (e.g. SSO-required, disable personal vault, etc.) before the caller has joined.

Surfaced by AppSec in the invite-link security review (Concern 1 — "Policy data"). Auth confirmed the pre-auth join UX only needs `PolicyType.MasterPassword` and `PolicyType.ResetPassword` (Account Recovery); this PR filters the query's response to just those two types.