### PR TITLE
chore: update code owners to include architecture team for RustSDK

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,7 +108,7 @@ bitwarden_license/src/Services/Pam @bitwarden/team-pam-dev
 bitwarden_license/test/Services/Pam.Test @bitwarden/team-pam-dev
 
 # SDK
-util/RustSdk @bitwarden/team-sdk-sme
+util/RustSdk @bitwarden/team-sdk-sme @bitwarden/dept-architecture # joint ownership
 
 ## Docker-related files
 **/Dockerfile @bitwarden/team-appsec @bitwarden/dept-shot


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Changing to a joint ownership of the RustSDK to include the architecture team for now while we work on the Seeder.  
We'll address the long-term ownership paradox later. 
