### PR TITLE
docs: note ISNULL rolling-deploy pattern for JSON/TVP NOT NULL columns

### DIFF
--- a/.claude/rules/database-dapper.md
+++ b/.claude/rules/database-dapper.md
@@ -94,6 +94,16 @@ GO
 - Add new columns at the **end** of the column list to keep `src/Sql/dbo/` in sync.
 - For a `NOT NULL` column, add a `DEFAULT` constraint rather than backfilling rows:
   `ADD [Column] INT NOT NULL CONSTRAINT [DF_Table_Column] DEFAULT 0`. Do **not** use defaults for string columns.
+- A `NOT NULL` column written through an `OPENJSON` or TVP path also needs `ISNULL([Column], <default>)` at every
+  insert/update site. A scalar procedure parameter stays backwards-compatible via its own default (`@Column BIT = 0`),
+  but a JSON/TVP field has no per-field default — during a rolling deployment an old server omits it, `OPENJSON`
+  yields `NULL`, and the write violates the `NOT NULL` constraint. (The `OrganizationUser_CreateMany`, `_UpdateMany`,
+  and `_CreateManyWithCollectionsAndGroups` procedures are the canonical example.)
+
+  ```sql
+  SELECT ..., ISNULL(OUI.[Column], 0)                  -- INSERT ... SELECT
+  SET    ..., [Column] = ISNULL(OUI.[Column], 0)       -- UPDATE ... SET
+  ```
 
 ### Create / drop a table
 


### PR DESCRIPTION
## 🎟️ Tracking

Came out of review feedback on #7957 (PM-40208).

## 📔 Objective

Add the missing backwards-compat rule to `.claude/rules/database-dapper.md`, in the "Add a column" section right after the existing `DEFAULT`-constraint guidance:

> A `NOT NULL` column written through an `OPENJSON` or TVP path also needs `ISNULL([Column], <default>)` at every insert/update site. A scalar procedure parameter stays backwards-compatible via its own default (`@Column BIT = 0`), but a JSON/TVP field has no per-field default — during a rolling deployment an old server omits it, `OPENJSON` yields `NULL`, and the write violates the `NOT NULL` constraint.

The rule pairs directly with the adjacent default-constraint mechanic and cites the `OrganizationUser_CreateMany`/`_UpdateMany`/`_CreateManyWithCollectionsAndGroups` procedures as the canonical example. Docs/rules only — no code or schema changes.

Related contributing docs change: https://github.com/bitwarden/contributing-docs/pull/833