### PR TITLE
[PM-41065] Arch/seeder api additional auth accounts

### DIFF
--- a/dev/secrets.json.example
+++ b/dev/secrets.json.example
@@ -1,7 +1,8 @@
 {
   "seederSettings": {
-    "username": "<your SeederApi username>",
-    "password": "<your SeederApi password>"
+    "accounts": [
+      { "username": "<your SeederApi username>", "password": "<your SeederApi password>" }
+    ]
   },
   "adminSettings": {
     "admins": "admin@localhost,owner@localhost,cs@localhost,billing@localhost,sales@localhost",

--- a/test/SeederApi.IntegrationTest/BasicAuthenticationHandlerTests.cs
+++ b/test/SeederApi.IntegrationTest/BasicAuthenticationHandlerTests.cs
@@ -1,0 +1,231 @@
+﻿using System.Net;
+using System.Text;
+using Bit.SeederApi.Models.Request;
+using Duende.IdentityModel.Client;
+using Xunit;
+
+namespace Bit.SeederApi.IntegrationTest;
+
+public class BasicAuthenticationHandlerTests : IClassFixture<SeederApiApplicationFactory>, IAsyncLifetime
+{
+    private const string User1 = "user1";
+    private const string Pass1 = "pass1";
+    private const string User2 = "user2";
+    private const string Pass2 = "pass2";
+
+    private readonly HttpClient _client;
+
+    public BasicAuthenticationHandlerTests(SeederApiApplicationFactory factory)
+    {
+        factory.ConfigureAccounts((User1, Pass1), (User2, Pass2));
+        _client = factory.CreateClient();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    // Usability
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithValidCredentials_ReturnsOk()
+    {
+        _client.SetBasicAuthentication(User1, Pass1);
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithMissingAuthorizationHeader_Returns401()
+    {
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("Bearer some-token")]
+    [InlineData("Digest realm=\"x\"")]
+    [InlineData("NotAScheme")]
+    public async Task ProtectedEndpoint_WithNonBasicScheme_Returns401(string headerValue)
+    {
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", headerValue);
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithLowercaseBasicScheme_ReturnsOk()
+    {
+        // Convention: RFC 7617 auth-scheme is case-insensitive.
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{User1}:{Pass1}"));
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"basic {token}");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithMalformedBase64_Returns401()
+    {
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Basic {User1}:{Pass1}");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithEmptyBasicToken_Returns401()
+    {
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", "Basic ");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithBase64ButNoColon_Returns401()
+    {
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes("no-colon-here"));
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Basic {token}");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithMultipleAuthorizationHeaders_Returns401()
+    {
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization",
+            new[] { $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Concat([User1, ":", Pass1])))}", $"Basic {Convert.ToBase64String(Encoding.UTF8.GetBytes(string.Concat([User2, ":", Pass2])))}" });
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // Security
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithValidUsernameAndWrongPassword_Returns401()
+    {
+        _client.SetBasicAuthentication(User1, "wrong-password");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithUnknownUsername_Returns401()
+    {
+        _client.SetBasicAuthentication("unknown-user", Pass1);
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithCrossAccountUsernameAndPassword_Returns401()
+    {
+        // Account A's username + Account B's password must not authenticate.
+        _client.SetBasicAuthentication(User1, Pass2);
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithWrongUsernameCase_Returns401()
+    {
+        // Ordinal comparison — case must match exactly.
+        _client.SetBasicAuthentication(User1.ToUpperInvariant(), Pass1);
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithEmptyUsername_Returns401()
+    {
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($":{Pass1}"));
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Basic {token}");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithEmptyPassword_Returns401()
+    {
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{User1}:"));
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Basic {token}");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    // Multi-account
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithSecondAccountCredentials_ReturnsOk()
+    {
+        _client.SetBasicAuthentication(User2, Pass2);
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AnonymousEndpoint_WithoutAuth_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/alive");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AnonymousEndpoint_WithInvalidAuth_ReturnsOk()
+    {
+        _client.SetBasicAuthentication("nobody", "nothing");
+        var response = await _client.GetAsync("/alive");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private Task<HttpResponseMessage> PostQuery()
+    {
+        return _client.PostAsJsonAsync("/query", new QueryRequestModel
+        {
+            Template = "EmergencyAccessInviteQuery",
+            Arguments = System.Text.Json.JsonSerializer.SerializeToElement(new { email = "any@example.com" })
+        });
+    }
+}
+
+public class BasicAuthenticationHandlerUnconfiguredTests
+    : IClassFixture<SeederApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly HttpClient _client;
+
+    public BasicAuthenticationHandlerUnconfiguredTests(SeederApiApplicationFactory factory)
+    {
+        // Deliberately do NOT call ConfigureAccounts — the handler should reject every
+        // protected request when no accounts are wired up.
+        _client = factory.CreateClient();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_WithNoAccountsConfigured_Returns401()
+    {
+        _client.SetBasicAuthentication("someone", "somepass");
+        var response = await _client.PostAsJsonAsync("/query", new QueryRequestModel
+        {
+            Template = "EmergencyAccessInviteQuery",
+            Arguments = System.Text.Json.JsonSerializer.SerializeToElement(new { email = "any@example.com" })
+        });
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AnonymousEndpoint_WithNoAccountsConfigured_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/alive");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/test/SeederApi.IntegrationTest/BasicAuthenticationHandlerTests.cs
+++ b/test/SeederApi.IntegrationTest/BasicAuthenticationHandlerTests.cs
@@ -12,12 +12,20 @@ public class BasicAuthenticationHandlerTests : IClassFixture<SeederApiApplicatio
     private const string Pass1 = "pass1";
     private const string User2 = "user2";
     private const string Pass2 = "pass2";
+    private const string BlankPwUser = "blank-pw-user";
+    private const string OrphanPassword = "orphan-password";
+    private const string DupePass = "different-pass";
 
     private readonly HttpClient _client;
 
     public BasicAuthenticationHandlerTests(SeederApiApplicationFactory factory)
     {
-        factory.ConfigureAccounts((User1, Pass1), (User2, Pass2));
+        factory.ConfigureAccounts(
+            (User1, Pass1),
+            (User2, Pass2),
+            (BlankPwUser, ""),
+            ("", OrphanPassword),
+            (User1, DupePass));
         _client = factory.CreateClient();
     }
 
@@ -163,6 +171,34 @@ public class BasicAuthenticationHandlerTests : IClassFixture<SeederApiApplicatio
         _client.SetBasicAuthentication(User2, Pass2);
         var response = await PostQuery();
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BlankConfiguredPassword_DoesNotAuthenticate_EvenWithEmptySuppliedPassword()
+    {
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{BlankPwUser}:"));
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Basic {token}");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task BlankConfiguredUsername_DoesNotAuthenticate_EvenWithMatchingPassword()
+    {
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($":{OrphanPassword}"));
+        _client.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"Basic {token}");
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DuplicateConfiguredUsername_LaterOccurrencePasswordRejected()
+    {
+        // First-occurrence-wins is verified by ProtectedEndpoint_WithValidCredentials_ReturnsOk
+        // (User1 is duplicated in the fixture with DupePass, and Pass1 still authenticates).
+        _client.SetBasicAuthentication(User1, DupePass);
+        var response = await PostQuery();
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
     [Fact]

--- a/test/SeederApi.IntegrationTest/InPlaySeederApiApplicationFactory.cs
+++ b/test/SeederApi.IntegrationTest/InPlaySeederApiApplicationFactory.cs
@@ -16,8 +16,8 @@ public class InPlaySeederApiApplicationFactory : WebApplicationFactoryBase<Start
     public InPlaySeederApiApplicationFactory()
     {
         UpdateConfiguration("globalSettings:testPlayIdTrackingEnabled", "true");
-        UpdateConfiguration("seederSettings:Username", _username);
-        UpdateConfiguration("seederSettings:Password", _password);
+        UpdateConfiguration("seederSettings:Accounts:0:Username", _username);
+        UpdateConfiguration("seederSettings:Accounts:0:Password", _password);
     }
 
     public string Username => _username;

--- a/test/SeederApi.IntegrationTest/SeederApiApplicationFactory.cs
+++ b/test/SeederApi.IntegrationTest/SeederApiApplicationFactory.cs
@@ -31,13 +31,20 @@ public class SeederApiApplicationFactory : WebApplicationFactoryBase<Startup>
 
     public void ConfigureAuth(string username, string password)
     {
+        ConfigureAccounts((username, password));
+    }
+
+    public void ConfigureAccounts(params (string Username, string Password)[] accounts)
+    {
         UpdateConfiguration(builder =>
         {
-            builder.AddInMemoryCollection(new Dictionary<string, string>
+            var entries = new Dictionary<string, string>();
+            for (var i = 0; i < accounts.Length; i++)
             {
-                { "seederSettings:Accounts:0:Username", username },
-                { "seederSettings:Accounts:0:Password", password }
-            });
+                entries[$"seederSettings:Accounts:{i}:Username"] = accounts[i].Username;
+                entries[$"seederSettings:Accounts:{i}:Password"] = accounts[i].Password;
+            }
+            builder.AddInMemoryCollection(entries);
         });
     }
 }

--- a/test/SeederApi.IntegrationTest/SeederApiApplicationFactory.cs
+++ b/test/SeederApi.IntegrationTest/SeederApiApplicationFactory.cs
@@ -35,8 +35,8 @@ public class SeederApiApplicationFactory : WebApplicationFactoryBase<Startup>
         {
             builder.AddInMemoryCollection(new Dictionary<string, string>
             {
-                { "seederSettings:Username", username},
-                { "seederSettings:Password", password}
+                { "seederSettings:Accounts:0:Username", username },
+                { "seederSettings:Accounts:0:Password", password }
             });
         });
     }

--- a/util/SeederApi/Utilities/BasicAuthenticationHandler.cs
+++ b/util/SeederApi/Utilities/BasicAuthenticationHandler.cs
@@ -22,10 +22,12 @@ public class BasicAuthenticationHandler : AuthenticationHandler<BasicAuthenticat
         IOptions<SeederSettings> seederSettings)
         : base(options, logger, encoder)
     {
-        _accounts = seederSettings.Value.Accounts.ToDictionary(
-            a => a.Username,
-            a => Encoding.UTF8.GetBytes(a.Password),
-            StringComparer.Ordinal);
+        // Drop half-configured entries
+        // Repeated usernames use the first configured password
+        _accounts = seederSettings.Value.Accounts
+            .Where(a => !string.IsNullOrEmpty(a.Username) && !string.IsNullOrEmpty(a.Password))
+            .GroupBy(a => a.Username, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => Encoding.UTF8.GetBytes(g.First().Password), StringComparer.Ordinal);
     }
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()

--- a/util/SeederApi/Utilities/BasicAuthenticationHandler.cs
+++ b/util/SeederApi/Utilities/BasicAuthenticationHandler.cs
@@ -10,7 +10,10 @@ namespace Bit.SeederApi.Utilities;
 
 public class BasicAuthenticationHandler : AuthenticationHandler<BasicAuthenticationOptions>
 {
-    private readonly SeederSettings _seederSettings;
+    private static readonly byte[] _dummyPassword = Encoding.UTF8.GetBytes(
+        "dummy-password-for-timing-equalization");
+
+    private readonly Dictionary<string, byte[]> _accounts;
 
     public BasicAuthenticationHandler(
         IOptionsMonitor<BasicAuthenticationOptions> options,
@@ -19,7 +22,10 @@ public class BasicAuthenticationHandler : AuthenticationHandler<BasicAuthenticat
         IOptions<SeederSettings> seederSettings)
         : base(options, logger, encoder)
     {
-        _seederSettings = seederSettings.Value;
+        _accounts = seederSettings.Value.Accounts.ToDictionary(
+            a => a.Username,
+            a => Encoding.UTF8.GetBytes(a.Password),
+            StringComparer.Ordinal);
     }
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -30,7 +36,7 @@ public class BasicAuthenticationHandler : AuthenticationHandler<BasicAuthenticat
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 
-        if (string.IsNullOrEmpty(_seederSettings.Username) || string.IsNullOrEmpty(_seederSettings.Password))
+        if (_accounts.Count == 0)
         {
             Logger.LogWarning("Seeder credentials are not configured");
             return Task.FromResult(AuthenticateResult.Fail("Seeder credentials not configured"));
@@ -65,15 +71,15 @@ public class BasicAuthenticationHandler : AuthenticationHandler<BasicAuthenticat
             return Task.FromResult(AuthenticateResult.Fail("Invalid Basic credential format"));
         }
 
-        var expectedUsername = Encoding.UTF8.GetBytes(_seederSettings.Username);
-        var expectedPassword = Encoding.UTF8.GetBytes(_seederSettings.Password);
-        var providedUsername = Encoding.UTF8.GetBytes(username);
+        // Equalize the miss path: if the username isn't found we still run FixedTimeEquals
+        // against a dummy so the branch cost matches a hit. Combine with bitwise & so the
+        // final decision doesn't short-circuit on the userExists check.
+        var userExists = _accounts.TryGetValue(username, out var storedPassword);
+        var comparisonTarget = storedPassword ?? _dummyPassword;
         var providedPassword = Encoding.UTF8.GetBytes(password);
+        var passwordMatches = CryptographicOperations.FixedTimeEquals(providedPassword, comparisonTarget);
 
-        var usernameMatch = CryptographicOperations.FixedTimeEquals(expectedUsername, providedUsername);
-        var passwordMatch = CryptographicOperations.FixedTimeEquals(expectedPassword, providedPassword);
-
-        if (!usernameMatch || !passwordMatch)
+        if (!(userExists & passwordMatches))
         {
             Logger.LogWarning("Invalid credentials provided for SeederApi");
             return Task.FromResult(AuthenticateResult.Fail("Invalid credentials"));

--- a/util/SeederApi/Utilities/SeederSettings.cs
+++ b/util/SeederApi/Utilities/SeederSettings.cs
@@ -1,7 +1,12 @@
 ﻿namespace Bit.SeederApi.Utilities;
 
+public class BasicAuth
+{
+    public required string Username { get; set; }
+    public required string Password { get; set; }
+}
+
 public class SeederSettings
 {
-    public string? Username { get; set; }
-    public string? Password { get; set; }
+    public BasicAuth[] Accounts { get; set; } = [];
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41065

## 📔 Objective

Expand SeederApi basic authentication with an array of known accounts.

> **Warning**: These changes require configuration updates to all environments with a SeederApi currently deployed. This includes all lower environments, self host instances, and dev machine environments