### PR TITLE
[PM-40161] feat(admin-approval-email): Update copy

### DIFF
--- a/src/Core/MailTemplates/Handlebars/Auth/TrustedDeviceAdminApproval.html.hbs
+++ b/src/Core/MailTemplates/Handlebars/Auth/TrustedDeviceAdminApproval.html.hbs
@@ -14,7 +14,7 @@
     </tr>
     <tr style="margin: 0; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none;">
         <td class="content-block last" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; color: #333; line-height: 25px; margin: 0; -webkit-font-smoothing: antialiased; padding: 0; -webkit-text-size-adjust: none;" valign="top">
-            If you do not recognize this device, contact your organization administrator.
+            If you do not recognize this device, contact your Bitwarden admin.
         </td>
     </tr>
 </table>

--- a/src/Core/MailTemplates/Handlebars/Auth/TrustedDeviceAdminApproval.text.hbs
+++ b/src/Core/MailTemplates/Handlebars/Auth/TrustedDeviceAdminApproval.text.hbs
@@ -5,5 +5,5 @@ Device Type: {{DeviceType}}
 IP Address: {{IpAddress}}
 Date: {{TheDate}} at {{TheTime}} {{TimeZone}}
 
-If you do not recognize this device, contact your organization administrator.
+If you do not recognize this device, contact your Bitwarden admin.
 {{/BasicTextLayout}}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40161](https://bitwarden.atlassian.net/browse/PM-40161)

## 📔 Objective

Update copy for `TrustedDeviceAdminApprovalEmail` (HTML and plaintext) to change "contact your organization administrator" to "contact your Bitwarden admin".

## 📸 Screenshots

### HTML
<img width="1033" height="553" alt="pm-40161_html" src="https://github.com/user-attachments/assets/83cea75f-d29e-4abd-a02c-1528c2695761" />

### Plaintext
<img width="1031" height="332" alt="pm-40161_plaintext" src="https://github.com/user-attachments/assets/c0be5cf0-e080-4a93-8c79-224ae1e237b9" />



[PM-40161]: https://bitwarden.atlassian.net/browse/PM-40161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ