### PR TITLE
[PM-38749] Add endpoint to update SupportsConfirmation and inviteBlob

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
@@ -19,6 +19,7 @@ public class OrganizationInviteLinksController(
     IGetOrganizationInviteLinkQuery getOrganizationInviteLinkQuery,
     IGetOrganizationInviteLinkStatusQuery getOrganizationInviteLinkStatusQuery,
     IUpdateOrganizationInviteLinkCommand updateOrganizationInviteLinkCommand,
+    IUpdateInviteSupportConfirmCommand updateInviteSupportConfirmCommand,
     IDeleteOrganizationInviteLinkCommand deleteOrganizationInviteLinkCommand,
     IRefreshOrganizationInviteLinkCommand refreshOrganizationInviteLinkCommand,
     IValidateOrganizationInviteLinkEmailDomainQuery validateOrganizationInviteLinkEmailDomainQuery,
@@ -91,6 +92,17 @@ public class OrganizationInviteLinksController(
     public async Task<IResult> Update(Guid orgId, [FromBody] UpdateOrganizationInviteLinkRequestModel model)
     {
         var result = await updateOrganizationInviteLinkCommand.UpdateAsync(
+            model.ToCommandRequest(orgId));
+
+        return Handle(result, link =>
+            TypedResults.Ok(new OrganizationInviteLinkResponseModel(link)));
+    }
+
+    [HttpPut("support-confirm")]
+    [Authorize<ManageUsersRequirement>]
+    public async Task<IResult> UpdateInviteSupportConfirm(Guid orgId, [FromBody] UpdateInviteSupportConfirmRequestModel model)
+    {
+        var result = await updateInviteSupportConfirmCommand.UpdateAsync(
             model.ToCommandRequest(orgId));
 
         return Handle(result, link =>

--- a/src/Api/AdminConsole/Models/Request/Organizations/CreateOrganizationInviteLinkRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/CreateOrganizationInviteLinkRequestModel.cs
@@ -15,7 +15,7 @@ public class CreateOrganizationInviteLinkRequestModel
     public required IEnumerable<string> AllowedDomains { get; set; }
 
     /// <summary>
-    /// An opaque cryptographic blob. The server only stores and transports it, so its format is not
+    /// An opaque cryptographic invite. The server only stores and transports it, so its format is not
     /// validated here.
     /// </summary>
     [Required]

--- a/src/Api/AdminConsole/Models/Request/Organizations/CreateOrganizationInviteLinkRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/CreateOrganizationInviteLinkRequestModel.cs
@@ -23,7 +23,7 @@ public class CreateOrganizationInviteLinkRequestModel
     public required string Invite { get; set; }
 
     /// <summary>
-    /// Indicates if the link supports user auto confirmation (not supported yet).
+    /// Whether this invite link can be used to confirm a user.
     /// </summary>
     [Required]
     public required bool SupportsConfirmation { get; set; }

--- a/src/Api/AdminConsole/Models/Request/Organizations/RefreshOrganizationInviteLinkRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/RefreshOrganizationInviteLinkRequestModel.cs
@@ -7,7 +7,7 @@ namespace Bit.Api.AdminConsole.Models.Request.Organizations;
 public class RefreshOrganizationInviteLinkRequestModel
 {
     /// <summary>
-    /// An opaque cryptographic blob. The server only stores and transports it, so its format is not
+    /// An opaque cryptographic invite. The server only stores and transports it, so its format is not
     /// validated here.
     /// </summary>
     [Required]

--- a/src/Api/AdminConsole/Models/Request/Organizations/UpdateInviteSupportConfirmRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/UpdateInviteSupportConfirmRequestModel.cs
@@ -7,7 +7,7 @@ namespace Bit.Api.AdminConsole.Models.Request.Organizations;
 public class UpdateInviteSupportConfirmRequestModel
 {
     /// <summary>
-    /// An opaque cryptographic blob. The server only stores and transports it, so its format is not
+    /// An opaque cryptographic invite. The server only stores and transports it, so its format is not
     /// validated here.
     /// </summary>
     [Required]

--- a/src/Api/AdminConsole/Models/Request/Organizations/UpdateInviteSupportConfirmRequestModel.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/UpdateInviteSupportConfirmRequestModel.cs
@@ -4,7 +4,7 @@ using Bit.Core.Utilities;
 
 namespace Bit.Api.AdminConsole.Models.Request.Organizations;
 
-public class RefreshOrganizationInviteLinkRequestModel
+public class UpdateInviteSupportConfirmRequestModel
 {
     /// <summary>
     /// An opaque cryptographic blob. The server only stores and transports it, so its format is not
@@ -20,7 +20,7 @@ public class RefreshOrganizationInviteLinkRequestModel
     [Required]
     public required bool SupportsConfirmation { get; set; }
 
-    public RefreshOrganizationInviteLinkRequest ToCommandRequest(Guid organizationId) => new()
+    public UpdateInviteSupportConfirmRequest ToCommandRequest(Guid organizationId) => new()
     {
         OrganizationId = organizationId,
         Invite = Invite,

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IUpdateInviteSupportConfirmCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IUpdateInviteSupportConfirmCommand.cs
@@ -6,7 +6,7 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
 public interface IUpdateInviteSupportConfirmCommand
 {
     /// <summary>
-    /// Updates only the <see cref="OrganizationInviteLink.Invite"/> blob and
+    /// Updates only the <see cref="OrganizationInviteLink.Invite"/> and
     /// <see cref="OrganizationInviteLink.SupportsConfirmation"/> flag for the specified organization's invite link.
     /// </summary>
     /// <param name="request">The details for the invite link update.</param>

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IUpdateInviteSupportConfirmCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IUpdateInviteSupportConfirmCommand.cs
@@ -1,0 +1,16 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+
+public interface IUpdateInviteSupportConfirmCommand
+{
+    /// <summary>
+    /// Updates only the <see cref="OrganizationInviteLink.Invite"/> blob and
+    /// <see cref="OrganizationInviteLink.SupportsConfirmation"/> flag for the specified organization's invite link.
+    /// </summary>
+    /// <param name="request">The details for the invite link update.</param>
+    /// <returns>The updated <see cref="OrganizationInviteLink"/>, or an error if the organization does not support
+    /// invite links or a link does not exist.</returns>
+    Task<CommandResult<OrganizationInviteLink>> UpdateAsync(UpdateInviteSupportConfirmRequest request);
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/RefreshOrganizationInviteLinkRequest.cs
@@ -5,7 +5,7 @@ public record RefreshOrganizationInviteLinkRequest
     public required Guid OrganizationId { get; init; }
 
     /// <summary>
-    /// The invite link cryptographic blob.
+    /// The cryptographic invite link.
     /// </summary>
     public required string Invite { get; init; }
 

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmCommand.cs
@@ -1,0 +1,43 @@
+﻿using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.AdminConsole.Utilities.v2.Results;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+
+public class UpdateInviteSupportConfirmCommand(
+    IOrganizationInviteLinkRepository organizationInviteLinkRepository,
+    IOrganizationAbilityCacheService organizationAbilityCacheService,
+    TimeProvider timeProvider)
+    : IUpdateInviteSupportConfirmCommand
+{
+    public async Task<CommandResult<OrganizationInviteLink>> UpdateAsync(
+        UpdateInviteSupportConfirmRequest request)
+    {
+        if (!await OrganizationHasInviteLinksAbilityAsync(request.OrganizationId))
+        {
+            return new InviteLinkNotAvailable();
+        }
+
+        var inviteLink = await organizationInviteLinkRepository.GetByOrganizationIdAsync(request.OrganizationId);
+        if (inviteLink is null)
+        {
+            return new InviteLinkNotFound();
+        }
+
+        inviteLink.Invite = request.Invite;
+        inviteLink.SupportsConfirmation = request.SupportsConfirmation;
+        inviteLink.RevisionDate = timeProvider.GetUtcNow().UtcDateTime;
+
+        await organizationInviteLinkRepository.ReplaceAsync(inviteLink);
+
+        return inviteLink;
+    }
+
+    private async Task<bool> OrganizationHasInviteLinksAbilityAsync(Guid organizationId)
+    {
+        var ability = await organizationAbilityCacheService.GetOrganizationAbilityAsync(organizationId);
+        return ability is not null && ability.UseInviteLinks;
+    }
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
 
-public record RefreshOrganizationInviteLinkRequest
+public record UpdateInviteSupportConfirmRequest
 {
     public required Guid OrganizationId { get; init; }
 

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmRequest.cs
@@ -5,7 +5,7 @@ public record UpdateInviteSupportConfirmRequest
     public required Guid OrganizationId { get; init; }
 
     /// <summary>
-    /// The invite link cryptographic blob.
+    /// The cryptographic invite link.
     /// </summary>
     public required string Invite { get; init; }
 

--- a/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
+++ b/src/Core/OrganizationFeatures/OrganizationServiceCollectionExtensions.cs
@@ -207,6 +207,7 @@ public static class OrganizationServiceCollectionExtensions
         services.TryAddScoped<IValidateOrganizationInviteLinkEmailDomainQuery, ValidateOrganizationInviteLinkEmailDomainQuery>();
         services.TryAddScoped<IGetOrganizationInviteLinkStatusQuery, GetOrganizationInviteLinkStatusQuery>();
         services.TryAddScoped<IUpdateOrganizationInviteLinkCommand, UpdateOrganizationInviteLinkCommand>();
+        services.TryAddScoped<IUpdateInviteSupportConfirmCommand, UpdateInviteSupportConfirmCommand>();
         services.TryAddScoped<IDeleteOrganizationInviteLinkCommand, DeleteOrganizationInviteLinkCommand>();
         services.TryAddScoped<IRefreshOrganizationInviteLinkCommand, RefreshOrganizationInviteLinkCommand>();
         services.TryAddScoped<IAcceptOrganizationInviteLinkCommand, AcceptOrganizationInviteLinkCommand>();

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -184,6 +184,61 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
     }
 
     [Fact]
+    public async Task UpdateInviteSupportConfirmThenGet_AsOwner_UpdatesOnlyInviteAndSupportsConfirmation()
+    {
+        // Arrange
+        var createRequest = new CreateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["acme.com"],
+            Invite = _invite,
+            SupportsConfirmation = false,
+        };
+
+        var createResponse = await _client.PostAsJsonAsync(
+            $"/organizations/{_organization.Id}/invite-link", createRequest);
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(created);
+
+        const string updatedInvite = "updated-invite-blob";
+        var updateRequest = new UpdateInviteSupportConfirmRequestModel
+        {
+            Invite = updatedInvite,
+            SupportsConfirmation = true,
+        };
+
+        // Act
+        var updateResponse = await _client.PutAsJsonAsync(
+            $"/organizations/{_organization.Id}/invite-link/support-confirm", updateRequest);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, updateResponse.StatusCode);
+
+        var updated = await updateResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(updated);
+        Assert.Equal(created.Id, updated.Id);
+        Assert.Equal(created.Code, updated.Code);
+        Assert.Equal(_organization.Id, updated.OrganizationId);
+        Assert.Equal(updatedInvite, updated.Invite);
+        Assert.True(updated.SupportsConfirmation);
+        Assert.Equal(["acme.com"], updated.AllowedDomains);
+
+        var getResponse = await _client.GetAsync($"/organizations/{_organization.Id}/invite-link");
+
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var content = await getResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(content);
+        Assert.Equal(created.Id, content.Id);
+        Assert.Equal(created.Code, content.Code);
+        Assert.Equal(updatedInvite, content.Invite);
+        Assert.True(content.SupportsConfirmation);
+        Assert.Equal(["acme.com"], content.AllowedDomains);
+    }
+
+    [Fact]
     public async Task Delete_AsOwner_ReturnsNoContentAndRemovesLink()
     {
         var createRequest = new CreateOrganizationInviteLinkRequestModel

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -22,7 +22,7 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
     private readonly ApiApplicationFactory _factory;
     private readonly LoginHelper _loginHelper;
 
-    private const string _invite = "opaque-invite-blob";
+    private const string _invite = "opaque-invite";
 
     private Organization _organization = null!;
     private string _ownerEmail = null!;
@@ -202,7 +202,7 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
         var created = await createResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
         Assert.NotNull(created);
 
-        const string updatedInvite = "updated-invite-blob";
+        const string updatedInvite = "updated-invite";
         var updateRequest = new UpdateInviteSupportConfirmRequestModel
         {
             Invite = updatedInvite,

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -32,7 +32,7 @@ public class OrganizationInviteLinksControllerTests
         var model = new CreateOrganizationInviteLinkRequestModel
         {
             AllowedDomains = ["acme.com"],
-            Invite = "invite-blob",
+            Invite = "invite",
             SupportsConfirmation = false,
         };
 
@@ -53,7 +53,7 @@ public class OrganizationInviteLinksControllerTests
             .Received(1)
             .CreateAsync(Arg.Is<CreateOrganizationInviteLinkRequest>(r =>
                 r.OrganizationId == orgId &&
-                r.Invite == "invite-blob"));
+                r.Invite == "invite"));
     }
 
     [Theory, BitAutoData]
@@ -64,7 +64,7 @@ public class OrganizationInviteLinksControllerTests
         var model = new CreateOrganizationInviteLinkRequestModel
         {
             AllowedDomains = ["acme.com"],
-            Invite = "invite-blob",
+            Invite = "invite",
             SupportsConfirmation = false,
         };
 
@@ -137,7 +137,7 @@ public class OrganizationInviteLinksControllerTests
         var model = new CreateOrganizationInviteLinkRequestModel
         {
             AllowedDomains = [],
-            Invite = "invite-blob",
+            Invite = "invite",
             SupportsConfirmation = false,
         };
 
@@ -234,7 +234,7 @@ public class OrganizationInviteLinksControllerTests
 
         var model = new UpdateInviteSupportConfirmRequestModel
         {
-            Invite = "new-invite-blob",
+            Invite = "new-invite",
             SupportsConfirmation = true,
         };
 
@@ -255,7 +255,7 @@ public class OrganizationInviteLinksControllerTests
             .Received(1)
             .UpdateAsync(Arg.Is<UpdateInviteSupportConfirmRequest>(r =>
                 r.OrganizationId == orgId &&
-                r.Invite == "new-invite-blob" &&
+                r.Invite == "new-invite" &&
                 r.SupportsConfirmation));
     }
 
@@ -267,7 +267,7 @@ public class OrganizationInviteLinksControllerTests
         // Arrange
         var model = new UpdateInviteSupportConfirmRequestModel
         {
-            Invite = "new-invite-blob",
+            Invite = "new-invite",
             SupportsConfirmation = true,
         };
 
@@ -291,7 +291,7 @@ public class OrganizationInviteLinksControllerTests
         // Arrange
         var model = new UpdateInviteSupportConfirmRequestModel
         {
-            Invite = "new-invite-blob",
+            Invite = "new-invite",
             SupportsConfirmation = true,
         };
 

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -223,6 +223,91 @@ public class OrganizationInviteLinksControllerTests
     }
 
     [Theory, BitAutoData]
+    public async Task UpdateInviteSupportConfirm_WithValidInput_ReturnsOk(
+        Guid orgId,
+        OrganizationInviteLink inviteLink,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        // Arrange
+        inviteLink.OrganizationId = orgId;
+        inviteLink.AllowedDomains = "[\"acme.com\"]";
+
+        var model = new UpdateInviteSupportConfirmRequestModel
+        {
+            Invite = "new-invite-blob",
+            SupportsConfirmation = true,
+        };
+
+        sutProvider.GetDependency<IUpdateInviteSupportConfirmCommand>()
+            .UpdateAsync(Arg.Any<UpdateInviteSupportConfirmRequest>())
+            .Returns(new CommandResult<OrganizationInviteLink>(inviteLink));
+
+        // Act
+        var result = await sutProvider.Sut.UpdateInviteSupportConfirm(orgId, model);
+
+        // Assert
+        var okResult = Assert.IsType<Ok<OrganizationInviteLinkResponseModel>>(result);
+        Assert.NotNull(okResult.Value);
+        Assert.Equal(inviteLink.Id, okResult.Value.Id);
+        Assert.Equal(orgId, okResult.Value.OrganizationId);
+
+        await sutProvider.GetDependency<IUpdateInviteSupportConfirmCommand>()
+            .Received(1)
+            .UpdateAsync(Arg.Is<UpdateInviteSupportConfirmRequest>(r =>
+                r.OrganizationId == orgId &&
+                r.Invite == "new-invite-blob" &&
+                r.SupportsConfirmation == true));
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateInviteSupportConfirm_WhenNoLinkExists_ReturnsNotFound(
+        Guid orgId,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        // Arrange
+        var model = new UpdateInviteSupportConfirmRequestModel
+        {
+            Invite = "new-invite-blob",
+            SupportsConfirmation = true,
+        };
+
+        sutProvider.GetDependency<IUpdateInviteSupportConfirmCommand>()
+            .UpdateAsync(Arg.Any<UpdateInviteSupportConfirmRequest>())
+            .Returns(new CommandResult<OrganizationInviteLink>(new InviteLinkNotFound()));
+
+        // Act
+        var result = await sutProvider.Sut.UpdateInviteSupportConfirm(orgId, model);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFound<ErrorResponseModel>>(result);
+        Assert.NotNull(notFoundResult.Value);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateInviteSupportConfirm_WhenInviteLinkNotAvailable_Returns400(
+        Guid orgId,
+        SutProvider<OrganizationInviteLinksController> sutProvider)
+    {
+        // Arrange
+        var model = new UpdateInviteSupportConfirmRequestModel
+        {
+            Invite = "new-invite-blob",
+            SupportsConfirmation = true,
+        };
+
+        sutProvider.GetDependency<IUpdateInviteSupportConfirmCommand>()
+            .UpdateAsync(Arg.Any<UpdateInviteSupportConfirmRequest>())
+            .Returns(new CommandResult<OrganizationInviteLink>(new InviteLinkNotAvailable()));
+
+        // Act
+        var result = await sutProvider.Sut.UpdateInviteSupportConfirm(orgId, model);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequest<ErrorResponseModel>>(result);
+        Assert.NotNull(badRequestResult.Value);
+    }
+
+    [Theory, BitAutoData]
     public async Task GetStatus_WithValidQuery_Success(
         GetOrganizationInviteLinkStatusRequestModel model,
         OrganizationInviteLinkStatus status,

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -256,7 +256,7 @@ public class OrganizationInviteLinksControllerTests
             .UpdateAsync(Arg.Is<UpdateInviteSupportConfirmRequest>(r =>
                 r.OrganizationId == orgId &&
                 r.Invite == "new-invite-blob" &&
-                r.SupportsConfirmation == true));
+                r.SupportsConfirmation));
     }
 
     [Theory, BitAutoData]

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmCommandTests.cs
@@ -35,7 +35,7 @@ public class UpdateInviteSupportConfirmCommandTests
             Id = Guid.NewGuid(),
             Code = Guid.NewGuid(),
             OrganizationId = organizationId,
-            Invite = "old-invite-blob",
+            Invite = "old-invite",
             SupportsConfirmation = false,
             CreationDate = originalCreationDate,
             RevisionDate = originalCreationDate,
@@ -47,7 +47,7 @@ public class UpdateInviteSupportConfirmCommandTests
             .GetByOrganizationIdAsync(organizationId)
             .Returns(existingLink);
 
-        var request = CreateRequest(organizationId, "new-invite-blob", supportsConfirmation: true);
+        var request = CreateRequest(organizationId, "new-invite", supportsConfirmation: true);
 
         // Act
         var result = await sutProvider.Sut.UpdateAsync(request);
@@ -56,7 +56,7 @@ public class UpdateInviteSupportConfirmCommandTests
         Assert.True(result.IsSuccess);
         var link = result.AsSuccess;
         Assert.Same(existingLink, link);
-        Assert.Equal("new-invite-blob", link.Invite);
+        Assert.Equal("new-invite", link.Invite);
         Assert.True(link.SupportsConfirmation);
         Assert.Equal(now, link.RevisionDate);
         Assert.Equal(originalCreationDate, link.CreationDate);
@@ -77,7 +77,7 @@ public class UpdateInviteSupportConfirmCommandTests
             .GetByOrganizationIdAsync(organizationId)
             .Returns((OrganizationInviteLink?)null);
 
-        var request = CreateRequest(organizationId, "new-invite-blob", supportsConfirmation: true);
+        var request = CreateRequest(organizationId, "new-invite", supportsConfirmation: true);
 
         // Act
         var result = await sutProvider.Sut.UpdateAsync(request);
@@ -98,7 +98,7 @@ public class UpdateInviteSupportConfirmCommandTests
         var sutProvider = GetSutProvider();
         SetupAbility(sutProvider, organizationId, useInviteLinks: false);
 
-        var request = CreateRequest(organizationId, "new-invite-blob", supportsConfirmation: true);
+        var request = CreateRequest(organizationId, "new-invite", supportsConfirmation: true);
 
         // Act
         var result = await sutProvider.Sut.UpdateAsync(request);
@@ -121,7 +121,7 @@ public class UpdateInviteSupportConfirmCommandTests
             .GetOrganizationAbilityAsync(organizationId)
             .Returns((OrganizationAbility?)null);
 
-        var request = CreateRequest(organizationId, "new-invite-blob", supportsConfirmation: true);
+        var request = CreateRequest(organizationId, "new-invite", supportsConfirmation: true);
 
         // Act
         var result = await sutProvider.Sut.UpdateAsync(request);

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/UpdateInviteSupportConfirmCommandTests.cs
@@ -1,0 +1,153 @@
+﻿using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.InviteLinks;
+
+[SutProviderCustomize]
+public class UpdateInviteSupportConfirmCommandTests
+{
+    private static SutProvider<UpdateInviteSupportConfirmCommand> GetSutProvider() =>
+        new SutProvider<UpdateInviteSupportConfirmCommand>()
+            .WithFakeTimeProvider()
+            .Create();
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithValidInput_UpdatesOnlyInviteAndSupportsConfirmation(Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        var now = new DateTime(2026, 7, 16, 12, 0, 0, DateTimeKind.Utc);
+        sutProvider.GetDependency<FakeTimeProvider>().SetUtcNow(now);
+
+        SetupAbility(sutProvider, organizationId);
+
+        var originalCreationDate = now.AddDays(-5);
+        var existingLink = new OrganizationInviteLink
+        {
+            Id = Guid.NewGuid(),
+            Code = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            Invite = "old-invite-blob",
+            SupportsConfirmation = false,
+            CreationDate = originalCreationDate,
+            RevisionDate = originalCreationDate,
+        };
+        existingLink.SetAllowedDomains(["acme.com"]);
+        var originalAllowedDomains = existingLink.AllowedDomains;
+
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(organizationId)
+            .Returns(existingLink);
+
+        var request = CreateRequest(organizationId, "new-invite-blob", supportsConfirmation: true);
+
+        // Act
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        var link = result.AsSuccess;
+        Assert.Same(existingLink, link);
+        Assert.Equal("new-invite-blob", link.Invite);
+        Assert.True(link.SupportsConfirmation);
+        Assert.Equal(now, link.RevisionDate);
+        Assert.Equal(originalCreationDate, link.CreationDate);
+        Assert.Equal(originalAllowedDomains, link.AllowedDomains);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .Received(1)
+            .ReplaceAsync(existingLink);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithNoExistingLink_ReturnsNotFoundError(Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupAbility(sutProvider, organizationId);
+        sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .GetByOrganizationIdAsync(organizationId)
+            .Returns((OrganizationInviteLink?)null);
+
+        var request = CreateRequest(organizationId, "new-invite-blob", supportsConfirmation: true);
+
+        // Act
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotFound>(result.AsError);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceAsync(default!);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithoutUseInviteLinksAbility_ReturnsNotAvailableError(Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupAbility(sutProvider, organizationId, useInviteLinks: false);
+
+        var request = CreateRequest(organizationId, "new-invite-blob", supportsConfirmation: true);
+
+        // Act
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotAvailable>(result.AsError);
+
+        await sutProvider.GetDependency<IOrganizationInviteLinkRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByOrganizationIdAsync(default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateAsync_WithNullAbility_ReturnsNotAvailableError(Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns((OrganizationAbility?)null);
+
+        var request = CreateRequest(organizationId, "new-invite-blob", supportsConfirmation: true);
+
+        // Act
+        var result = await sutProvider.Sut.UpdateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        Assert.IsType<InviteLinkNotAvailable>(result.AsError);
+    }
+
+    private static void SetupAbility(
+        SutProvider<UpdateInviteSupportConfirmCommand> sutProvider,
+        Guid organizationId,
+        bool useInviteLinks = true)
+    {
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { UseInviteLinks = useInviteLinks });
+    }
+
+    private static UpdateInviteSupportConfirmRequest CreateRequest(
+        Guid organizationId,
+        string invite,
+        bool supportsConfirmation) => new()
+        {
+            OrganizationId = organizationId,
+            Invite = invite,
+            SupportsConfirmation = supportsConfirmation,
+        };
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38749

## 📔 Objective

1. Add an endpoint to update the invite and supportsConfirmation to enable or disable the confirmation flow for the invite link.
3. Add tests.

