### PR TITLE
[PM-40516] fix: Isolate ExtendedCache backplane per cache name on shared Redis

### DIFF
--- a/src/Core/Utilities/ExtendedCacheServiceCollectionExtensions.cs
+++ b/src/Core/Utilities/ExtendedCacheServiceCollectionExtensions.cs
@@ -89,7 +89,9 @@ public static class ExtendedCacheServiceCollectionExtensions
                 return services;
             }
 
-            // Using Shared Redis, TryAdd and reuse all pieces (multiplexer, distributed cache and backplane)
+            // Using Shared Redis, TryAdd and reuse the multiplexer and distributed cache.
+            // The multiplexer and distributed cache are safe to share across caches: one Redis
+            // connection serves everyone, and L2 entries are namespaced by WithCacheKeyPrefix.
 
             services.TryAddSingleton<IConnectionMultiplexer>(sp =>
                 CreateConnectionMultiplexer(sp, cacheName, globalSettings.DistributedCache.Redis.ConnectionString));
@@ -103,18 +105,24 @@ public static class ExtendedCacheServiceCollectionExtensions
                 });
             });
 
-            services.TryAddSingleton<IFusionCacheBackplane>(sp =>
-            {
-                var mux = sp.GetRequiredService<IConnectionMultiplexer>();
-                return new RedisBackplane(new RedisBackplaneOptions
+            // The backplane must be keyed per cache name. A RedisBackplane instance is bound to a
+            // single pub/sub channel (set on Subscribe), so sharing one instance across named caches
+            // collapses them onto a single channel and misroutes cross-instance invalidations. Each
+            // cache gets its own backplane while still reusing the shared multiplexer.
+            services.TryAddKeyedSingleton<IFusionCacheBackplane>(
+                cacheName,
+                (sp, _) =>
                 {
-                    ConnectionMultiplexerFactory = () => Task.FromResult(mux)
+                    var mux = sp.GetRequiredService<IConnectionMultiplexer>();
+                    return new RedisBackplane(new RedisBackplaneOptions
+                    {
+                        ConnectionMultiplexerFactory = () => Task.FromResult(mux)
+                    });
                 });
-            });
 
             fusionCacheBuilder
                 .WithRegisteredDistributedCache()
-                .WithRegisteredBackplane();
+                .WithRegisteredKeyedBackplaneByCacheName();
 
             return services;
         }

--- a/test/Core.Test/Utilities/ExtendedCacheServiceCollectionExtensionsTests.cs
+++ b/test/Core.Test/Utilities/ExtendedCacheServiceCollectionExtensionsTests.cs
@@ -257,6 +257,40 @@ public class ExtendedCacheServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddExtendedCache_SharedRedis_MultipleCaches_EachGetsIsolatedBackplane()
+    {
+        var settings = CreateGlobalSettings(new()
+        {
+            { "GlobalSettings:DistributedCache:Redis:ConnectionString", "localhost:6379" },
+            { "GlobalSettings:DistributedCache:DefaultExtendedCache:UseSharedDistributedCache", "true" }
+        });
+
+        // Shared multiplexer, as AddDistributedCache would provide
+        _services.AddSingleton(Substitute.For<IConnectionMultiplexer>());
+
+        _services.AddExtendedCache("CacheA", settings);
+        _services.AddExtendedCache("CacheB", settings);
+
+        using var provider = _services.BuildServiceProvider();
+
+        var cacheA = provider.GetRequiredKeyedService<IFusionCache>("CacheA");
+        var cacheB = provider.GetRequiredKeyedService<IFusionCache>("CacheB");
+        Assert.True(cacheA.HasBackplane);
+        Assert.True(cacheB.HasBackplane);
+
+        // Each cache must resolve its own backplane instance. Sharing a single backplane binds
+        // both caches to one pub/sub channel and misroutes cross-instance invalidations.
+        var backplaneA = provider.GetRequiredKeyedService<IFusionCacheBackplane>("CacheA");
+        var backplaneB = provider.GetRequiredKeyedService<IFusionCacheBackplane>("CacheB");
+        Assert.NotSame(backplaneA, backplaneB);
+
+        // The multiplexer is still shared across both caches
+        var muxA = provider.GetRequiredService<IConnectionMultiplexer>();
+        var muxB = provider.GetRequiredService<IConnectionMultiplexer>();
+        Assert.Same(muxA, muxB);
+    }
+
+    [Fact]
     public void AddExtendedCache_KeyedRedis_UsesSeparateMultiplexers()
     {
         var settingsA = new GlobalSettings.ExtendedCacheSettings


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.slack.com/archives/C04LE162PHA/p1784244774428999

## 📔 Objective

Distributed FusionCache invalidations were not propagating across instances. The root cause is in the shared-Redis path of `AddExtendedCache`. It registered a single unnamed `IFusionCacheBackplane` singleton and bound every named cache to it via `WithRegisteredBackplane()`. A `RedisBackplane` instance is bound to exactly one pub/sub channel at `Subscribe` time: it overwrites its `_channel` field with no guard, and `Publish` always sends to that one field. Sharing a single instance across our named caches therefore collapses them all onto whichever channel subscribed last. In practice an `OrganizationAbilities` `RemoveAsync` was publishing on the `OrganizationReports` channel, so the invalidation never reached the right cache's L1 on other nodes. API and Admin are separate processes with different registration order, so a different cache won the channel in each. That accounts for the asymmetry in the DataDog trace.

Five caches take the shared-Redis path and were all affected: `OrganizationAbilities`, `ProviderAbilities`, `OrganizationReports`, `EventIntegrations`, and the SSO persisted-grants cache.

The fix registers the backplane as a keyed singleton per cache name and resolves it with `WithRegisteredKeyedBackplaneByCacheName()`, matching the keyed-Redis path already in this file. The multiplexer and distributed cache stay shared. One Redis connection is fine to share, and L2 entries are already namespaced by the per-cache key prefix, so only the backplane needed isolating.

Added a regression test asserting that two caches on the shared-Redis path resolve distinct backplane instances while still sharing the multiplexer.