### PR TITLE
[PM-36007] add event logging for changed email

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/IUpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/IUpdateOrganizationUserCommand.cs
@@ -12,7 +12,7 @@ public interface IUpdateOrganizationUserCommand
     /// <item>Autoscales the organization's Secrets Manager seats when enabling Secrets Manager requires more seats.</item>
     /// <item>Updates organization user along with collection access and groups</item>
     /// <item>Creates a default collection when the user is demoted from a privileged role and organization data ownership requires it.</item>
-    /// <item>Logs an <c>OrganizationUser_AdminChangedEmail</c> event if the member's email was changed, otherwise logs an <c>OrganizationUser_Updated</c> event.</item>
+    /// <item>Logs an <c>OrganizationUser_Updated</c> event. Additionally logs an <c>OrganizationUser_AdminChangedEmail</c> event if the member's email was changed.</item>
     /// </list>
     /// </summary>
     /// <param name="request">The user's current state, the requested changes, and the acting user.</param>

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/IUpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/IUpdateOrganizationUserCommand.cs
@@ -12,7 +12,7 @@ public interface IUpdateOrganizationUserCommand
     /// <item>Autoscales the organization's Secrets Manager seats when enabling Secrets Manager requires more seats.</item>
     /// <item>Updates organization user along with collection access and groups</item>
     /// <item>Creates a default collection when the user is demoted from a privileged role and organization data ownership requires it.</item>
-    /// <item>Logs an <c>OrganizationUser_Updated</c> event.</item>
+    /// <item>Logs an <c>OrganizationUser_AdminChangedEmail</c> event if the member's email was changed, otherwise logs an <c>OrganizationUser_Updated</c> event.</item>
     /// </list>
     /// </summary>
     /// <param name="request">The user's current state, the requested changes, and the acting user.</param>

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommand.cs
@@ -64,7 +64,8 @@ public class UpdateOrganizationUserCommand(
             }
         }
 
-        if (request.IsEmailChanged() || request.IsNameChanged())
+        var emailChanged = request.IsEmailChanged();
+        if (emailChanged || request.IsNameChanged())
         {
             var commandError = await TryApplyAccountChangesAsync(request);
             if (commandError is not null)
@@ -89,7 +90,10 @@ public class UpdateOrganizationUserCommand(
                 request.DefaultUserCollectionName!);
         }
 
-        await eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Updated);
+        var eventType = emailChanged
+            ? EventType.OrganizationUser_AdminChangedEmail
+            : EventType.OrganizationUser_Updated;
+        await eventService.LogOrganizationUserEventAsync(organizationUser, eventType);
 
         return new None();
     }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommand.cs
@@ -6,6 +6,7 @@ using Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyRequirements;
 using Bit.Core.AdminConsole.Utilities.v2.Results;
 using Bit.Core.Auth.UserFeatures.UserEmail;
 using Bit.Core.Billing.Pricing;
+using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Business;
@@ -64,10 +65,9 @@ public class UpdateOrganizationUserCommand(
             }
         }
 
-        var emailChanged = request.IsEmailChanged();
-        if (emailChanged || request.IsNameChanged())
+        if (request.IsEmailChanged() || request.IsNameChanged())
         {
-            var commandError = await TryApplyAccountChangesAsync(request);
+            var commandError = await TryApplyAccountChangesAsync(request, organizationUser);
             if (commandError is not null)
             {
                 return commandError;
@@ -90,15 +90,12 @@ public class UpdateOrganizationUserCommand(
                 request.DefaultUserCollectionName!);
         }
 
-        var eventType = emailChanged
-            ? EventType.OrganizationUser_AdminChangedEmail
-            : EventType.OrganizationUser_Updated;
-        await eventService.LogOrganizationUserEventAsync(organizationUser, eventType);
+        await eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Updated);
 
         return new None();
     }
 
-    private async Task<CommandError?> TryApplyAccountChangesAsync(UpdateOrganizationUserRequest request)
+    private async Task<CommandError?> TryApplyAccountChangesAsync(UpdateOrganizationUserRequest request, OrganizationUser organizationUser)
     {
         if (request.UserToUpdate is null)
         {
@@ -122,6 +119,7 @@ public class UpdateOrganizationUserCommand(
                 await changeEmailCommand.ChangeEmailAsync(request.UserToUpdate, request.NewEmail!);
 
                 await TrySendEmailChangedNotificationAsync(previousEmail, request);
+                await eventService.LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_AdminChangedEmail);
             }
             else
             {

--- a/src/Core/Dirt/Enums/EventType.cs
+++ b/src/Core/Dirt/Enums/EventType.cs
@@ -83,6 +83,7 @@ public enum EventType : int
     OrganizationUser_NotificationBannerActionClicked = 1522,
     OrganizationUser_Staged = 1523, // Member provisioned without an invitation (e.g. via SCIM / Directory Connector)
     OrganizationUser_InviteLinkAccepted = 1524, // User accepted an organization invite via invite link
+    OrganizationUser_AdminChangedEmail = 1525, // Admin changed a member's email address
 
     Organization_Updated = 1600,
     Organization_PurgedVault = 1601,

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommandTests.cs
@@ -56,6 +56,9 @@ public class UpdateOrganizationUserCommandTests
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .Received(1)
             .ReplaceAsync(organizationUser, Arg.Any<IEnumerable<CollectionAccessSelection>>());
+        await sutProvider.GetDependency<IEventService>()
+            .Received(1)
+            .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_AdminChangedEmail);
     }
 
     [Theory]
@@ -104,6 +107,23 @@ public class UpdateOrganizationUserCommandTests
         await sutProvider.GetDependency<IPushNotificationService>()
             .DidNotReceiveWithAnyArgs()
             .PushSyncSettingsAsync(Arg.Any<Guid>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateUserAsync_WhenNotEmailChanging_LogsUpdatedEvent(
+        SutProvider<UpdateOrganizationUserCommand> sutProvider,
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser organizationUser)
+    {
+        var request = Setup(sutProvider, organization, organizationUser, newEmail: null);
+
+        var result = await sutProvider.Sut.UpdateUserAsync(request);
+
+        Assert.True(result.IsSuccess);
+        await sutProvider.GetDependency<IEventService>()
+            .Received(1)
+            .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Updated);
     }
 
     [Theory]

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommandTests.cs
@@ -127,6 +127,9 @@ public class UpdateOrganizationUserCommandTests
         await sutProvider.GetDependency<IEventService>()
             .Received(1)
             .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Updated);
+        await sutProvider.GetDependency<IEventService>()
+            .DidNotReceive()
+            .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_AdminChangedEmail);
     }
 
     [Theory]

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommandTests.cs
@@ -59,6 +59,9 @@ public class UpdateOrganizationUserCommandTests
         await sutProvider.GetDependency<IEventService>()
             .Received(1)
             .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_AdminChangedEmail);
+        await sutProvider.GetDependency<IEventService>()
+            .Received(1)
+            .LogOrganizationUserEventAsync(organizationUser, EventType.OrganizationUser_Updated);
     }
 
     [Theory]


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-36007
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
Adds server side event log handling when admins change claimed organization member emails
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots
<img width="1379" height="86" alt="Screenshot 2026-07-29 at 10 37 48 AM" src="https://github.com/user-attachments/assets/04365ecf-498e-45fb-9787-6c60f4663324" />

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
