### PR TITLE
Stabilize RelayPushRegistration tests

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -6,15 +6,18 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        Host
+        CreateHostBuilder(args).Build().Run();
+    }
+
+    public static IHostBuilder CreateHostBuilder(string[] args)
+    {
+        return Host
             .CreateDefaultBuilder(args)
             .UseBitwardenSdk()
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseStartup<Startup>();
             })
-            .AddSerilogFileLogging()
-            .Build()
-            .Run();
+            .AddSerilogFileLogging();
     }
 }

--- a/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
+++ b/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
@@ -126,9 +126,7 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
     protected override IHostBuilder? CreateHostBuilder()
     {
         var builder = base.CreateHostBuilder();
-        // Disable OTel in all test factories. UseBitwardenSdk() registers OTLP exporters that
-        // open gRPC channels with exponential-backoff retries; when the endpoint is unreachable
-        // (e.g. CI) the retry loop stalls response-body completion for ~136 s per request.
+        // Disable OTel to prevent OTLP export attempts hanging test runs in CI.
         builder?.ConfigureAppConfiguration((_, config) =>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>

--- a/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
+++ b/test/IntegrationTestCommon/Factories/WebApplicationFactoryBase.cs
@@ -15,6 +15,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -120,6 +121,22 @@ public abstract class WebApplicationFactoryBase<T> : WebApplicationFactory<T>
                 { key, value },
             });
         });
+    }
+
+    protected override IHostBuilder? CreateHostBuilder()
+    {
+        var builder = base.CreateHostBuilder();
+        // Disable OTel in all test factories. UseBitwardenSdk() registers OTLP exporters that
+        // open gRPC channels with exponential-backoff retries; when the endpoint is unreachable
+        // (e.g. CI) the retry loop stalls response-body completion for ~136 s per request.
+        builder?.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                { "OpenTelemetry:Enabled", "false" },
+            });
+        });
+        return builder;
     }
 
     /// <summary>


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

It appears that the integration tests were trying to upload traces and metrics which seems to add some stress/delays to these tests. This seems to improve all tests from taking ~18 minutes to ~12 minutes. It still seems wild to me that this one test was the only one that ever failed in response to this but my testing has shown that it does not fail after this change so far. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
