### PR TITLE
[PM-41066] fix: Preserve subscription schedule phase metadata on phase rebuilds

### DIFF
--- a/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
+++ b/src/Billing/Services/Implementations/UpcomingInvoiceHandler.cs
@@ -855,6 +855,7 @@ public class UpcomingInvoiceHandler(
                         ? []
                         : customerDiscount.MergeDiscountCouponIds(
                             phase.Discounts?.Select(d => d.CouponId)).ToPhaseDiscountOptions(),
+                    Metadata = phase.Metadata,
                     ProrationBehavior = phase.ProrationBehavior,
                     AutomaticTax = new SubscriptionSchedulePhaseAutomaticTaxOptions
                     {

--- a/src/Core/Billing/Payment/Commands/UpdateBillingAddressCommand.cs
+++ b/src/Core/Billing/Payment/Commands/UpdateBillingAddressCommand.cs
@@ -167,6 +167,7 @@ public class UpdateBillingAddressCommand(
                                 ? []
                                 : customerDiscount.MergeDiscountCouponIds(
                                     phase.Discounts?.Select(d => d.CouponId)).ToPhaseDiscountOptions(),
+                            Metadata = phase.Metadata,
                             ProrationBehavior = phase.ProrationBehavior,
                             AutomaticTax = new SubscriptionSchedulePhaseAutomaticTaxOptions
                             {

--- a/src/Core/Billing/Premium/Commands/UpdatePremiumStorageCommand.cs
+++ b/src/Core/Billing/Premium/Commands/UpdatePremiumStorageCommand.cs
@@ -184,6 +184,7 @@ public class UpdatePremiumStorageCommand(
                     Items = BuildPhaseItemsWithStorage(phase1.Items, storagePriceId, additionalStorageGb),
                     Discounts = phase1.Discounts?.Select(d =>
                         new SubscriptionSchedulePhaseDiscountOptions { Coupon = d.CouponId }).ToList(),
+                    Metadata = phase1.Metadata,
                     ProrationBehavior = phase1.ProrationBehavior
                 });
             }
@@ -211,6 +212,7 @@ public class UpdatePremiumStorageCommand(
                         ? []
                         : (subscription.Customer?.Discount).MergeDiscountCouponIds(
                             phase2.Discounts?.Select(d => d.CouponId)).ToPhaseDiscountOptions(),
+                    Metadata = phase2.Metadata,
                     ProrationBehavior = phase2.ProrationBehavior
                 });
             }

--- a/test/Billing.Test/Services/UpcomingInvoiceHandlerTests.cs
+++ b/test/Billing.Test/Services/UpcomingInvoiceHandlerTests.cs
@@ -1236,6 +1236,273 @@ public class UpcomingInvoiceHandlerTests
     }
 
     [Fact]
+    public async Task HandleAsync_WhenOrganizationTaxNotEnabled_SchedulePresent_PreservesPhaseMetadata()
+    {
+        // Arrange
+        var parsedEvent = new Event { Id = "evt_123", Type = "invoice.upcoming" };
+        var invoice = new Invoice { CustomerId = "cus_123", Lines = new StripeList<InvoiceLineItem> { Data = [] } };
+        var subscription = new Subscription
+        {
+            Id = "sub_123",
+            CustomerId = "cus_123",
+            AutomaticTax = new SubscriptionAutomaticTax { Enabled = false },
+            Items = new StripeList<SubscriptionItem> { Data = [] },
+            Metadata = new Dictionary<string, string> { { "organizationId", _organizationId.ToString() } }
+        };
+        var customer = new Customer
+        {
+            Id = "cus_123",
+            Subscriptions = new StripeList<Subscription> { Data = [subscription] },
+            Address = new Address { Country = "US" }
+        };
+        var organization = new Organization { Id = _organizationId, PlanType = PlanType.TeamsAnnually, BillingEmail = "test@test.com" };
+
+        var phase1Start = DateTime.UtcNow.AddDays(-10);
+        var phase1End = DateTime.UtcNow.AddDays(5);
+        var phase2End = DateTime.UtcNow.AddDays(370);
+
+        _stripeEventService.GetInvoice(parsedEvent).Returns(invoice);
+        _stripeAdapter.GetCustomerAsync(invoice.CustomerId, Arg.Any<CustomerGetOptions>()).Returns(customer);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(_organizationId, null, null));
+        _organizationRepository.GetByIdAsync(_organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(new TeamsPlan(isAnnual: true));
+
+        // The non-cohort key pins the passthrough as unconditional — nothing filters by key.
+        var phaseMetadata = new Dictionary<string, string>
+        {
+            { MetadataKeys.MigrationCohortId, "cohort_123" },
+            { MetadataKeys.MigrationCohortName, "Teams 2020 Annual" },
+            { "unrelated_key", "unrelated_value" }
+        };
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data =
+                [
+                    new SubscriptionSchedule
+                    {
+                        Id = "sub_sched_123",
+                        SubscriptionId = "sub_123",
+                        Status = SubscriptionScheduleStatus.Active,
+                        Phases = new List<SubscriptionSchedulePhase>
+                        {
+                            new()
+                            {
+                                StartDate = phase1Start,
+                                EndDate = phase1End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_old", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = phaseMetadata,
+                                ProrationBehavior = "none"
+                            },
+                            new()
+                            {
+                                StartDate = phase1End,
+                                EndDate = phase2End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_new", Quantity = 1 }],
+                                Discounts = [new SubscriptionSchedulePhaseDiscount { CouponId = "milestone-coupon" }],
+                                Metadata = phaseMetadata,
+                                ProrationBehavior = "none"
+                            }
+                        }
+                    }
+                ]
+            });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            Arg.Is("sub_sched_123"),
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[0].Metadata != null &&
+                o.Phases[0].Metadata[MetadataKeys.MigrationCohortId] == "cohort_123" &&
+                o.Phases[0].Metadata[MetadataKeys.MigrationCohortName] == "Teams 2020 Annual" &&
+                o.Phases[0].Metadata["unrelated_key"] == "unrelated_value" &&
+                o.Phases[1].Metadata != null &&
+                o.Phases[1].Metadata[MetadataKeys.MigrationCohortId] == "cohort_123" &&
+                o.Phases[1].Metadata[MetadataKeys.MigrationCohortName] == "Teams 2020 Annual" &&
+                o.Phases[1].Metadata["unrelated_key"] == "unrelated_value"));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOrganizationTaxNotEnabled_SchedulePresent_PhaseMetadataEmpty_StaysEmpty()
+    {
+        // Arrange
+        var parsedEvent = new Event { Id = "evt_123", Type = "invoice.upcoming" };
+        var invoice = new Invoice { CustomerId = "cus_123", Lines = new StripeList<InvoiceLineItem> { Data = [] } };
+        var subscription = new Subscription
+        {
+            Id = "sub_123",
+            CustomerId = "cus_123",
+            AutomaticTax = new SubscriptionAutomaticTax { Enabled = false },
+            Items = new StripeList<SubscriptionItem> { Data = [] },
+            Metadata = new Dictionary<string, string> { { "organizationId", _organizationId.ToString() } }
+        };
+        var customer = new Customer
+        {
+            Id = "cus_123",
+            Subscriptions = new StripeList<Subscription> { Data = [subscription] },
+            Address = new Address { Country = "US" }
+        };
+        var organization = new Organization { Id = _organizationId, PlanType = PlanType.TeamsAnnually, BillingEmail = "test@test.com" };
+
+        var phase1Start = DateTime.UtcNow.AddDays(-10);
+        var phase1End = DateTime.UtcNow.AddDays(5);
+        var phase2End = DateTime.UtcNow.AddDays(370);
+
+        _stripeEventService.GetInvoice(parsedEvent).Returns(invoice);
+        _stripeAdapter.GetCustomerAsync(invoice.CustomerId, Arg.Any<CustomerGetOptions>()).Returns(customer);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(_organizationId, null, null));
+        _organizationRepository.GetByIdAsync(_organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(new TeamsPlan(isAnnual: true));
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data =
+                [
+                    new SubscriptionSchedule
+                    {
+                        Id = "sub_sched_123",
+                        SubscriptionId = "sub_123",
+                        Status = SubscriptionScheduleStatus.Active,
+                        Phases = new List<SubscriptionSchedulePhase>
+                        {
+                            new()
+                            {
+                                StartDate = phase1Start,
+                                EndDate = phase1End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_old", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string>(),
+                                ProrationBehavior = "none"
+                            },
+                            new()
+                            {
+                                StartDate = phase1End,
+                                EndDate = phase2End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_new", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string>(),
+                                ProrationBehavior = "none"
+                            }
+                        }
+                    }
+                ]
+            });
+
+        // Act
+        await _sut.HandleAsync(parsedEvent);
+
+        // Assert
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            Arg.Is("sub_sched_123"),
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[0].Metadata != null && o.Phases[0].Metadata.Count == 0 &&
+                o.Phases[1].Metadata != null && o.Phases[1].Metadata.Count == 0));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenOrganizationTaxNotEnabled_MultiPhaseSchedule_PreservesMetadataOnEveryRebuiltPhase()
+    {
+        // Phase 0 has already ended, so it is skipped and the surviving phases shift down by one.
+        // Distinct metadata per phase is what catches an index-shift bug; a uniform dict would hide it.
+        var parsedEvent = new Event { Id = "evt_123", Type = "invoice.upcoming" };
+        var invoice = new Invoice { CustomerId = "cus_123", Lines = new StripeList<InvoiceLineItem> { Data = [] } };
+        var subscription = new Subscription
+        {
+            Id = "sub_123",
+            CustomerId = "cus_123",
+            AutomaticTax = new SubscriptionAutomaticTax { Enabled = false },
+            Items = new StripeList<SubscriptionItem> { Data = [] },
+            Metadata = new Dictionary<string, string> { { "organizationId", _organizationId.ToString() } }
+        };
+        var customer = new Customer
+        {
+            Id = "cus_123",
+            Subscriptions = new StripeList<Subscription> { Data = [subscription] },
+            Address = new Address { Country = "US" }
+        };
+        var organization = new Organization { Id = _organizationId, PlanType = PlanType.TeamsAnnually, BillingEmail = "test@test.com" };
+
+        var phase0Start = DateTime.UtcNow.AddDays(-370);
+        var phase0End = DateTime.UtcNow.AddDays(-5);
+        var phase1End = DateTime.UtcNow.AddDays(360);
+        var phase2End = DateTime.UtcNow.AddDays(725);
+
+        _stripeEventService.GetInvoice(parsedEvent).Returns(invoice);
+        _stripeAdapter.GetCustomerAsync(invoice.CustomerId, Arg.Any<CustomerGetOptions>()).Returns(customer);
+        _stripeEventUtilityService.GetIdsFromMetadata(subscription.Metadata)
+            .Returns(new Tuple<Guid?, Guid?, Guid?>(_organizationId, null, null));
+        _organizationRepository.GetByIdAsync(_organizationId).Returns(organization);
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(new TeamsPlan(isAnnual: true));
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data =
+                [
+                    new SubscriptionSchedule
+                    {
+                        Id = "sub_sched_123",
+                        SubscriptionId = "sub_123",
+                        Status = SubscriptionScheduleStatus.Active,
+                        Phases = new List<SubscriptionSchedulePhase>
+                        {
+                            new()
+                            {
+                                StartDate = phase0Start,
+                                EndDate = phase0End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_oldest", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string> { { MetadataKeys.MigrationCohortId, "cohort_0" } },
+                                ProrationBehavior = "none"
+                            },
+                            new()
+                            {
+                                StartDate = phase0End,
+                                EndDate = phase1End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_old", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string> { { MetadataKeys.MigrationCohortId, "cohort_1" } },
+                                ProrationBehavior = "none"
+                            },
+                            new()
+                            {
+                                StartDate = phase1End,
+                                EndDate = phase2End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_new", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string> { { MetadataKeys.MigrationCohortId, "cohort_2" } },
+                                ProrationBehavior = "none"
+                            }
+                        }
+                    }
+                ]
+            });
+
+        await _sut.HandleAsync(parsedEvent);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            Arg.Is("sub_sched_123"),
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[0].Items[0].Price == "price_old" &&
+                o.Phases[0].Metadata != null &&
+                o.Phases[0].Metadata[MetadataKeys.MigrationCohortId] == "cohort_1" &&
+                o.Phases[1].Items[0].Price == "price_new" &&
+                o.Phases[1].Metadata != null &&
+                o.Phases[1].Metadata[MetadataKeys.MigrationCohortId] == "cohort_2"));
+    }
+
+    [Fact]
     public async Task HandleAsync_WhenOrganizationTaxNotEnabled_NoSchedule_UpdatesSubscriptionDirectly()
     {
         // Arrange

--- a/test/Core.Test/Billing/Payment/Commands/UpdateBillingAddressCommandTests.cs
+++ b/test/Core.Test/Billing/Payment/Commands/UpdateBillingAddressCommandTests.cs
@@ -732,6 +732,306 @@ public class UpdateBillingAddressCommandTests
     }
 
     [Fact]
+    public async Task Run_PersonalOrganization_SchedulePresent_PreservesPhaseMetadata()
+    {
+        var organization = new Organization
+        {
+            PlanType = PlanType.FamiliesAnnually,
+            GatewayCustomerId = "cus_123",
+            GatewaySubscriptionId = "sub_123"
+        };
+
+        var input = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345",
+            Line1 = "123 Main St.",
+            City = "New York",
+            State = "NY"
+        };
+
+        var phase1Start = DateTime.UtcNow.AddDays(-10);
+        var phase1End = DateTime.UtcNow.AddDays(5);
+        var phase2End = DateTime.UtcNow.AddDays(370);
+
+        var customer = new Customer
+        {
+            Address = new Address { Country = "US", PostalCode = "12345", Line1 = "123 Main St.", City = "New York", State = "NY" },
+            Subscriptions = new StripeList<Subscription>
+            {
+                Data =
+                [
+                    new Subscription
+                    {
+                        Id = organization.GatewaySubscriptionId,
+                        CustomerId = organization.GatewayCustomerId,
+                        AutomaticTax = new SubscriptionAutomaticTax { Enabled = false }
+                    }
+                ]
+            }
+        };
+
+        _stripeAdapter.UpdateCustomerAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(customer);
+
+        // The non-cohort key pins the passthrough as unconditional — nothing filters by key.
+        var phaseMetadata = new Dictionary<string, string>
+        {
+            { MetadataKeys.MigrationCohortId, "cohort_123" },
+            { MetadataKeys.MigrationCohortName, "Families 2020 Annual" },
+            { "unrelated_key", "unrelated_value" }
+        };
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data =
+                [
+                    new SubscriptionSchedule
+                    {
+                        Id = "sub_sched_123",
+                        SubscriptionId = organization.GatewaySubscriptionId,
+                        Status = SubscriptionScheduleStatus.Active,
+                        Phases = new List<SubscriptionSchedulePhase>
+                        {
+                            new()
+                            {
+                                StartDate = phase1Start,
+                                EndDate = phase1End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_old", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = phaseMetadata,
+                                ProrationBehavior = "none"
+                            },
+                            new()
+                            {
+                                StartDate = phase1End,
+                                EndDate = phase2End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_new", Quantity = 1 }],
+                                Discounts = [new SubscriptionSchedulePhaseDiscount { CouponId = "milestone-3" }],
+                                Metadata = phaseMetadata,
+                                ProrationBehavior = "none"
+                            }
+                        }
+                    }
+                ]
+            });
+
+        var result = await _command.Run(organization, input);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            Arg.Is("sub_sched_123"),
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[0].Metadata != null &&
+                o.Phases[0].Metadata[MetadataKeys.MigrationCohortId] == "cohort_123" &&
+                o.Phases[0].Metadata[MetadataKeys.MigrationCohortName] == "Families 2020 Annual" &&
+                o.Phases[0].Metadata["unrelated_key"] == "unrelated_value" &&
+                o.Phases[1].Metadata != null &&
+                o.Phases[1].Metadata[MetadataKeys.MigrationCohortId] == "cohort_123" &&
+                o.Phases[1].Metadata[MetadataKeys.MigrationCohortName] == "Families 2020 Annual" &&
+                o.Phases[1].Metadata["unrelated_key"] == "unrelated_value"));
+    }
+
+    [Fact]
+    public async Task Run_PersonalOrganization_SchedulePresent_PhaseMetadataEmpty_StaysEmpty()
+    {
+        var organization = new Organization
+        {
+            PlanType = PlanType.FamiliesAnnually,
+            GatewayCustomerId = "cus_123",
+            GatewaySubscriptionId = "sub_123"
+        };
+
+        var input = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345",
+            Line1 = "123 Main St.",
+            City = "New York",
+            State = "NY"
+        };
+
+        var phase1Start = DateTime.UtcNow.AddDays(-10);
+        var phase1End = DateTime.UtcNow.AddDays(5);
+        var phase2End = DateTime.UtcNow.AddDays(370);
+
+        var customer = new Customer
+        {
+            Address = new Address { Country = "US", PostalCode = "12345", Line1 = "123 Main St.", City = "New York", State = "NY" },
+            Subscriptions = new StripeList<Subscription>
+            {
+                Data =
+                [
+                    new Subscription
+                    {
+                        Id = organization.GatewaySubscriptionId,
+                        CustomerId = organization.GatewayCustomerId,
+                        AutomaticTax = new SubscriptionAutomaticTax { Enabled = false }
+                    }
+                ]
+            }
+        };
+
+        _stripeAdapter.UpdateCustomerAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(customer);
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data =
+                [
+                    new SubscriptionSchedule
+                    {
+                        Id = "sub_sched_123",
+                        SubscriptionId = organization.GatewaySubscriptionId,
+                        Status = SubscriptionScheduleStatus.Active,
+                        Phases = new List<SubscriptionSchedulePhase>
+                        {
+                            new()
+                            {
+                                StartDate = phase1Start,
+                                EndDate = phase1End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_old", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string>(),
+                                ProrationBehavior = "none"
+                            },
+                            new()
+                            {
+                                StartDate = phase1End,
+                                EndDate = phase2End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_new", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string>(),
+                                ProrationBehavior = "none"
+                            }
+                        }
+                    }
+                ]
+            });
+
+        var result = await _command.Run(organization, input);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            Arg.Is("sub_sched_123"),
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[0].Metadata != null && o.Phases[0].Metadata.Count == 0 &&
+                o.Phases[1].Metadata != null && o.Phases[1].Metadata.Count == 0));
+    }
+
+    [Fact]
+    public async Task Run_PersonalOrganization_MultiPhaseSchedule_PreservesMetadataOnEveryRebuiltPhase()
+    {
+        // Phase 0 has already ended, so it is skipped and the surviving phases shift down by one.
+        // Distinct metadata per phase is what catches an index-shift bug; a uniform dict would hide it.
+        var organization = new Organization
+        {
+            PlanType = PlanType.FamiliesAnnually,
+            GatewayCustomerId = "cus_123",
+            GatewaySubscriptionId = "sub_123"
+        };
+
+        var input = new BillingAddress
+        {
+            Country = "US",
+            PostalCode = "12345",
+            Line1 = "123 Main St.",
+            City = "New York",
+            State = "NY"
+        };
+
+        var phase0Start = DateTime.UtcNow.AddDays(-370);
+        var phase0End = DateTime.UtcNow.AddDays(-5);
+        var phase1End = DateTime.UtcNow.AddDays(360);
+        var phase2End = DateTime.UtcNow.AddDays(725);
+
+        var customer = new Customer
+        {
+            Address = new Address { Country = "US", PostalCode = "12345", Line1 = "123 Main St.", City = "New York", State = "NY" },
+            Subscriptions = new StripeList<Subscription>
+            {
+                Data =
+                [
+                    new Subscription
+                    {
+                        Id = organization.GatewaySubscriptionId,
+                        CustomerId = organization.GatewayCustomerId,
+                        AutomaticTax = new SubscriptionAutomaticTax { Enabled = false }
+                    }
+                ]
+            }
+        };
+
+        _stripeAdapter.UpdateCustomerAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(customer);
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule>
+            {
+                Data =
+                [
+                    new SubscriptionSchedule
+                    {
+                        Id = "sub_sched_123",
+                        SubscriptionId = organization.GatewaySubscriptionId,
+                        Status = SubscriptionScheduleStatus.Active,
+                        Phases = new List<SubscriptionSchedulePhase>
+                        {
+                            new()
+                            {
+                                StartDate = phase0Start,
+                                EndDate = phase0End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_oldest", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string> { { MetadataKeys.MigrationCohortId, "cohort_0" } },
+                                ProrationBehavior = "none"
+                            },
+                            new()
+                            {
+                                StartDate = phase0End,
+                                EndDate = phase1End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_old", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string> { { MetadataKeys.MigrationCohortId, "cohort_1" } },
+                                ProrationBehavior = "none"
+                            },
+                            new()
+                            {
+                                StartDate = phase1End,
+                                EndDate = phase2End,
+                                Items = [new SubscriptionSchedulePhaseItem { PriceId = "price_new", Quantity = 1 }],
+                                Discounts = [],
+                                Metadata = new Dictionary<string, string> { { MetadataKeys.MigrationCohortId, "cohort_2" } },
+                                ProrationBehavior = "none"
+                            }
+                        }
+                    }
+                ]
+            });
+
+        var result = await _command.Run(organization, input);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            Arg.Is("sub_sched_123"),
+            Arg.Is<SubscriptionScheduleUpdateOptions>(o =>
+                o.Phases.Count == 2 &&
+                o.Phases[0].Items[0].Price == "price_old" &&
+                o.Phases[0].Metadata != null &&
+                o.Phases[0].Metadata[MetadataKeys.MigrationCohortId] == "cohort_1" &&
+                o.Phases[1].Items[0].Price == "price_new" &&
+                o.Phases[1].Metadata != null &&
+                o.Phases[1].Metadata[MetadataKeys.MigrationCohortId] == "cohort_2"));
+    }
+
+    [Fact]
     public async Task Run_PersonalOrganization_NoSchedule_UpdatesSubscriptionDirectly()
     {
         var organization = new Organization

--- a/test/Core.Test/Billing/Premium/Commands/UpdatePremiumStorageCommandTests.cs
+++ b/test/Core.Test/Billing/Premium/Commands/UpdatePremiumStorageCommandTests.cs
@@ -862,6 +862,91 @@ public class UpdatePremiumStorageCommandTests
         await _userService.Received(1).SaveUserAsync(Arg.Is<User>(u => u.MaxStorageGb == 1));
     }
 
+    [Theory, BitAutoData]
+    public async Task Run_WithSchedule_PreservesPhaseMetadata(User user)
+    {
+        user.Premium = true;
+        user.MaxStorageGb = 5;
+        user.Storage = 2L * 1024 * 1024 * 1024;
+        user.GatewaySubscriptionId = "sub_123";
+
+        var subscription = CreateMockSubscription("sub_123", 4);
+        _stripeAdapter.GetSubscriptionAsync("sub_123", Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
+
+        var schedule = CreateMockSchedule("sub_123", hasStorage: true, storageQuantity: 4);
+
+        // Distinct values per phase catch an index-shift bug; the non-cohort key pins the
+        // passthrough as unconditional — nothing filters by key.
+        schedule.Phases[0].Metadata = new Dictionary<string, string>
+        {
+            { MetadataKeys.MigrationCohortId, "cohort_1" },
+            { MetadataKeys.MigrationCohortName, "Premium 2020" },
+            { "unrelated_key", "phase_1_value" }
+        };
+        schedule.Phases[1].Metadata = new Dictionary<string, string>
+        {
+            { MetadataKeys.MigrationCohortId, "cohort_2" },
+            { MetadataKeys.MigrationCohortName, "Premium 2025" },
+            { "unrelated_key", "phase_2_value" }
+        };
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var result = await _command.Run(user, 9);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            schedule.Id,
+            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
+                opts.Phases.Count == 2 &&
+                opts.Phases[0].Metadata != null &&
+                opts.Phases[0].Metadata[MetadataKeys.MigrationCohortId] == "cohort_1" &&
+                opts.Phases[0].Metadata[MetadataKeys.MigrationCohortName] == "Premium 2020" &&
+                opts.Phases[0].Metadata["unrelated_key"] == "phase_1_value" &&
+                opts.Phases[1].Metadata != null &&
+                opts.Phases[1].Metadata[MetadataKeys.MigrationCohortId] == "cohort_2" &&
+                opts.Phases[1].Metadata[MetadataKeys.MigrationCohortName] == "Premium 2025" &&
+                opts.Phases[1].Metadata["unrelated_key"] == "phase_2_value"));
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_WithSinglePhaseSchedule_PreservesPhaseMetadata(User user)
+    {
+        user.Premium = true;
+        user.MaxStorageGb = 5;
+        user.Storage = 2L * 1024 * 1024 * 1024;
+        user.GatewaySubscriptionId = "sub_123";
+
+        var subscription = CreateMockSubscription("sub_123", 4);
+        _stripeAdapter.GetSubscriptionAsync("sub_123", Arg.Any<SubscriptionGetOptions>()).Returns(subscription);
+
+        var schedule = CreateMockSchedule("sub_123", hasStorage: true, storageQuantity: 4, singlePhase: true);
+        schedule.Phases[0].Metadata = new Dictionary<string, string>
+        {
+            { MetadataKeys.MigrationCohortId, "cohort_1" },
+            { MetadataKeys.MigrationCohortName, "Premium 2020" },
+            { "unrelated_key", "unrelated_value" }
+        };
+
+        _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
+            .Returns(new StripeList<SubscriptionSchedule> { Data = [schedule] });
+
+        var result = await _command.Run(user, 9);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).UpdateSubscriptionScheduleAsync(
+            schedule.Id,
+            Arg.Is<SubscriptionScheduleUpdateOptions>(opts =>
+                opts.Phases.Count == 1 &&
+                opts.Phases[0].Metadata != null &&
+                opts.Phases[0].Metadata[MetadataKeys.MigrationCohortId] == "cohort_1" &&
+                opts.Phases[0].Metadata[MetadataKeys.MigrationCohortName] == "Premium 2020" &&
+                opts.Phases[0].Metadata["unrelated_key"] == "unrelated_value"));
+    }
+
     private static SubscriptionSchedule CreateMockSchedule(
         string subscriptionId,
         bool hasStorage,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41066

## 📔 Objective

Stripe treats a schedule's `Phases` array as a **full replacement**, not a merge. Any field a rebuild doesn't explicitly copy is dropped. Three paths rebuilt phases without carrying `Metadata` forward, silently stripping migration cohort identity off schedules created by `PriceIncreaseScheduler`. All three returned success, so the loss was invisible without inspecting Stripe.

Adds `Metadata = phase.Metadata` at the three lossy sites:

| Site | Reached from |
| --- | --- |
| `UpcomingInvoiceHandler.EnableAutomaticTaxAsync` | `invoice.upcoming` webhook — orgs and premium users. Rebuilds every unexpired phase. |
| `UpdateBillingAddressCommand.EnableAutomaticTaxAsync` | Address update, subscription restart, provider address update |
| `UpdatePremiumStorageCommand` | Premium storage changes. Latent, not active — the personal price-increase path never stamps cohort metadata. Fixed for consistency. |

Preservation is an unconditional passthrough of the source phase's dictionary — nothing inspects, filters, or rewrites cohort keys, and production code has zero references to the key constants. Each site's deliberate discount handling is untouched.

`UpdateOrganizationSubscriptionCommand` and `RedeemChurnMitigationOfferCommand` already preserved metadata and are unchanged.

No feature flag — there's no behavior to toggle, and a flag-off branch would just be the bug.

**Deferred, tracked separately:** extracting a shared phase-copy helper (held until #8010 merges, which touches `UpdateOrganizationSubscriptionCommand.cs`); tightening schedule-ownership classification to require cohort metadata (the target query isn't on `main` yet); backfilling schedules that already lost metadata.

### Testing

8 new tests, each verified to fail with the production change reverted and pass with it applied — including a multi-phase case where an expired leading phase shifts the surviving indices.

`Billing.Test` 288 passed · `Core.Test` Billing 1003 passed · `dotnet format` clean.
