### PR TITLE
[PM-16095] feat: Enhance provider seat limit validation messages

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/PasswordManager/InviteUsersPasswordManagerValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/PasswordManager/InviteUsersPasswordManagerValidator.cs
@@ -99,7 +99,7 @@ public class InviteUsersPasswordManagerValidator(
 
         if (provider is not null)
         {
-            var providerValidationResult = InvitingUserOrganizationProviderValidator.Validate(new InviteOrganizationProvider(provider));
+            var providerValidationResult = InvitingUserOrganizationProviderValidator.Validate(new InviteOrganizationProvider(provider), request.Seats);
 
             if (providerValidationResult is Invalid<InviteOrganizationProvider> invalidProviderValidation)
             {

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/Provider/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/Provider/Errors.cs
@@ -7,7 +7,10 @@ public record ProviderBillableSeatLimitError(InviteOrganizationProvider InvalidR
     public const string Code = "Seat limit has been reached. Please contact your provider to add more seats.";
 }
 
-public record ProviderResellerSeatLimitError(InviteOrganizationProvider InvalidRequest) : Error<InviteOrganizationProvider>(Code, InvalidRequest)
+public record ProviderResellerSeatLimitError : Error<InviteOrganizationProvider>
 {
-    public const string Code = "Seat limit has been reached. Contact your provider to purchase additional seats.";
+    public ProviderResellerSeatLimitError(InviteOrganizationProvider invalidRequest, int? seats)
+        : base($"Seat limit of {seats} has been reached. Contact your provider to purchase additional seats.", invalidRequest)
+    {
+    }
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/Provider/InvitingUserOrganizationProviderValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Validation/Provider/InvitingUserOrganizationProviderValidator.cs
@@ -6,7 +6,7 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUse
 
 public static class InvitingUserOrganizationProviderValidator
 {
-    public static ValidationResult<InviteOrganizationProvider> Validate(InviteOrganizationProvider inviteOrganizationProvider)
+    public static ValidationResult<InviteOrganizationProvider> Validate(InviteOrganizationProvider inviteOrganizationProvider, int? seats)
     {
         if (inviteOrganizationProvider is not { Enabled: true })
         {
@@ -20,7 +20,7 @@ public static class InvitingUserOrganizationProviderValidator
 
         if (inviteOrganizationProvider.Type == ProviderType.Reseller)
         {
-            return new Invalid<InviteOrganizationProvider>(new ProviderResellerSeatLimitError(inviteOrganizationProvider));
+            return new Invalid<InviteOrganizationProvider>(new ProviderResellerSeatLimitError(inviteOrganizationProvider, seats));
         }
 
         return new Valid<InviteOrganizationProvider>(inviteOrganizationProvider);

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -733,7 +733,7 @@ public class OrganizationService : IOrganizationService
 
             if (provider.Type == ProviderType.Reseller)
             {
-                return (false, "Seat limit has been reached. Contact your provider to purchase additional seats.");
+                return (false, $"Seat limit of {organization.Seats} has been reached. Contact your provider to purchase additional seats.");
             }
         }
 

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -829,7 +829,7 @@ public class OrganizationServiceTests
         var (result, failureMessage) = await sutProvider.Sut.CanScaleAsync(organization, 10);
 
         Assert.False(result);
-        Assert.Contains("Seat limit has been reached. Contact your provider to purchase additional seats.", failureMessage);
+        Assert.Contains($"Seat limit of {organization.Seats} has been reached. Contact your provider to purchase additional seats.", failureMessage);
     }
 
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16095

## 📔 Objective

Fixes error message for reseller orgs to say how many seats they have in the error message explicitly

## 📸 Screenshots

<img width="316" height="131" alt="image" src="https://github.com/user-attachments/assets/0de6222e-2c22-411e-a8ea-3a4d303af1d8" />

