### PR TITLE
[PM-29460] feat: Authenticate PricingClient to the pricing service

### DIFF
--- a/src/Core/Billing/Pricing/ServiceCollectionExtensions.cs
+++ b/src/Core/Billing/Pricing/ServiceCollectionExtensions.cs
@@ -21,6 +21,10 @@ public static class ServiceCollectionExtensions
                 "Bitwarden-Region",
                 globalSettings.BaseServiceUri.CloudRegion?.ToLower(CultureInfo.InvariantCulture) ?? "us"
             );
+            if (!string.IsNullOrEmpty(globalSettings.PricingApiKey))
+            {
+                httpClient.DefaultRequestHeaders.Add("X-Pricing-Api-Key", globalSettings.PricingApiKey);
+            }
         });
     }
 }

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -101,6 +101,7 @@ public class GlobalSettings : IGlobalSettings
     /// </summary>
     public virtual string SendDefaultHashKey { get; set; }
     public virtual string PricingUri { get; set; }
+    public virtual string PricingApiKey { get; set; }
     public virtual Fido2Settings Fido2 { get; set; } = new Fido2Settings();
     public virtual ICommunicationSettings Communication { get; set; } = new CommunicationSettings();
 

--- a/test/Core.Test/Billing/Pricing/ServiceCollectionExtensionsTests.cs
+++ b/test/Core.Test/Billing/Pricing/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,60 @@
+﻿using Bit.Core.Billing.Pricing;
+using Bit.Core.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Bit.Core.Test.Billing.Pricing;
+
+public class ServiceCollectionExtensionsTests
+{
+    private const string PricingApiKeyHeader = "X-Pricing-Api-Key";
+
+    // Obviously-synthetic test value; the server does not enforce the pricing
+    // service's >=32 character rule, so any non-empty value exercises the guard.
+    private const string ApiKey = "test-pricing-api-key-0123456789abcdef";
+
+    [Fact]
+    public void AddPricingClient_WhenApiKeyConfigured_SendsApiKeyHeader()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(new GlobalSettings
+        {
+            PricingUri = "https://test.com/",
+            PricingApiKey = ApiKey
+        });
+        services.AddLogging();
+        services.AddPricingClient();
+
+        using var provider = services.BuildServiceProvider();
+
+        // Act
+        var httpClient = provider
+            .GetRequiredService<IHttpClientFactory>()
+            .CreateClient(nameof(IPricingClient));
+
+        // Assert
+        Assert.True(httpClient.DefaultRequestHeaders.Contains(PricingApiKeyHeader));
+        Assert.Equal(ApiKey, httpClient.DefaultRequestHeaders.GetValues(PricingApiKeyHeader).Single());
+    }
+
+    [Fact]
+    public void AddPricingClient_WhenApiKeyNotConfigured_DoesNotSendApiKeyHeader()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(new GlobalSettings { PricingUri = "https://test.com/" });
+        services.AddLogging();
+        services.AddPricingClient();
+
+        using var provider = services.BuildServiceProvider();
+
+        // Act
+        var httpClient = provider
+            .GetRequiredService<IHttpClientFactory>()
+            .CreateClient(nameof(IPricingClient));
+
+        // Assert
+        Assert.False(httpClient.DefaultRequestHeaders.Contains(PricingApiKeyHeader));
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29460

## 📔 Objective

Make `server`'s cloud-side `PricingClient` send the shared `X-Pricing-Api-Key` header on every request to the pricing service, so the pricing service's `use-pricing-api-key-authentication` flag can be turned on without breaking cloud plan retrieval.

Two small, additive changes:

- **`GlobalSettings.PricingApiKey`** — a new optional (nullable) setting mirroring the existing `PricingUri`. Absent/empty means "don't send." Binds from `globalSettings:pricingApiKey` / `globalSettings__pricingApiKey` like the other `globalSettings` secrets.
- **`AddPricingClient`** — attaches `X-Pricing-Api-Key` as a default request header on the typed client, guarded on the key being non-empty (mirrors the existing `PricingUri` empty-guard). `PricingClient` is unchanged — it already sends whatever default headers the factory configures.

Why it's safe to ship ahead of the flag flip:

- **Cloud-only.** Self-hosted short-circuits in `PricingClient` before any HTTP call, so the header is never sent from a self-host instance.
- **Inert until enabled.** While the pricing service's `use-pricing-api-key-authentication` flag is off, its middleware is a pass-through and ignores the header. The header is only sent once `PricingApiKey` is provisioned, so there's no behavior change until then — decoupling the server deploy from the flag flip (no window where both must change together).

## ✅ Testing

- New `ServiceCollectionExtensionsTests` asserts the header is present + correct when the key is configured, and absent when it isn't (verified via `IHttpClientFactory.CreateClient(nameof(IPricingClient))`).
- Existing `PricingClientTests` stay green, including the self-hosted no-call cases.
- `dotnet build`, `dotnet format --verify-no-changes`, and the Billing/Pricing suite (99 tests) all pass.

## 🚫 Out of scope

- Prod Key Vault / overlay provisioning of `globalSettings__pricingApiKey` (separate devops ticket, gated on QA validation; non-prod overlays already wired).
- No changes in `bitwarden/billing-pricing` — the authentication middleware already exists there.
- Local-dev cloud key, if needed, belongs in the internal `additional-keys-for-cloud-services.json` secrets (not this repo), per contributing-docs.
