### PR TITLE
Auth/PM-40869 - SSO JIT - adjust email verification logic

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/AccountController.cs
+++ b/bitwarden_license/src/Sso/Controllers/AccountController.cs
@@ -53,7 +53,6 @@ public class AccountController : Controller
     private readonly IGlobalSettings _globalSettings;
     private readonly Core.Services.IEventService _eventService;
     private readonly IDataProtectorTokenFactory<SsoTokenable> _dataProtector;
-    private readonly IOrganizationDomainRepository _organizationDomainRepository;
     private readonly IRegisterUserCommand _registerUserCommand;
 
     public AccountController(
@@ -74,7 +73,6 @@ public class AccountController : Controller
         IGlobalSettings globalSettings,
         Core.Services.IEventService eventService,
         IDataProtectorTokenFactory<SsoTokenable> dataProtector,
-        IOrganizationDomainRepository organizationDomainRepository,
         IRegisterUserCommand registerUserCommand)
     {
         _schemeProvider = schemeProvider;
@@ -94,7 +92,6 @@ public class AccountController : Controller
         _eventService = eventService;
         _globalSettings = globalSettings;
         _dataProtector = dataProtector;
-        _organizationDomainRepository = organizationDomainRepository;
         _registerUserCommand = registerUserCommand;
     }
 
@@ -657,19 +654,9 @@ public class AccountController : Controller
             }
         }
 
-        // If the email domain is verified, we can mark the email as verified
         if (string.IsNullOrWhiteSpace(email))
         {
             throw new Exception(_i18nService.T("CannotFindEmailClaim"));
-        }
-
-        var emailVerified = false;
-        var emailDomain = CoreHelpers.GetEmailDomain(email);
-        if (!string.IsNullOrWhiteSpace(emailDomain))
-        {
-            var organizationDomain =
-                await _organizationDomainRepository.GetDomainByOrgIdAndDomainNameAsync(organization.Id, emailDomain);
-            emailVerified = organizationDomain?.VerifiedDate.HasValue ?? false;
         }
 
         //--------------------------------------------------
@@ -679,7 +666,6 @@ public class AccountController : Controller
         {
             Name = name,
             Email = email,
-            EmailVerified = emailVerified,
             ApiKey = CoreHelpers.SecureRandomString(30)
         };
 

--- a/bitwarden_license/test/SSO.Test/Controllers/AccountControllerTest.cs
+++ b/bitwarden_license/test/SSO.Test/Controllers/AccountControllerTest.cs
@@ -6,6 +6,7 @@ using Bit.Core.Auth.Entities;
 using Bit.Core.Auth.Models.Business.Tokenables;
 using Bit.Core.Auth.Models.Data;
 using Bit.Core.Auth.Repositories;
+using Bit.Core.Auth.UserFeatures.Registration;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Repositories;
@@ -560,6 +561,120 @@ public class AccountControllerTest
         Assert.Equal(1, orgGet);
         Assert.Equal(0, orgUserGetByOrg);
         Assert.Equal(1, orgUserGetByEmail);
+    }
+
+    [Theory, BitAutoData]
+    public async Task ExternalCallback_JitProvision_NewUserAndOrgUserCreated_DoesNotMarkEmailVerified(
+        SutProvider<AccountController> sutProvider)
+    {
+        // Arrange - Scenario 2: no existing User, no existing OrganizationUser. The JIT
+        // flow creates both a new User and a new OrganizationUser. The controller must
+        // not flip EmailVerified on the newly-created User: the flag reflects proof of
+        // inbox ownership, and JIT does not establish that.
+        var orgId = Guid.NewGuid();
+        var providerUserId = "ext-jit-new-user";
+        var email = "user@example.com";
+        var organization = new Organization { Id = orgId, Name = "Org", Seats = null };
+
+        var authResult = BuildSuccessfulExternalAuth(orgId, providerUserId, email);
+        SetupHttpContextWithAuth(sutProvider, authResult);
+
+        var ssoConfigRepository = sutProvider.GetDependency<ISsoConfigRepository>();
+        var userRepository = sutProvider.GetDependency<IUserRepository>();
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var organizationUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
+        var registerUserCommand = sutProvider.GetDependency<IRegisterUserCommand>();
+
+        var ssoConfig = new SsoConfig { OrganizationId = orgId, Enabled = true };
+        var ssoData = new SsoConfigurationData();
+        ssoConfig.SetData(ssoData);
+        ssoConfigRepository.GetByOrganizationIdAsync(orgId).Returns(ssoConfig);
+
+        userRepository.GetBySsoUserAsync(providerUserId, orgId).Returns((User?)null);
+        userRepository.GetByEmailAsync(email).Returns((User?)null);
+        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        organizationUserRepository.GetByOrganizationEmailAsync(orgId, email).Returns((OrganizationUser?)null);
+
+        sutProvider.GetDependency<IIdentityServerInteractionService>()
+            .GetAuthorizationContextAsync("~/").Returns((AuthorizationRequest?)null);
+
+        // Act
+        try
+        {
+            _ = await sutProvider.Sut.ExternalCallback();
+        }
+        catch
+        {
+            // ExternalCallback's post-provision sign-in path may throw in the SutProvider
+            // harness; the RegisterSSOAutoProvisionedUserAsync call under test fires
+            // before that point.
+        }
+
+        // Assert
+        await registerUserCommand.Received(1).RegisterSSOAutoProvisionedUserAsync(
+            Arg.Is<User>(u => u.Email == email && u.EmailVerified == false),
+            Arg.Is<Organization>(o => o.Id == orgId));
+    }
+
+    [Theory, BitAutoData]
+    public async Task ExternalCallback_JitProvision_ExistingInvitedOrgUser_DoesNotMarkEmailVerified(
+        SutProvider<AccountController> sutProvider)
+    {
+        // Arrange - Scenario 3: no existing User, but there IS an existing OrganizationUser
+        // row invited by email. The JIT flow creates a new User and links it. The controller
+        // must not flip EmailVerified on the newly-created User: the flag reflects proof of
+        // inbox ownership, and JIT does not establish that.
+        var orgId = Guid.NewGuid();
+        var providerUserId = "ext-jit-invited-orguser";
+        var email = "invited@example.com";
+        var organization = new Organization { Id = orgId, Name = "Org", Seats = null };
+        var existingOrgUser = new OrganizationUser
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            Email = email,
+            Status = OrganizationUserStatusType.Invited,
+            Type = OrganizationUserType.User
+        };
+
+        var authResult = BuildSuccessfulExternalAuth(orgId, providerUserId, email);
+        SetupHttpContextWithAuth(sutProvider, authResult);
+
+        var ssoConfigRepository = sutProvider.GetDependency<ISsoConfigRepository>();
+        var userRepository = sutProvider.GetDependency<IUserRepository>();
+        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
+        var organizationUserRepository = sutProvider.GetDependency<IOrganizationUserRepository>();
+        var registerUserCommand = sutProvider.GetDependency<IRegisterUserCommand>();
+
+        var ssoConfig = new SsoConfig { OrganizationId = orgId, Enabled = true };
+        var ssoData = new SsoConfigurationData();
+        ssoConfig.SetData(ssoData);
+        ssoConfigRepository.GetByOrganizationIdAsync(orgId).Returns(ssoConfig);
+
+        userRepository.GetBySsoUserAsync(providerUserId, orgId).Returns((User?)null);
+        userRepository.GetByEmailAsync(email).Returns((User?)null);
+        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        organizationUserRepository.GetByOrganizationEmailAsync(orgId, email).Returns(existingOrgUser);
+
+        sutProvider.GetDependency<IIdentityServerInteractionService>()
+            .GetAuthorizationContextAsync("~/").Returns((AuthorizationRequest?)null);
+
+        // Act
+        try
+        {
+            _ = await sutProvider.Sut.ExternalCallback();
+        }
+        catch
+        {
+            // ExternalCallback's post-provision sign-in path may throw in the SutProvider
+            // harness; the RegisterSSOAutoProvisionedUserAsync call under test fires
+            // before that point.
+        }
+
+        // Assert
+        await registerUserCommand.Received(1).RegisterSSOAutoProvisionedUserAsync(
+            Arg.Is<User>(u => u.Email == email && u.EmailVerified == false),
+            Arg.Is<Organization>(o => o.Id == orgId));
     }
 
     [Theory, BitAutoData]

--- a/bitwarden_license/test/Sso.IntegrationTest/Controllers/AccountControllerTests.cs
+++ b/bitwarden_license/test/Sso.IntegrationTest/Controllers/AccountControllerTests.cs
@@ -764,6 +764,58 @@ public class AccountControllerTests(SsoApplicationFactory factory) : IClassFixtu
     }
 
     /*
+    * JIT-provisioning must not mark EmailVerified, even when the org has a
+    * DNS-verified domain matching the email.
+    */
+    [Fact]
+    public async Task ExternalCallback_JitProvision_WithVerifiedDomain_DoesNotMarkEmailVerified()
+    {
+        // Arrange - JIT scenario with an SSO-enabled org.
+        var testData = await new SsoTestDataBuilder()
+            .WithSsoConfig()
+            .BuildAsync();
+
+        // SsoTestDataBuilder mocks the IdP to assert emails under @test.com. Seed a
+        // verified OrganizationDomain matching that domain so the JIT flow would see
+        // a verified-domain match if it still consulted it.
+        var verifiedDomain = new OrganizationDomain
+        {
+            OrganizationId = testData.Organization!.Id,
+            DomainName = "test.com",
+            Txt = "bw=verification"
+        };
+        verifiedDomain.SetVerifiedDate();
+        var domainRepo = testData.Factory.Services.GetRequiredService<IOrganizationDomainRepository>();
+        await domainRepo.CreateAsync(verifiedDomain);
+
+        var client = testData.Factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        });
+
+        // Act
+        var response = await client.GetAsync("/Account/ExternalCallback");
+
+        // Assert - Callback should succeed (existing coverage).
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Redirect,
+            $"Expected success/redirect but got {response.StatusCode}");
+
+        // Fetch the newly-provisioned User via the created OrganizationUser row.
+        // The JIT scenario seeds no User, so the org user record just created is the one.
+        var orgUserRepo = testData.Factory.Services.GetRequiredService<IOrganizationUserRepository>();
+        var orgUsers = await orgUserRepo.GetManyByOrganizationAsync(testData.Organization!.Id, type: null);
+        var newOrgUser = Assert.Single(orgUsers);
+        Assert.NotNull(newOrgUser.UserId);
+
+        var userRepo = testData.Factory.Services.GetRequiredService<IUserRepository>();
+        var provisionedUser = await userRepo.GetByIdAsync(newOrgUser.UserId!.Value);
+        Assert.NotNull(provisionedUser);
+
+        Assert.False(provisionedUser!.EmailVerified);
+    }
+
+    /*
     * SUCCESS PATH: Test to verify /Account/ExternalCallback succeeds when an existing user
     * with a valid (Confirmed) organization user status logs in via SSO for the first time.
     */


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40869

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Stops setting `User.EmailVerified` when a claimed domain matches during SSO JIT auto-provisioning in the SSO Portal's AccountController, prunes a now-unused repository dependency, and adds unit + integration test coverage for the JIT provisioning path.

