### PR TITLE
Seeder - Tech debt - Migrate CoreHelpers.GenerateComb to CombGuid.Generate

### DIFF
--- a/util/Seeder/Factories/CipherEncryption.cs
+++ b/util/Seeder/Factories/CipherEncryption.cs
@@ -52,7 +52,7 @@ internal static class CipherEncryption
 
         return new Cipher
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             OrganizationId = organizationId,
             UserId = userId,
             Type = cipherType,

--- a/util/Seeder/Factories/CollectionSeeder.cs
+++ b/util/Seeder/Factories/CollectionSeeder.cs
@@ -10,7 +10,7 @@ internal static class CollectionSeeder
     {
         return new Collection
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             OrganizationId = organizationId,
             Name = RustSdkService.EncryptString(name, orgKey),
             CreationDate = DateTime.UtcNow,

--- a/util/Seeder/Factories/DeviceSeeder.cs
+++ b/util/Seeder/Factories/DeviceSeeder.cs
@@ -10,7 +10,7 @@ internal static class DeviceSeeder
     {
         return new Device
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             UserId = userId,
             Type = deviceType,
             Name = deviceName,

--- a/util/Seeder/Factories/FolderSeeder.cs
+++ b/util/Seeder/Factories/FolderSeeder.cs
@@ -10,7 +10,7 @@ internal static class FolderSeeder
     {
         return new Folder
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             UserId = userId,
             Name = RustSdkService.EncryptString(name, userKeyBase64)
         };

--- a/util/Seeder/Factories/GroupSeeder.cs
+++ b/util/Seeder/Factories/GroupSeeder.cs
@@ -9,7 +9,7 @@ internal static class GroupSeeder
     {
         return new Group
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             OrganizationId = organizationId,
             Name = name
         };

--- a/util/Seeder/Factories/OrganizationDomainSeeder.cs
+++ b/util/Seeder/Factories/OrganizationDomainSeeder.cs
@@ -9,7 +9,7 @@ internal static class OrganizationDomainSeeder
     {
         var domain = new OrganizationDomain
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             OrganizationId = organizationId,
             DomainName = domainName,
             Txt = Guid.NewGuid().ToString("N"),

--- a/util/Seeder/Factories/OrganizationSeeder.cs
+++ b/util/Seeder/Factories/OrganizationSeeder.cs
@@ -57,7 +57,7 @@ internal static class OrganizationExtensions
 
         return new OrganizationUser
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             OrganizationId = organization.Id,
             UserId = shouldLinkUserId ? user.Id : null,
             Email = shouldLinkUserId ? null : user.Email,

--- a/util/Seeder/Factories/UserSeeder.cs
+++ b/util/Seeder/Factories/UserSeeder.cs
@@ -31,7 +31,7 @@ internal static class UserSeeder
 
         var user = new User
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             Name = name ?? mangledEmail.Split('@')[0],
             Email = mangledEmail,
             EmailVerified = emailVerified,

--- a/util/Seeder/Recipes/CollectionsRecipe.cs
+++ b/util/Seeder/Recipes/CollectionsRecipe.cs
@@ -35,7 +35,7 @@ public class CollectionsRecipe(DatabaseContext db)
         {
             collectionList.Add(new Core.Entities.Collection
             {
-                Id = CoreHelpers.GenerateComb(),
+                Id = CombGuid.Generate(),
                 OrganizationId = organizationId,
                 Name = $"Collection {i + 1}",
                 Type = CollectionType.SharedCollection,

--- a/util/Seeder/Recipes/GroupsRecipe.cs
+++ b/util/Seeder/Recipes/GroupsRecipe.cs
@@ -33,7 +33,7 @@ public class GroupsRecipe(DatabaseContext db)
         {
             groupList.Add(new Core.AdminConsole.Entities.Group
             {
-                Id = CoreHelpers.GenerateComb(),
+                Id = CombGuid.Generate(),
                 OrganizationId = organizationId,
                 Name = $"Group {i + 1}"
             });

--- a/util/Seeder/Scenes/MigrationCohortExportScene.cs
+++ b/util/Seeder/Scenes/MigrationCohortExportScene.cs
@@ -176,7 +176,7 @@ public class MigrationCohortExportScene(
 
             organizations.Add(new CoreOrganization
             {
-                Id = CoreHelpers.GenerateComb(),
+                Id = CombGuid.Generate(),
                 Name = $"{request.NamePrefix}{suffix}",
                 BillingEmail = $"{request.NamePrefix}{n}@example.com",
                 Plan = "Enterprise (Annually)",

--- a/util/Seeder/Scenes/SingleOrganizationScene.cs
+++ b/util/Seeder/Scenes/SingleOrganizationScene.cs
@@ -103,7 +103,7 @@ public class SingleOrganizationScene(
 
         var apiKey = new OrganizationApiKey
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             OrganizationId = organization.Id,
             Type = OrganizationApiKeyType.Default,
             ApiKey = CoreHelpers.SecureRandomString(30),

--- a/util/Seeder/Steps/CreateOrganizationApiKeyStep.cs
+++ b/util/Seeder/Steps/CreateOrganizationApiKeyStep.cs
@@ -13,7 +13,7 @@ internal sealed class CreateOrganizationApiKeyStep : IStep
 
         var apiKey = new OrganizationApiKey
         {
-            Id = CoreHelpers.GenerateComb(),
+            Id = CombGuid.Generate(),
             OrganizationId = org.Id,
             Type = OrganizationApiKeyType.Default,
             ApiKey = CoreHelpers.SecureRandomString(30),


### PR DESCRIPTION
## 🎟️ Tracking

Non-ticket tech-debt cleanup. 

## 📔 Objective

`CoreHelpers.GenerateComb()` is `[Obsolete("Use Bit.Core.Utilities.CombGuid.Generate() instead.")]` and simply delegates to `CombGuid.Generate()`, so this is a behavior-neutral swap — runtime GUID generation is unchanged; it only removes obsolete-API (CS0618) usage from the Seeder.

Flips all 13 remaining call sites in `util/Seeder` from `CoreHelpers.GenerateComb()` to `CombGuid.Generate()`. No `using` edits (every site already imports `Bit.Core.Utilities`); no test or behavior changes.

### Verification
- `git grep CoreHelpers.GenerateComb` in the Seeder → 0 hits
- Seeder, SeederApi, SeederUtility, SeederApi.IntegrationTest build clean (0 errors, 0 CS0618)
- `dotnet test SeederApi.IntegrationTest` → 273/273 pass
