### PR TITLE
[PM-40372] Fix Issue with Restoring Staged Users

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/v1/RestoreOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/v1/RestoreOrganizationUserCommand.cs
@@ -314,9 +314,11 @@ public class RestoreOrganizationUserCommand(
 
     private async Task CheckPoliciesBeforeRestoreAsync(OrganizationUser orgUser, bool userHasTwoFactorEnabled)
     {
-        // An invited OrganizationUser isn't linked with a user account yet, so these checks are irrelevant
-        // The user will be subject to the same checks when they try to accept the invite
-        if (orgUser.GetPriorActiveOrganizationUserStatusType() == OrganizationUserStatusType.Invited)
+        // An Invited or Staged OrganizationUser isn't linked with a user account yet, so these checks
+        // are irrelevant (and there is no UserId to check against). The user will be subject to the
+        // same checks when they accept the invite.
+        var priorStatus = orgUser.GetPriorActiveOrganizationUserStatusType();
+        if (priorStatus is OrganizationUserStatusType.Invited or OrganizationUserStatusType.Staged)
         {
             return;
         }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerRestoreTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerRestoreTests.cs
@@ -1,0 +1,112 @@
+﻿using System.Net;
+using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Bit.Api.AdminConsole.Models.Response.Organizations;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
+using Bit.Api.Models.Response;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Repositories;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
+
+public class OrganizationUsersControllerRestoreTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly HttpClient _client;
+    private readonly ApiApplicationFactory _factory;
+    private readonly LoginHelper _loginHelper;
+
+    private Organization _organization = null!;
+    private string _ownerEmail = null!;
+
+    public OrganizationUsersControllerRestoreTests(ApiApplicationFactory apiFactory)
+    {
+        _factory = apiFactory;
+        _client = _factory.CreateClient();
+        _loginHelper = new LoginHelper(_factory, _client);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ownerEmail = $"org-user-restore-test-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(_ownerEmail);
+
+        (_organization, _) = await OrganizationTestHelpers.SignUpAsync(_factory, plan: PlanType.EnterpriseMonthly,
+            ownerEmail: _ownerEmail, passwordManagerSeats: 10, paymentMethod: PaymentMethodType.Card);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Restore_RevokedStagedUser_ReturnsOkAndRestoresToStaged()
+    {
+        var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
+        var stagedUser = await CreateRevokedStagedUserAsync(organizationUserRepository);
+
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var request = new OrganizationUserRestoreRequest { DefaultUserCollectionName = null };
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/{stagedUser.Id}/restore/vnext", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var restoredUser = await organizationUserRepository.GetByIdAsync(stagedUser.Id);
+        Assert.NotNull(restoredUser);
+        Assert.Equal(OrganizationUserStatusType.Staged, restoredUser.Status);
+    }
+
+    [Fact]
+    public async Task BulkRestore_RevokedStagedUser_ReturnsOkWithoutErrorAndRestoresToStaged()
+    {
+        var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
+        var stagedUser = await CreateRevokedStagedUserAsync(organizationUserRepository);
+
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var request = new OrganizationUserBulkRequestModel { Ids = [stagedUser.Id] };
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/restore", request);
+        var content = await response.Content.ReadFromJsonAsync<ListResponseModel<OrganizationUserBulkResponseModel>>();
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(content);
+        Assert.Single(content.Data);
+        Assert.All(content.Data, r => Assert.Empty(r.Error));
+
+        var restoredUser = await organizationUserRepository.GetByIdAsync(stagedUser.Id);
+        Assert.NotNull(restoredUser);
+        Assert.Equal(OrganizationUserStatusType.Staged, restoredUser.Status);
+    }
+
+    /// <summary>
+    /// Creates a Staged OrganizationUser (no linked user account) and then revokes it, mirroring the
+    /// production flow that snapshots the prior Staged status onto the revoked row.
+    /// </summary>
+    private async Task<OrganizationUser> CreateRevokedStagedUserAsync(IOrganizationUserRepository organizationUserRepository)
+    {
+        var stagedUser = new OrganizationUser
+        {
+            OrganizationId = _organization.Id,
+            UserId = null,
+            Email = $"staged-{Guid.NewGuid()}@bitwarden.com",
+            Key = null,
+            Type = OrganizationUserType.User,
+            Status = OrganizationUserStatusType.Staged
+        };
+        await organizationUserRepository.CreateAsync(stagedUser);
+
+        await organizationUserRepository.RevokeAsync(stagedUser.Id, RevocationReason.Manual);
+
+        var revokedUser = await organizationUserRepository.GetByIdAsync(stagedUser.Id);
+        Assert.NotNull(revokedUser);
+        Assert.Equal(OrganizationUserStatusType.Revoked, revokedUser.Status);
+
+        return stagedUser;
+    }
+}

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/RestoreOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/RestoreUser/RestoreOrganizationUserCommandTests.cs
@@ -640,6 +640,43 @@ public class RestoreOrganizationUserCommandTests
     }
 
     [Theory, BitAutoData]
+    public async Task RestoreUser_StagedUserInFreeOrganization_Success(
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Owner)] OrganizationUser owner,
+        [OrganizationUser(OrganizationUserStatusType.Revoked)] OrganizationUser organizationUser,
+        SutProvider<RestoreOrganizationUserCommand> sutProvider)
+    {
+        // A staged user has no linked account (UserId == null) and its pre-revoke status is snapshotted
+        // onto StatusNew by the revoke flow. It must skip the account-level policy checks in
+        // CheckPoliciesBeforeRestoreAsync (which would otherwise dereference the null UserId).
+        organization.PlanType = PlanType.Free;
+        organizationUser.UserId = null;
+        organizationUser.Key = null;
+        organizationUser.Status = OrganizationUserStatusType.Revoked;
+        organizationUser.StatusNew = OrganizationUserStatusTypeNew.Staged;
+
+        RestoreUser_Setup(organization, owner, organizationUser, sutProvider);
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id).Returns(new OrganizationSeatCounts
+            {
+                Sponsored = 0,
+                Users = 1
+            });
+
+        await sutProvider.Sut.RestoreUserAsync(organizationUser, owner.Id, "");
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .RestoreAsync(organizationUser.Id, OrganizationUserStatusType.Staged);
+        await sutProvider.GetDependency<IEventService>()
+            .Received(1)
+            .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Restored);
+        await sutProvider.GetDependency<IPushNotificationService>()
+            .DidNotReceiveWithAnyArgs()
+            .PushSyncOrgKeysAsync(Arg.Any<Guid>());
+    }
+
+    [Theory, BitAutoData]
     public async Task RestoreUser_WithAutoConfirmPolicyEnabled_DeletesEmergencyAccess(
         Organization organization,
         [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Owner)] OrganizationUser owner,


### PR DESCRIPTION
## 🎟️ Tracking
[PM-40372](https://bitwarden.atlassian.net/browse/PM-40372)

## 📔 Objective
This spot was missed when implementing staged users, where they look and quack a lot like invited users with no associated user record. Folks attempting to restore right now are getting nullrefs on the user entity.

[PM-40372]: https://bitwarden.atlassian.net/browse/PM-40372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ