### PR TITLE
[PM-40751] fix: Sales-assisted trials email copy

### DIFF
--- a/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.cs
+++ b/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.cs
@@ -42,41 +42,37 @@ public class SalesAssistedTrialInvitationEmailView : BaseMailView
     public required int ExpiryDays { get; set; }
 
     public string HeroTitle => TrialLength > 0
-        ? $"You're invited to start a <b>{TrialLength}-day free trial</b> of {ProductName}"
+        ? $"You're invited to start a <b>{TrialLength}-day<br/>free trial</b> of {ProductName}"
         : $"You're invited to try <b>{ProductName}</b>";
 
     public string ProductName => ProductTier switch
     {
+        ProductTierType.Free => "Bitwarden",
         ProductTierType.Families => "Bitwarden Families",
         ProductTierType.Teams => "Bitwarden Teams",
-        ProductTierType.TeamsStarter => "Bitwarden Teams Starter",
         ProductTierType.Enterprise => "Bitwarden Enterprise",
-        _ => "Bitwarden"
+        _ => throw new InvalidOperationException($"Unexpected ProductTierType: {ProductTier}")
     };
 
     public string SpotImageUrl => ProductTier switch
     {
-        ProductTierType.Families => "https://assets.bitwarden.com/email/v1/spot-family-homes.png",
         ProductTierType.Free => "https://assets.bitwarden.com/email/v1/account-fill.png",
+        ProductTierType.Families => "https://assets.bitwarden.com/email/v1/spot-family-homes.png",
         ProductTierType.Teams => "https://assets.bitwarden.com/email/v1/spot-enterprise.png",
-        ProductTierType.TeamsStarter => "https://assets.bitwarden.com/email/v1/spot-enterprise.png",
         ProductTierType.Enterprise => "https://assets.bitwarden.com/email/v1/spot-enterprise.png",
-        _ => "https://assets.bitwarden.com/email/v1/spot-enterprise.png"
+        _ => throw new InvalidOperationException($"Unexpected ProductTierType: {ProductTier}")
     };
 
     public IEnumerable<string> Features => ProductTier switch
     {
+        ProductTierType.Free => [],
         ProductTierType.Families =>
         [
             "Securely store and share passwords, credentials, and sensitive data",
             "Cover up to 6 family members, each with their own personal encrypted vault",
             "Store up to 5GB of encrypted file attachments",
         ],
-        ProductTierType.Free =>
-        [
-            "Securely store and share passwords, credentials, and sensitive data",
-        ],
-        ProductTierType.Teams or ProductTierType.TeamsStarter =>
+        ProductTierType.Teams =>
         [
             "Securely store and share passwords, credentials, and sensitive data",
             "Manage team access with group-based permissions and admin controls",
@@ -88,7 +84,7 @@ public class SalesAssistedTrialInvitationEmailView : BaseMailView
             "Enforce security policies across your entire organization",
             "Integrate with your existing SSO provider and directory services",
         ],
-        _ => []
+        _ => throw new InvalidOperationException($"Unexpected ProductTierType: {ProductTier}")
     };
 
     /// <summary>

--- a/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.cs
+++ b/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.cs
@@ -57,6 +57,10 @@ public class SalesAssistedTrialInvitationEmailView : BaseMailView
     public string SpotImageUrl => ProductTier switch
     {
         ProductTierType.Families => "https://assets.bitwarden.com/email/v1/spot-family-homes.png",
+        ProductTierType.Free => "https://assets.bitwarden.com/email/v1/account-fill.png",
+        ProductTierType.Teams => "https://assets.bitwarden.com/email/v1/spot-enterprise.png",
+        ProductTierType.TeamsStarter => "https://assets.bitwarden.com/email/v1/spot-enterprise.png",
+        ProductTierType.Enterprise => "https://assets.bitwarden.com/email/v1/spot-enterprise.png",
         _ => "https://assets.bitwarden.com/email/v1/spot-enterprise.png"
     };
 
@@ -68,12 +72,23 @@ public class SalesAssistedTrialInvitationEmailView : BaseMailView
             "Cover up to 6 family members, each with their own personal encrypted vault",
             "Store up to 5GB of encrypted file attachments",
         ],
-        _ =>
+        ProductTierType.Free =>
+        [
+            "Securely store and share passwords, credentials, and sensitive data",
+        ],
+        ProductTierType.Teams or ProductTierType.TeamsStarter =>
         [
             "Securely store and share passwords, credentials, and sensitive data",
             "Manage team access with group-based permissions and admin controls",
             "Connect to your directory service for automated user provisioning",
-        ]
+        ],
+        ProductTierType.Enterprise =>
+        [
+            "Securely store and share passwords, credentials, and sensitive data",
+            "Enforce security policies across your entire organization",
+            "Integrate with your existing SSO provider and directory services",
+        ],
+        _ => []
     };
 
     /// <summary>

--- a/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.html.hbs
+++ b/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.html.hbs
@@ -231,7 +231,7 @@
         <tbody>
           
               <tr>
-                <td align="left" style="font-size:0px;padding:15px 15px 8px 15px;word-break:break-word;">
+                <td align="left" style="font-size:0px;padding:15px 15px 24px 15px;word-break:break-word;">
                   
       <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#1B2029;">Your Bitwarden contact, <b>{{SenderEmail}}</b>, has arranged this trial for you.</div>
     

--- a/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.html.hbs
+++ b/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.html.hbs
@@ -237,7 +237,7 @@
     
                 </td>
               </tr>
-            
+            {{#if Features}}
               <tr>
                 <td align="left" style="font-size:0px;padding:0px 15px 8px 15px;word-break:break-word;">
                   
@@ -254,7 +254,7 @@
     
                 </td>
               </tr>
-            
+            {{/if}}
         </tbody>
       </table>
     

--- a/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.text.hbs
+++ b/src/Core/Billing/Models/Mail/Mailer/SalesAssistedTrialInvitationEmailView.text.hbs
@@ -1,10 +1,12 @@
 {{#>FullTextLayout}}
 Your Bitwarden contact, {{SenderEmail}}, has arranged this trial for you.
 
+{{#if Features}}
 {{#if TrialLength}}During your {{TrialLength}}-day free trial of {{ProductName}}, your team can:{{else}}With your {{ProductName}} plan, your team can:{{/if}}
 {{#each Features}}
   • {{this}}
 {{/each}}
+{{/if}}
 
 Get started:
 {{{Url}}}

--- a/src/Core/Billing/TrialInitiation/Registration/Implementations/SendSalesAssistedTrialInvitationCommand.cs
+++ b/src/Core/Billing/TrialInitiation/Registration/Implementations/SendSalesAssistedTrialInvitationCommand.cs
@@ -26,6 +26,11 @@ public class SendSalesAssistedTrialInvitationCommand(
         int trialLength,
         bool paymentOptional)
     {
+        if (productTier == ProductTierType.TeamsStarter)
+        {
+            throw new BadRequestException("Teams Starter is no longer available for new trials.");
+        }
+
         if (trialLength is < 0 or > 30)
         {
             throw new BadRequestException("Trial length must be between 0 and 30 days.");

--- a/src/Core/MailTemplates/Mjml/emails/Billing/TrialInitiation/SalesAssistedTrialInvitationEmailView.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/Billing/TrialInitiation/SalesAssistedTrialInvitationEmailView.mjml
@@ -19,6 +19,7 @@
           <mj-text padding="15px 15px 8px 15px">
             Your Bitwarden contact, <b>{{SenderEmail}}</b>, has arranged this trial for you.
           </mj-text>
+          <mj-raw>{{#if Features}}</mj-raw>
           <mj-text padding="0px 15px 8px 15px">
             {{#if TrialLength}}During your {{TrialLength}}-day free trial of {{ProductName}}, your team can:{{else}}With your {{ProductName}} plan, your team can:{{/if}}
           </mj-text>
@@ -26,6 +27,7 @@
             <ul style="margin: 0; padding-left: 20px; list-style-type: disc;">{{#each Features}}<li style="margin-bottom: 8px; line-height: 24px;">{{this}}</li>
 {{/each}}</ul>
           </mj-text>
+          <mj-raw>{{/if}}</mj-raw>
         </mj-column>
       </mj-section>
 

--- a/src/Core/MailTemplates/Mjml/emails/Billing/TrialInitiation/SalesAssistedTrialInvitationEmailView.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/Billing/TrialInitiation/SalesAssistedTrialInvitationEmailView.mjml
@@ -16,7 +16,7 @@
     <mj-wrapper padding="5px 20px 8px 20px">
       <mj-section background-color="#fff" padding="10px 10px 0px 10px">
         <mj-column>
-          <mj-text padding="15px 15px 8px 15px">
+          <mj-text padding="15px 15px 24px 15px">
             Your Bitwarden contact, <b>{{SenderEmail}}</b>, has arranged this trial for you.
           </mj-text>
           <mj-raw>{{#if Features}}</mj-raw>

--- a/test/Core.Test/Billing/TrialInitiation/SalesAssistedTrialInvitationEmailViewTests.cs
+++ b/test/Core.Test/Billing/TrialInitiation/SalesAssistedTrialInvitationEmailViewTests.cs
@@ -21,13 +21,11 @@ public class SalesAssistedTrialInvitationEmailViewTests
         };
 
     [Fact]
-    public void Features_Free_ReturnsSharedBulletOnly()
+    public void Features_Free_ReturnsEmpty()
     {
         var view = CreateView(ProductTierType.Free);
 
-        Assert.Equal(
-            ["Securely store and share passwords, credentials, and sensitive data"],
-            view.Features);
+        Assert.Empty(view.Features);
     }
 
     [Fact]
@@ -44,12 +42,10 @@ public class SalesAssistedTrialInvitationEmailViewTests
             view.Features);
     }
 
-    [Theory]
-    [InlineData(ProductTierType.Teams)]
-    [InlineData(ProductTierType.TeamsStarter)]
-    public void Features_Teams_ReturnsTeamsCopy(ProductTierType productTier)
+    [Fact]
+    public void Features_Teams_ReturnsTeamsCopy()
     {
-        var view = CreateView(productTier);
+        var view = CreateView(ProductTierType.Teams);
 
         Assert.Equal(
             [
@@ -74,20 +70,10 @@ public class SalesAssistedTrialInvitationEmailViewTests
             view.Features);
     }
 
-    [Fact]
-    public void Features_EnterpriseAndTeams_AreNotIdentical()
-    {
-        var enterprise = CreateView(ProductTierType.Enterprise).Features;
-        var teams = CreateView(ProductTierType.Teams).Features;
-
-        Assert.NotEqual(teams, enterprise);
-    }
-
     [Theory]
     [InlineData(ProductTierType.Families, "https://assets.bitwarden.com/email/v1/spot-family-homes.png")]
     [InlineData(ProductTierType.Free, "https://assets.bitwarden.com/email/v1/account-fill.png")]
     [InlineData(ProductTierType.Teams, "https://assets.bitwarden.com/email/v1/spot-enterprise.png")]
-    [InlineData(ProductTierType.TeamsStarter, "https://assets.bitwarden.com/email/v1/spot-enterprise.png")]
     [InlineData(ProductTierType.Enterprise, "https://assets.bitwarden.com/email/v1/spot-enterprise.png")]
     public void SpotImageUrl_ReturnsTierBucketedImage(ProductTierType productTier, string expectedUrl)
     {

--- a/test/Core.Test/Billing/TrialInitiation/SalesAssistedTrialInvitationEmailViewTests.cs
+++ b/test/Core.Test/Billing/TrialInitiation/SalesAssistedTrialInvitationEmailViewTests.cs
@@ -1,0 +1,98 @@
+﻿using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Models.Mail.Mailer;
+using Bit.Core.Settings;
+using Xunit;
+
+namespace Bit.Core.Test.Billing.TrialInitiation;
+
+public class SalesAssistedTrialInvitationEmailViewTests
+{
+    private static SalesAssistedTrialInvitationEmailView CreateView(ProductTierType productTier) =>
+        new(new GlobalSettings())
+        {
+            Token = "token",
+            Email = "prospect@example.com",
+            ProductTier = productTier,
+            Products = [ProductType.PasswordManager],
+            TrialLength = 7,
+            PaymentOptional = false,
+            SenderEmail = "sales@bitwarden.com",
+            ExpiryDays = 5,
+        };
+
+    [Fact]
+    public void Features_Free_ReturnsSharedBulletOnly()
+    {
+        var view = CreateView(ProductTierType.Free);
+
+        Assert.Equal(
+            ["Securely store and share passwords, credentials, and sensitive data"],
+            view.Features);
+    }
+
+    [Fact]
+    public void Features_Families_ReturnsFamiliesCopy()
+    {
+        var view = CreateView(ProductTierType.Families);
+
+        Assert.Equal(
+            [
+                "Securely store and share passwords, credentials, and sensitive data",
+                "Cover up to 6 family members, each with their own personal encrypted vault",
+                "Store up to 5GB of encrypted file attachments",
+            ],
+            view.Features);
+    }
+
+    [Theory]
+    [InlineData(ProductTierType.Teams)]
+    [InlineData(ProductTierType.TeamsStarter)]
+    public void Features_Teams_ReturnsTeamsCopy(ProductTierType productTier)
+    {
+        var view = CreateView(productTier);
+
+        Assert.Equal(
+            [
+                "Securely store and share passwords, credentials, and sensitive data",
+                "Manage team access with group-based permissions and admin controls",
+                "Connect to your directory service for automated user provisioning",
+            ],
+            view.Features);
+    }
+
+    [Fact]
+    public void Features_Enterprise_ReturnsEnterpriseCopy()
+    {
+        var view = CreateView(ProductTierType.Enterprise);
+
+        Assert.Equal(
+            [
+                "Securely store and share passwords, credentials, and sensitive data",
+                "Enforce security policies across your entire organization",
+                "Integrate with your existing SSO provider and directory services",
+            ],
+            view.Features);
+    }
+
+    [Fact]
+    public void Features_EnterpriseAndTeams_AreNotIdentical()
+    {
+        var enterprise = CreateView(ProductTierType.Enterprise).Features;
+        var teams = CreateView(ProductTierType.Teams).Features;
+
+        Assert.NotEqual(teams, enterprise);
+    }
+
+    [Theory]
+    [InlineData(ProductTierType.Families, "https://assets.bitwarden.com/email/v1/spot-family-homes.png")]
+    [InlineData(ProductTierType.Free, "https://assets.bitwarden.com/email/v1/account-fill.png")]
+    [InlineData(ProductTierType.Teams, "https://assets.bitwarden.com/email/v1/spot-enterprise.png")]
+    [InlineData(ProductTierType.TeamsStarter, "https://assets.bitwarden.com/email/v1/spot-enterprise.png")]
+    [InlineData(ProductTierType.Enterprise, "https://assets.bitwarden.com/email/v1/spot-enterprise.png")]
+    public void SpotImageUrl_ReturnsTierBucketedImage(ProductTierType productTier, string expectedUrl)
+    {
+        var view = CreateView(productTier);
+
+        Assert.Equal(expectedUrl, view.SpotImageUrl);
+    }
+}

--- a/test/Core.Test/Billing/TrialInitiation/SendSalesAssistedTrialInvitationCommandTests.cs
+++ b/test/Core.Test/Billing/TrialInitiation/SendSalesAssistedTrialInvitationCommandTests.cs
@@ -193,4 +193,24 @@ public class SendSalesAssistedTrialInvitationCommandTests
         await Assert.ThrowsAsync<BadRequestException>(() =>
             sutProvider.Sut.HandleAsync(email, name, senderEmail, ProductTierType.Enterprise, products, 0, true));
     }
+
+    [Theory]
+    [BitAutoData]
+    public async Task HandleAsync_TeamsStarter_ThrowsBadRequest(
+        string email,
+        string name,
+        string senderEmail,
+        SutProvider<SendSalesAssistedTrialInvitationCommand> sutProvider)
+    {
+        // Arrange
+        var products = new[] { ProductType.PasswordManager };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.HandleAsync(email, name, senderEmail, ProductTierType.TeamsStarter, products, 7, false));
+
+        await sutProvider.GetDependency<IMailer>()
+            .DidNotReceiveWithAnyArgs()
+            .SendEmail(Arg.Any<SalesAssistedTrialInvitationEmail>());
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-40751](https://bitwarden.atlassian.net/browse/PM-40751)
[PM-40752](https://bitwarden.atlassian.net/browse/PM-40752)

Parent: [PM-38388](https://bitwarden.atlassian.net/browse/PM-38388)

## 📔 Objective

Fixes the following issues with email template copy:
- Updates feature list for _Enterprise_, _Families_, and _Free_ product tiers.
- Adds a line break in hero text between trial length and product tier.
- Adds an additional in-command check to guard against _Teams Starter_ product tier, _deprecated_ and not available for this feature. _Teams Starter_ is already omitted from Admin form; this hardens that stance in the command -- not specifically in-scope of the filed issue, but helpful.
- Switches on product tier have had defaults removed and each tier defined explicity: sales-assisted supports a predefined set of product tiers; other presented product tiers should throw unconditionally.

Tests have been added to guard against regression.

## 📸 Screenshots

See [PM-40751](https://bitwarden.atlassian.net/browse/PM-40751) for rendered screenshots of all email templates.



[PM-40751]: https://bitwarden.atlassian.net/browse/PM-40751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-40752]: https://bitwarden.atlassian.net/browse/PM-40752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-38388]: https://bitwarden.atlassian.net/browse/PM-38388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-40751]: https://bitwarden.atlassian.net/browse/PM-40751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ