### PR TITLE
map System.Text.Json.Nodes types to OpenAPI schemas

### DIFF
--- a/src/SharedWeb/Swagger/SwaggerGenOptionsExt.cs
+++ b/src/SharedWeb/Swagger/SwaggerGenOptionsExt.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Bit.SharedWeb.Swagger;
@@ -13,6 +15,13 @@ public static class SwaggerGenOptionsExt
     public static void InitializeSwaggerFilters(
     this SwaggerGenOptions config, IWebHostEnvironment environment)
     {
+        // Map System.Text.Json.Nodes types to free-form schemas. Otherwise Swashbuckle reflects over their
+        // members and emits a bogus named "JsonValue"/"JsonNode" component that breaks the SDK bindings.
+        config.MapType<JsonNode>(() => new OpenApiSchema());
+        config.MapType<JsonValue>(() => new OpenApiSchema());
+        config.MapType<JsonObject>(() => new OpenApiSchema { Type = JsonSchemaType.Object });
+        config.MapType<JsonArray>(() => new OpenApiSchema { Type = JsonSchemaType.Array });
+
         config.SchemaFilter<EnumSchemaFilter>();
         config.SchemaFilter<EncryptedStringSchemaFilter>();
         config.SchemaFilter<Base64UrlSchemaFilter>();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

#7898 changed `ConfigResponseModel.FeatureStates` to `IReadOnlyDictionary<string, JsonValue>`. Swashbuckle doesn't special-case `System.Text.Json.Nodes` types, so it reflected over `JsonValue`'s members and emitted a bogus `JsonValue` component (options/parent/root), which the SDK generator turned into a made-up type and broke the bindings.

This registers `MapType` mappings in the shared Swagger setup so these opaque types render as free-form schemas (matching the old object behavior), keeping JsonValue as the accurate model type and covering future uses across the Api and Identity specs.



## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
