### PR TITLE
[PM-40515] Add the support confirmation check.

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkErrors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkErrors.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.AcceptMembership;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements.Errors;
+using Bit.Core.AdminConsole.Utilities.v2;
 using Bit.Core.AdminConsole.Utilities.v2.Validation;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
@@ -15,6 +16,19 @@ public record ConfirmInviteLinkNotAvailable()
 {
     public string PropertyName => "code";
     public string Type => "invite_link_not_available";
+}
+
+/// <summary>
+/// Returned when the invite link was not created with
+/// <see cref="Entities.OrganizationInviteLink.SupportsConfirmation"/>, so it may only be used with the
+/// accept flow. This error has no accept-endpoint counterpart, so it declares its own message rather
+/// than inheriting one from a shared invite-link error.
+/// </summary>
+public record ConfirmInviteLinkConfirmationNotSupported()
+    : BadRequestError("This invite link cannot be used to confirm your organization membership."), IValidationError
+{
+    public string PropertyName => "code";
+    public string Type => "invite_link_confirmation_not_supported";
 }
 
 public record ConfirmEmailDomainNotAllowed()

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkErrors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkErrors.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.AcceptMembership;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements.Errors;
-using Bit.Core.AdminConsole.Utilities.v2;
 using Bit.Core.AdminConsole.Utilities.v2.Validation;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks;
@@ -18,14 +17,8 @@ public record ConfirmInviteLinkNotAvailable()
     public string Type => "invite_link_not_available";
 }
 
-/// <summary>
-/// Returned when the invite link was not created with
-/// <see cref="Entities.OrganizationInviteLink.SupportsConfirmation"/>, so it may only be used with the
-/// accept flow. This error has no accept-endpoint counterpart, so it declares its own message rather
-/// than inheriting one from a shared invite-link error.
-/// </summary>
 public record ConfirmInviteLinkConfirmationNotSupported()
-    : BadRequestError("This invite link cannot be used to confirm your organization membership."), IValidationError
+    : InviteLinkConfirmationNotSupported(), IValidationError
 {
     public string PropertyName => "code";
     public string Type => "invite_link_confirmation_not_supported";

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidator.cs
@@ -61,6 +61,11 @@ public class ConfirmOrganizationInviteLinkValidator(
             return new ConfirmInviteLinkNotAvailable();
         }
 
+        if (!link.SupportsConfirmation)
+        {
+            return new ConfirmInviteLinkConfirmationNotSupported();
+        }
+
         if (!InviteLinkDomainValidator.IsEmailDomainAllowed(user.Email, link.GetAllowedDomains()))
         {
             return new ConfirmEmailDomainNotAllowed();

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Errors.cs
@@ -11,6 +11,9 @@ public record InviteLinkDomainsRequired()
 public record InviteLinkNotAvailable()
     : BadRequestError("Your organization's plan does not support invite links.");
 
+public record InviteLinkConfirmationNotSupported()
+    : BadRequestError("This invite link does not support confirmation.");
+
 public record InviteLinkNotFound()
     : NotFoundError("Invite link not found.");
 

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IConfirmOrganizationInviteLinkValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/Interfaces/IConfirmOrganizationInviteLinkValidator.cs
@@ -10,7 +10,7 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.InviteLinks.Interfaces;
 /// <remarks>
 /// The following are validated:
 /// <list type="bullet">
-///     <item>The invite link exists and its organization is enabled and supports invite links.</item>
+///     <item>The invite link exists, its organization is enabled and supports invite links, and the link supports confirmation.</item>
 ///     <item>The user's email domain is allowed by the link.</item>
 ///     <item>The user is not a provider user.</item>
 ///     <item>Any existing membership is neither revoked nor already confirmed.</item>

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/ConfirmOrganizationInviteLinkValidatorTests.cs
@@ -150,6 +150,41 @@ public class ConfirmOrganizationInviteLinkValidatorTests
     }
 
     [Theory, BitAutoData]
+    public async Task ValidateAsync_WithLinkThatDoesNotSupportConfirmation_ReturnsConfirmationNotSupported(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        SutProvider<ConfirmOrganizationInviteLinkValidator> sutProvider)
+    {
+        // Arrange
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        inviteLink.SupportsConfirmation = false;
+
+        var request = new ConfirmOrganizationInviteLinkValidationRequest
+        {
+            OrganizationId = organization.Id,
+            Code = Guid.Parse(inviteLink.Code),
+            User = user,
+        };
+
+        // Act
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        // Assert
+        Assert.True(result.IsError);
+        var error = Assert.IsType<ConfirmInviteLinkConfirmationNotSupported>(result.AsError);
+        Assert.IsAssignableFrom<IValidationError>(error);
+
+        // The check must short-circuit before the membership is resolved so no membership can be mutated.
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByOrganizationAsync(Arg.Any<Guid>(), Arg.Any<Guid>());
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .GetByOrganizationEmailAsync(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Theory, BitAutoData]
     public async Task ValidateAsync_WithEmailDomainNotAllowed_ReturnsEmailDomainNotAllowed(
         Organization organization,
         OrganizationInviteLink inviteLink,
@@ -609,6 +644,7 @@ public class ConfirmOrganizationInviteLinkValidatorTests
         link.OrganizationId = org.Id;
         link.Code = Guid.NewGuid().ToString();
         link.AllowedDomains = "[\"example.com\"]";
+        link.SupportsConfirmation = true;
         user.Email = "user@example.com";
 
         sutProvider.GetDependency<IOrganizationInviteLinkRepository>()


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40515


## 📔 Objective
 

1. Add a support confirmation check to the confirm endpoint to ensure the invite link supports confirmation.
2. Add test coverage.

