### PR TITLE
[PM-40537] fix: Only rewrite Stripe schedules for plan-migration organizations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
-    <Version>2026.7.0</Version>
+    <Version>2026.7.1</Version>
 
     <RootNamespace>Bit.$(MSBuildProjectName)</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommand.cs
@@ -132,46 +132,56 @@ public class UpdateOrganizationSubscriptionCommand(
 
         if (activeSchedule is { Phases.Count: > 0 })
         {
-            var now = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
-
-            // Stripe normalizes attached schedules into 3 phases when the subscription is mutated:
-            // an anchor phase covering current_period_start -> schedule.created becomes phases[0].
-            // Strict > on EndDate: a phase ending exactly at `now` has effectively ended, and Stripe
-            // rejects schedule updates that include past phases.
-            var migrationPhases = activeSchedule.Phases.Where(p => p.EndDate > now).ToList();
-
-            if (migrationPhases.Count == 0)
+            // PM-40537: only rewrite schedules we created for a migration — rewriting a schedule we
+            // didn't create (e.g. a Finance-built renewal) would corrupt its negotiated phases, so those
+            // fall through to the direct update. Accepted gap: a stale cohort assignment can mis-flag one.
+            var migrationPlans = await ResolvePhasePlansAsync(organization);
+            if (migrationPlans is { } plans)
             {
-                _logger.LogWarning(
-                    "{Command}: Schedule ({ScheduleId}) has no updatable phases remaining",
-                    CommandName, activeSchedule.Id);
-                return DefaultConflict;
-            }
+                var now = subscription.TestClock?.FrozenTime ?? DateTime.UtcNow;
 
-            if (migrationPhases.Count > 2)
-            {
-                _logger.LogWarning(
-                    "{Command}: Schedule ({ScheduleId}) has {PhaseCount} active phases — expected at most 2. Only the first two will be updated.",
-                    CommandName, activeSchedule.Id, migrationPhases.Count);
+                // Stripe normalizes attached schedules into 3 phases when the subscription is mutated:
+                // an anchor phase covering current_period_start -> schedule.created becomes phases[0].
+                // Strict > on EndDate: a phase ending exactly at `now` has effectively ended, and Stripe
+                // rejects schedule updates that include past phases.
+                var migrationPhases = activeSchedule.Phases.Where(p => p.EndDate > now).ToList();
+
+                if (migrationPhases.Count == 0)
+                {
+                    _logger.LogWarning(
+                        "{Command}: Schedule ({ScheduleId}) has no updatable phases remaining",
+                        CommandName, activeSchedule.Id);
+                    return DefaultConflict;
+                }
+
+                if (migrationPhases.Count > 2)
+                {
+                    _logger.LogWarning(
+                        "{Command}: Schedule ({ScheduleId}) has {PhaseCount} active phases — expected at most 2. Only the first two will be updated.",
+                        CommandName, activeSchedule.Id, migrationPhases.Count);
+                }
+
+                _logger.LogInformation(
+                    "{Command}: Active migration schedule ({ScheduleId}) found for subscription ({SubscriptionId}), updating {PhaseCount} active phase(s)",
+                    CommandName, activeSchedule.Id, subscription.Id, migrationPhases.Count);
+
+                var phases = BuildUpdatedPhases(migrationPhases, changeSet.Changes,
+                    plans.source, plans.target, subscription.Customer?.Discount);
+
+                await stripeAdapter.UpdateSubscriptionScheduleAsync(activeSchedule.Id,
+                    new SubscriptionScheduleUpdateOptions
+                    {
+                        EndBehavior = SubscriptionScheduleEndBehavior.Release,
+                        Phases = phases,
+                        ProrationBehavior = prorationBehavior
+                    });
+
+                return subscription;
             }
 
             _logger.LogInformation(
-                "{Command}: Active subscription schedule ({ScheduleId}) found for subscription ({SubscriptionId}), updating {PhaseCount} active phase(s)",
-                CommandName, activeSchedule.Id, subscription.Id, migrationPhases.Count);
-
-            var (sourcePlan, targetPlan) = await ResolvePhasePlansAsync(organization);
-            var phases = BuildUpdatedPhases(migrationPhases, changeSet.Changes, sourcePlan, targetPlan,
-                subscription.Customer?.Discount);
-
-            await stripeAdapter.UpdateSubscriptionScheduleAsync(activeSchedule.Id,
-                new SubscriptionScheduleUpdateOptions
-                {
-                    EndBehavior = SubscriptionScheduleEndBehavior.Release,
-                    Phases = phases,
-                    ProrationBehavior = prorationBehavior
-                });
-
-            return subscription;
+                "{Command}: Active schedule ({ScheduleId}) on subscription ({SubscriptionId}) is not a Bitwarden migration schedule; leaving it untouched and updating the subscription directly",
+                CommandName, activeSchedule.Id, subscription.Id);
         }
 
         var options = new SubscriptionUpdateOptions { Items = items, ProrationBehavior = prorationBehavior };
@@ -236,13 +246,12 @@ public class UpdateOrganizationSubscriptionCommand(
         }
     }
 
-    private async Task<(Plan source, Plan target)> ResolvePhasePlansAsync(Organization organization)
+    private async Task<(Plan source, Plan target)?> ResolvePhasePlansAsync(Organization organization)
     {
         var migrationPath = await TryResolveMigrationPathAsync(organization.Id);
         if (migrationPath is null)
         {
-            var current = await pricingClient.GetPlanOrThrow(organization.PlanType);
-            return (current, current);
+            return null;
         }
 
         var source = await pricingClient.GetPlanOrThrow(migrationPath.FromPlan);
@@ -360,7 +369,7 @@ public class UpdateOrganizationSubscriptionCommand(
         Discount? customerDiscount)
     {
         var phase1IsPostMigration = migrationPhases.Count == 1
-            && IsPostMigrationPhase(migrationPhases[0], sourcePlan, targetPlan);
+            && IsPostMigrationPhase(migrationPhases[0], targetPlan);
 
         var phases = new List<SubscriptionSchedulePhaseOptions>();
 
@@ -385,17 +394,11 @@ public class UpdateOrganizationSubscriptionCommand(
         return phases;
     }
 
-    // For non-migrations (source == target), a lone remaining phase always means Stripe has rolled
-    // past phase 1. For migrations, require the phase to actually use target-plan price IDs — a
-    // legacy source-priced single-phase schedule (cancelled without releasing) would otherwise have
-    // its still-valid migration discount wrongly suppressed.
-    private static bool IsPostMigrationPhase(SubscriptionSchedulePhase phase, Plan source, Plan target)
+    // A lone remaining phase counts as post-migration only when it actually uses target-plan price
+    // IDs. A legacy source-priced single-phase schedule (cancelled without releasing) would otherwise
+    // have its still-valid migration discount wrongly suppressed.
+    private static bool IsPostMigrationPhase(SubscriptionSchedulePhase phase, Plan target)
     {
-        if (ReferenceEquals(source, target))
-        {
-            return true;
-        }
-
         var targetIds = new HashSet<string>(StringComparer.Ordinal)
         {
             target.PasswordManager.StripeSeatPlanId,

--- a/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/UpdateOrganizationSubscriptionCommandTests.cs
@@ -35,12 +35,9 @@ public class UpdateOrganizationSubscriptionCommandTests
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule> { Data = [] });
 
-        // Default: no migration assignment; any plan resolution returns a single mock instance so
-        // ReferenceEquals(source, target) is true and the price mapper short-circuits.
+        // Default: no cohort assignment, so tests take the non-migration path unless SetupMigration is called.
         _assignmentRepository.GetByOrganizationIdAsync(Arg.Any<Guid>())
             .Returns((OrganizationPlanMigrationCohortAssignment?)null);
-        _pricingClient.GetPlanOrThrow(Arg.Any<PlanType>())
-            .Returns(MockPlans.Get(PlanType.EnterpriseAnnually2020));
 
         _command = new UpdateOrganizationSubscriptionCommand(
             _featureService,
@@ -1021,46 +1018,21 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_AddItem_WithSchedule_UpdatesBothPhases()
+    public async Task Run_BusinessMigration_CustomerDiscount_CarriedOntoFuturePhaseOnly()
     {
+        // Discount stacking is migration-only, so this is set up as a migration org.
         var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2020);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
 
-        SetupGetSubscription(organization, subscription);
+        SetupMigration(organization,
+            MigrationPathId.Enterprise2020AnnualToCurrent,
+            PlanType.EnterpriseAnnually2020, source,
+            PlanType.EnterpriseAnnually, target);
 
-        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+        var sourceSeat = source.PasswordManager.StripeSeatPlanId;
+        var targetSeat = target.PasswordManager.StripeSeatPlanId;
 
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new AddItem("price_storage", 3)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.ProrationBehavior == ProrationBehavior.CreateProrations &&
-                opts.EndBehavior == SubscriptionScheduleEndBehavior.Release &&
-                opts.Phases.Count == 2 &&
-                opts.Phases[0].ProrationBehavior == ProrationBehavior.None &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 3) &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_seats" && i.Quantity == 5) &&
-                opts.Phases[1].ProrationBehavior == ProrationBehavior.None &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_storage" && i.Quantity == 3) &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_seats_new" && i.Quantity == 5)));
-
-        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
-    }
-
-    [Fact]
-    public async Task Run_WithSchedule_CustomerDiscount_CarriedOntoFuturePhaseOnly()
-    {
-        var organization = CreateOrganization();
         var subscription = CreateSubscription(
             customer: new Customer
             {
@@ -1069,18 +1041,18 @@ public class UpdateOrganizationSubscriptionCommandTests
                 TaxExempt = TaxExempt.None,
                 Discount = new Discount { Coupon = new Coupon { Id = "retention" } }
             },
-            items: [("price_seats", "si_1", 5)]);
+            items: [(sourceSeat, "si_1", 5)]);
 
         SetupGetSubscription(organization, subscription);
 
-        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
+        var schedule = CreateMockSchedule(subscription.Id, [(sourceSeat, 5)], [(targetSeat, 5)]);
         schedule.Phases[1].Discounts = [new SubscriptionSchedulePhaseDiscount { CouponId = "migration-coupon" }];
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 3)]
+            Changes = [new AddItem(source.PasswordManager.StripeStoragePlanId, 3)]
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -1098,88 +1070,34 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_UpdateItemQuantity_WithSchedule_UpdatesBothPhases()
+    public async Task Run_BusinessMigration_SkipsInvoiceProcessing()
     {
+        // The migration rewrite returns early, before the send-invoice finalization path.
         var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5), ("price_storage", "si_2", 3)]);
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2020);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
 
-        SetupGetSubscription(organization, subscription);
+        SetupMigration(organization,
+            MigrationPathId.Enterprise2020AnnualToCurrent,
+            PlanType.EnterpriseAnnually2020, source,
+            PlanType.EnterpriseAnnually, target);
 
-        var schedule = CreateMockSchedule(
-            subscription.Id,
-            [("price_seats", 5), ("price_storage", 3)],
-            [("price_seats_new", 5), ("price_storage", 3)]);
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
-
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new UpdateItemQuantity("price_storage", 7)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 7) &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_storage" && i.Quantity == 7)));
-
-        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
-    }
-
-    [Fact]
-    public async Task Run_UpdateItemQuantity_Zero_WithSchedule_RemovesFromBothPhases()
-    {
-        var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5), ("price_storage", "si_2", 3)]);
-
-        SetupGetSubscription(organization, subscription);
-
-        var schedule = CreateMockSchedule(
-            subscription.Id,
-            [("price_seats", 5), ("price_storage", 3)],
-            [("price_seats_new", 5), ("price_storage", 3)]);
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
-
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new UpdateItemQuantity("price_storage", 0)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases[0].Items.All(i => i.Price != "price_storage") &&
-                opts.Phases[1].Items.All(i => i.Price != "price_storage")));
-
-        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
-    }
-
-    [Fact]
-    public async Task Run_WithSchedule_SkipsInvoiceProcessing()
-    {
-        var organization = CreateOrganization();
         var subscription = CreateSubscription(
             collectionMethod: CollectionMethod.SendInvoice,
-            items: [("price_seats", "si_1", 5)]);
+            items: [(source.PasswordManager.StripeSeatPlanId, "si_1", 5)]);
 
         SetupGetSubscription(organization, subscription);
 
-        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
+        var schedule = CreateMockSchedule(
+            subscription.Id,
+            [(source.PasswordManager.StripeSeatPlanId, 5)],
+            [(target.PasswordManager.StripeSeatPlanId, 5)]);
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new AddItem("price_storage", 1)],
+            Changes = [new AddItem(source.PasswordManager.StripeStoragePlanId, 1)],
             ChargeImmediately = true
         };
 
@@ -1191,108 +1109,6 @@ public class UpdateOrganizationSubscriptionCommandTests
         await _stripeAdapter.DidNotReceive().GetInvoiceAsync(Arg.Any<string>(), Arg.Any<InvoiceGetOptions>());
         await _stripeAdapter.DidNotReceive().FinalizeInvoiceAsync(Arg.Any<string>(), Arg.Any<InvoiceFinalizeOptions>());
         await _stripeAdapter.DidNotReceive().SendInvoiceAsync(Arg.Any<string>());
-    }
-
-    [Fact]
-    public async Task Run_AddItem_WithSinglePhaseSchedule_UpdatesOnlyPhase1()
-    {
-        var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
-
-        SetupGetSubscription(organization, subscription);
-
-        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)]);
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
-
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new AddItem("price_storage", 3)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.EndBehavior == SubscriptionScheduleEndBehavior.Release &&
-                opts.Phases.Count == 1 &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 3) &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_seats" && i.Quantity == 5)));
-
-        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
-    }
-
-    [Fact]
-    public async Task Run_AddItem_WithSchedule_Phase2Active_UpdatesOnlyPhase2()
-    {
-        var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
-
-        SetupGetSubscription(organization, subscription);
-
-        var schedule = CreateMockSchedule(
-            subscription.Id,
-            [("price_seats", 5)],
-            [("price_seats_new", 5)],
-            phase2Active: true);
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
-
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new AddItem("price_storage", 3)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases.Count == 1 &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_seats_new" && i.Quantity == 5) &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 3) &&
-                opts.Phases[0].Discounts != null && opts.Phases[0].Discounts.Count == 0));
-
-        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
-    }
-
-    [Fact]
-    public async Task Run_UpdateItemQuantity_Zero_WithSchedule_Phase2Active_RemovesFromPhase2()
-    {
-        var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5), ("price_storage", "si_2", 3)]);
-
-        SetupGetSubscription(organization, subscription);
-
-        var schedule = CreateMockSchedule(
-            subscription.Id,
-            [("price_seats", 5), ("price_storage", 3)],
-            [("price_seats_new", 5), ("price_storage", 3)],
-            phase2Active: true);
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
-
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new UpdateItemQuantity("price_storage", 0)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases.Count == 1 &&
-                opts.Phases[0].Items.All(i => i.Price != "price_storage")));
-
-        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
     }
 
     [Fact]
@@ -1585,157 +1401,20 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_NoMigrationAssignment_DoesNotTranslate()
+    public async Task Run_BusinessMigration_AllPhasesExpired_ReturnsConflict()
     {
+        // The "no updatable phases" conflict is only reachable on the migration path.
         var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2020);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
 
-        SetupGetSubscription(organization, subscription);
+        SetupMigration(organization,
+            MigrationPathId.Enterprise2020AnnualToCurrent,
+            PlanType.EnterpriseAnnually2020, source,
+            PlanType.EnterpriseAnnually, target);
 
-        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
-
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new AddItem("price_storage", 3)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases.Count == 2 &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_storage" && i.Quantity == 3) &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_seats" && i.Quantity == 5) &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_storage" && i.Quantity == 3) &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_seats_new" && i.Quantity == 5)));
-    }
-
-    [Fact]
-    public async Task Run_WithSchedule_FiltersExpiredPhases()
-    {
-        var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
-        SetupGetSubscription(organization, subscription);
-
-        var now = DateTime.UtcNow;
-        var schedule = new SubscriptionSchedule
-        {
-            Id = "sub_sched_123",
-            SubscriptionId = subscription.Id,
-            Status = SubscriptionScheduleStatus.Active,
-            EndBehavior = SubscriptionScheduleEndBehavior.Release,
-            Phases =
-            [
-                new SubscriptionSchedulePhase
-                {
-                    StartDate = now.AddDays(-30),
-                    EndDate = now.AddMinutes(-5),
-                    Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_anchor", Quantity = 1 }],
-                    ProrationBehavior = ProrationBehavior.None
-                },
-                new SubscriptionSchedulePhase
-                {
-                    StartDate = now.AddMinutes(-5),
-                    EndDate = now.AddYears(1),
-                    Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_seats", Quantity = 5 }],
-                    ProrationBehavior = ProrationBehavior.None
-                },
-                new SubscriptionSchedulePhase
-                {
-                    StartDate = now.AddYears(1),
-                    EndDate = now.AddYears(2),
-                    Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_seats_new", Quantity = 5 }],
-                    ProrationBehavior = ProrationBehavior.None
-                }
-            ]
-        };
-
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
-
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new AddItem("price_storage", 1)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases.Count == 2 &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_seats") &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_storage") &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_seats_new") &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_storage")));
-    }
-
-    [Fact]
-    public async Task Run_WithSchedule_SinglePhaseCancellation_HandlesPhase1Only()
-    {
-        var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
-        SetupGetSubscription(organization, subscription);
-
-        var now = DateTime.UtcNow;
-        var schedule = new SubscriptionSchedule
-        {
-            Id = "sub_sched_123",
-            SubscriptionId = subscription.Id,
-            Status = SubscriptionScheduleStatus.Active,
-            EndBehavior = SubscriptionScheduleEndBehavior.Release,
-            Phases =
-            [
-                new SubscriptionSchedulePhase
-                {
-                    StartDate = now.AddDays(-30),
-                    EndDate = now.AddMinutes(-5),
-                    Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_anchor", Quantity = 1 }],
-                    ProrationBehavior = ProrationBehavior.None
-                },
-                new SubscriptionSchedulePhase
-                {
-                    StartDate = now.AddMinutes(-5),
-                    EndDate = now.AddDays(7),
-                    Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_seats", Quantity = 5 }],
-                    ProrationBehavior = ProrationBehavior.None
-                }
-            ]
-        };
-
-        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
-            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
-
-        var changeSet = new OrganizationSubscriptionChangeSet
-        {
-            Changes = [new UpdateItemQuantity("price_seats", 10)]
-        };
-
-        var result = await _command.Run(organization, changeSet);
-
-        Assert.True(result.Success);
-
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases.Count == 1 &&
-                opts.Phases[0].Discounts != null &&
-                opts.Phases[0].Discounts.Count == 0 &&
-                opts.Phases[0].Items.Any(i => i.Price == "price_seats" && i.Quantity == 10)));
-    }
-
-    [Fact]
-    public async Task Run_WithSchedule_AllPhasesExpired_ReturnsConflict()
-    {
-        var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        var sourceSeat = source.PasswordManager.StripeSeatPlanId;
+        var subscription = CreateSubscription(items: [(sourceSeat, "si_1", 5)]);
         SetupGetSubscription(organization, subscription);
 
         var now = DateTime.UtcNow;
@@ -1751,7 +1430,7 @@ public class UpdateOrganizationSubscriptionCommandTests
                 {
                     StartDate = now.AddDays(-30),
                     EndDate = now.AddMinutes(-1),
-                    Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_seats", Quantity = 5 }],
+                    Items = [new SubscriptionSchedulePhaseItem { PriceId = sourceSeat, Quantity = 5 }],
                     ProrationBehavior = ProrationBehavior.None
                 }
             ]
@@ -1762,7 +1441,7 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new UpdateItemQuantity("price_seats", 10)]
+            Changes = [new UpdateItemQuantity(sourceSeat, 10)]
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -1774,10 +1453,21 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_WithSchedule_PreservesPhaseMetadata()
+    public async Task Run_BusinessMigration_PreservesPhaseMetadata()
     {
         var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2020);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        SetupMigration(organization,
+            MigrationPathId.Enterprise2020AnnualToCurrent,
+            PlanType.EnterpriseAnnually2020, source,
+            PlanType.EnterpriseAnnually, target);
+
+        var sourceSeat = source.PasswordManager.StripeSeatPlanId;
+        var targetSeat = target.PasswordManager.StripeSeatPlanId;
+
+        var subscription = CreateSubscription(items: [(sourceSeat, "si_1", 5)]);
         SetupGetSubscription(organization, subscription);
 
         var metadata = new Dictionary<string, string>
@@ -1786,7 +1476,7 @@ public class UpdateOrganizationSubscriptionCommandTests
             [MetadataKeys.MigrationCohortName] = "bar"
         };
 
-        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
+        var schedule = CreateMockSchedule(subscription.Id, [(sourceSeat, 5)], [(targetSeat, 5)]);
         schedule.Phases[0].Metadata = metadata;
         schedule.Phases[1].Metadata = metadata;
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
@@ -1794,7 +1484,7 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new UpdateItemQuantity("price_seats", 10)]
+            Changes = [new UpdateItemQuantity(sourceSeat, 10)]
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -1813,13 +1503,24 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_WithSchedule_PhaseMetadataNull_StaysNull()
+    public async Task Run_BusinessMigration_PhaseMetadataNull_StaysNull()
     {
         var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2020);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        SetupMigration(organization,
+            MigrationPathId.Enterprise2020AnnualToCurrent,
+            PlanType.EnterpriseAnnually2020, source,
+            PlanType.EnterpriseAnnually, target);
+
+        var sourceSeat = source.PasswordManager.StripeSeatPlanId;
+        var targetSeat = target.PasswordManager.StripeSeatPlanId;
+
+        var subscription = CreateSubscription(items: [(sourceSeat, "si_1", 5)]);
         SetupGetSubscription(organization, subscription);
 
-        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
+        var schedule = CreateMockSchedule(subscription.Id, [(sourceSeat, 5)], [(targetSeat, 5)]);
         schedule.Phases[0].Metadata = null;
         schedule.Phases[1].Metadata = null;
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
@@ -1827,7 +1528,7 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new UpdateItemQuantity("price_seats", 10)]
+            Changes = [new UpdateItemQuantity(sourceSeat, 10)]
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -1842,13 +1543,24 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task Run_WithSchedule_PhaseMetadataEmpty_StaysEmpty()
+    public async Task Run_BusinessMigration_PhaseMetadataEmpty_StaysEmpty()
     {
         var organization = CreateOrganization();
-        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2020);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        SetupMigration(organization,
+            MigrationPathId.Enterprise2020AnnualToCurrent,
+            PlanType.EnterpriseAnnually2020, source,
+            PlanType.EnterpriseAnnually, target);
+
+        var sourceSeat = source.PasswordManager.StripeSeatPlanId;
+        var targetSeat = target.PasswordManager.StripeSeatPlanId;
+
+        var subscription = CreateSubscription(items: [(sourceSeat, "si_1", 5)]);
         SetupGetSubscription(organization, subscription);
 
-        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
+        var schedule = CreateMockSchedule(subscription.Id, [(sourceSeat, 5)], [(targetSeat, 5)]);
         schedule.Phases[0].Metadata = new Dictionary<string, string>();
         schedule.Phases[1].Metadata = new Dictionary<string, string>();
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
@@ -1856,7 +1568,7 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         var changeSet = new OrganizationSubscriptionChangeSet
         {
-            Changes = [new UpdateItemQuantity("price_seats", 10)]
+            Changes = [new UpdateItemQuantity(sourceSeat, 10)]
         };
 
         var result = await _command.Run(organization, changeSet);
@@ -1957,17 +1669,15 @@ public class UpdateOrganizationSubscriptionCommandTests
     }
 
     [Fact]
-    public async Task ResolvePhasePlansAsync_AssignmentNull_ReturnsSameInstancePair()
+    public async Task Run_NonMigration_AssignmentNull_UpdatesSubscriptionDirectly()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
         SetupGetSubscription(organization, subscription);
+        SetupUpdateSubscription(subscription);
 
         _assignmentRepository.GetByOrganizationIdAsync(organization.Id)
             .Returns((OrganizationPlanMigrationCohortAssignment?)null);
-
-        var plan = MockPlans.Get(PlanType.EnterpriseAnnually2020);
-        _pricingClient.GetPlanOrThrow(Arg.Any<PlanType>()).Returns(plan);
 
         var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
@@ -1982,20 +1692,20 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         Assert.True(result.Success);
 
-        // Same instance pair → mapper short-circuits → both phases keep original IDs.
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases[0].Items.Any(i => i.Price == "price_seats" && i.Quantity == 10) &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_seats_new" && i.Quantity == 5)));
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionScheduleAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(o =>
+                o.Items.Any(i => i.Price == "price_seats" && i.Quantity == 10)));
     }
 
     [Fact]
-    public async Task ResolvePhasePlansAsync_CohortMissingMigrationPathId_ReturnsSameInstancePair()
+    public async Task Run_NonMigration_CohortMissingMigrationPathId_UpdatesSubscriptionDirectly()
     {
         var organization = CreateOrganization();
         var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
         SetupGetSubscription(organization, subscription);
+        SetupUpdateSubscription(subscription);
 
         var assignment = new OrganizationPlanMigrationCohortAssignment
         {
@@ -2011,9 +1721,6 @@ public class UpdateOrganizationSubscriptionCommandTests
             MigrationPathId = null
         });
 
-        var plan = MockPlans.Get(PlanType.EnterpriseAnnually2020);
-        _pricingClient.GetPlanOrThrow(Arg.Any<PlanType>()).Returns(plan);
-
         var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats_new", 5)]);
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
@@ -2027,11 +1734,11 @@ public class UpdateOrganizationSubscriptionCommandTests
 
         Assert.True(result.Success);
 
-        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
-            schedule.Id,
-            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
-                opts.Phases[0].Items.Any(i => i.Price == "price_seats" && i.Quantity == 10) &&
-                opts.Phases[1].Items.Any(i => i.Price == "price_seats_new" && i.Quantity == 5)));
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionScheduleAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(o =>
+                o.Items.Any(i => i.Price == "price_seats" && i.Quantity == 10)));
     }
 
     [Fact]
@@ -2073,6 +1780,255 @@ public class UpdateOrganizationSubscriptionCommandTests
             Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
                 opts.Phases[0].Items.Any(i => i.Price == sourceSeat && i.Quantity == 10) &&
                 opts.Phases[1].Items.Any(i => i.Price == targetSeat && i.Quantity == 10)));
+    }
+
+    [Fact]
+    public async Task Run_NonMigration_SeatChange_TwoPhaseSchedule_LeavesScheduleUntouched()
+    {
+        // Bug 1 regression: a routine seat change must not rewrite the schedule's negotiated future phase.
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        SetupGetSubscription(organization, subscription);
+        SetupUpdateSubscription(subscription);
+
+        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats", 15)]);
+        schedule.Phases[1].Discounts = [new SubscriptionSchedulePhaseDiscount { CouponId = "nego-10" }];
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new UpdateItemQuantity("price_seats", 8)]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionScheduleAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(o =>
+                o.Items.Any(i => i.Price == "price_seats" && i.Quantity == 8)));
+    }
+
+    [Fact]
+    public async Task Run_NonMigration_SinglePhaseWithCoupon_SeatChange_DoesNotTouchSchedule()
+    {
+        // Bug 2 regression: old code stripped the coupon on a lone remaining phase; the fix leaves it.
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        SetupGetSubscription(organization, subscription);
+        SetupUpdateSubscription(subscription);
+
+        var now = DateTime.UtcNow;
+        var schedule = new SubscriptionSchedule
+        {
+            Id = "sub_sched_123",
+            SubscriptionId = subscription.Id,
+            Status = SubscriptionScheduleStatus.Active,
+            EndBehavior = SubscriptionScheduleEndBehavior.Release,
+            Phases =
+            [
+                new SubscriptionSchedulePhase
+                {
+                    StartDate = now.AddDays(-30),
+                    EndDate = now.AddDays(7),
+                    Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_seats", Quantity = 5 }],
+                    Discounts = [new SubscriptionSchedulePhaseDiscount { CouponId = "nego-coupon" }],
+                    ProrationBehavior = ProrationBehavior.None
+                }
+            ]
+        };
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new UpdateItemQuantity("price_seats", 10)]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionScheduleAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(o =>
+                o.Items.Any(i => i.Price == "price_seats" && i.Quantity == 10)));
+    }
+
+    [Fact]
+    public async Task Run_NonMigration_AddItem_UpdatesSubscriptionDirectly()
+    {
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5)]);
+        SetupGetSubscription(organization, subscription);
+        SetupUpdateSubscription(subscription);
+
+        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats", 5)]);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new AddItem("price_storage", 3)]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionScheduleAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(o =>
+                o.Items.Any(i => i.Price == "price_storage" && i.Quantity == 3)));
+    }
+
+    [Fact]
+    public async Task Run_NonMigration_RemoveItem_UpdatesSubscriptionDirectly()
+    {
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(items: [("price_seats", "si_1", 5), ("price_storage", "si_2", 2)]);
+        SetupGetSubscription(organization, subscription);
+        SetupUpdateSubscription(subscription);
+
+        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats", 5)]);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new RemoveItem("price_storage")]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionScheduleAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(o =>
+                o.Items.Any(i => i.Id == "si_2" && i.Deleted == true)));
+    }
+
+    [Fact]
+    public async Task Run_NonMigration_AnnualNonStructural_WithSchedule_SetsPendingInvoiceItemInterval()
+    {
+        // Falling through with an active schedule still sets the monthly PendingInvoiceItemInterval.
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(
+            status: SubscriptionStatus.Active,
+            billingInterval: Intervals.Year,
+            items: [("price_seats", "si_1", 5)]);
+        SetupGetSubscription(organization, subscription);
+        SetupUpdateSubscription(subscription);
+
+        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats", 5)]);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new UpdateItemQuantity("price_seats", 10)]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionScheduleAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.Received(1).UpdateSubscriptionAsync(subscription.Id,
+            Arg.Is<SubscriptionUpdateOptions>(o =>
+                o.PendingInvoiceItemInterval != null &&
+                o.PendingInvoiceItemInterval.Interval == Intervals.Month));
+    }
+
+    [Fact]
+    public async Task Run_NonMigration_SendInvoiceStructural_WithSchedule_FinalizesAndSends()
+    {
+        // Falling through with an active schedule still runs the send-invoice finalization.
+        var organization = CreateOrganization();
+        var subscription = CreateSubscription(
+            collectionMethod: CollectionMethod.SendInvoice,
+            items: [("price_seats", "si_1", 5)]);
+        SetupGetSubscription(organization, subscription);
+
+        var updatedSubscription = CreateSubscription(
+            collectionMethod: CollectionMethod.SendInvoice,
+            items: [("price_seats", "si_1", 5), ("price_storage", "si_2", 1)]);
+        updatedSubscription.LatestInvoiceId = "inv_123";
+        _stripeAdapter
+            .UpdateSubscriptionAsync(subscription.Id, Arg.Any<SubscriptionUpdateOptions>())
+            .Returns(updatedSubscription);
+
+        var draftInvoice = new Invoice { Id = "inv_123", Status = InvoiceStatus.Draft };
+        _stripeAdapter.GetInvoiceAsync("inv_123", Arg.Any<InvoiceGetOptions>()).Returns(draftInvoice);
+        var finalizedInvoice = new Invoice { Id = "inv_123", Status = InvoiceStatus.Open };
+        _stripeAdapter
+            .FinalizeInvoiceAsync("inv_123", Arg.Is<InvoiceFinalizeOptions>(o => o.AutoAdvance == false))
+            .Returns(finalizedInvoice);
+
+        var schedule = CreateMockSchedule(subscription.Id, [("price_seats", 5)], [("price_seats", 5)]);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new AddItem("price_storage", 1)],
+            ChargeImmediately = true
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionScheduleAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.Received(1).GetInvoiceAsync("inv_123", Arg.Any<InvoiceGetOptions>());
+        await _stripeAdapter.Received(1).FinalizeInvoiceAsync("inv_123", Arg.Any<InvoiceFinalizeOptions>());
+        await _stripeAdapter.Received(1).SendInvoiceAsync("inv_123");
+    }
+
+    [Fact]
+    public async Task Run_Migration_SeatChange_RewritesSchedule()
+    {
+        var organization = CreateOrganization();
+        var source = MockPlans.Get(PlanType.EnterpriseAnnually2020);
+        var target = MockPlans.Get(PlanType.EnterpriseAnnually);
+
+        SetupMigration(organization,
+            MigrationPathId.Enterprise2020AnnualToCurrent,
+            PlanType.EnterpriseAnnually2020, source,
+            PlanType.EnterpriseAnnually, target);
+
+        var sourceSeat = source.PasswordManager.StripeSeatPlanId;
+        var targetSeat = target.PasswordManager.StripeSeatPlanId;
+
+        var subscription = CreateSubscription(items: [(sourceSeat, "si_1", 5)]);
+        SetupGetSubscription(organization, subscription);
+
+        var schedule = CreateMockSchedule(subscription.Id, [(sourceSeat, 5)], [(targetSeat, 5)]);
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var changeSet = new OrganizationSubscriptionChangeSet
+        {
+            Changes = [new UpdateItemQuantity(sourceSeat, 8)]
+        };
+
+        var result = await _command.Run(organization, changeSet);
+
+        Assert.True(result.Success);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            schedule.Id, Arg.Any<SubscriptionScheduleUpdateOptions>());
+        await _stripeAdapter.DidNotReceive().UpdateSubscriptionAsync(
+            Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>());
     }
 
     private void SetupMigration(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40537](https://bitwarden.atlassian.net/browse/PM-40537)

## 📔 Objective

Cherry-picks server#8035 (merged to `main`) into `hotfix-rc` for an unscheduled deployment.

Gates the Stripe schedule-rewrite branch in `UpdateOrganizationSubscriptionCommand` on `ResolvePhasePlansAsync` returning non-null — i.e. the org has a real plan-migration cohort assignment via `TryResolveMigrationPathAsync`. Previously, any active Stripe `SubscriptionSchedule` was treated as ours to rewrite during routine seat changes regardless of migration status, which clobbered a Finance-hand-built schedule on a live org (stripped seats + discount). Non-migration orgs now skip the schedule entirely and fall through to the existing direct `UpdateSubscriptionAsync` call.

Also carries the accompanying version bump to `2026.7.1` (#8038), cherry-picked from `main` as required by the hotfix-rc process.


[PM-40537]: https://bitwarden.atlassian.net/browse/PM-40537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ