### PR TITLE
[PM-17002] - Added self host guard to stop autoscale when self hosted and creating a service account.

### DIFF
--- a/src/Api/SecretsManager/Controllers/ServiceAccountsController.cs
+++ b/src/Api/SecretsManager/Controllers/ServiceAccountsController.cs
@@ -18,6 +18,7 @@ using Bit.Core.SecretsManager.Entities;
 using Bit.Core.SecretsManager.Queries.ServiceAccounts.Interfaces;
 using Bit.Core.SecretsManager.Repositories;
 using Bit.Core.Services;
+using Bit.Core.Settings;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -43,7 +44,7 @@ public class ServiceAccountsController : Controller
     private readonly IRevokeAccessTokensCommand _revokeAccessTokensCommand;
     private readonly IPricingClient _pricingClient;
     private readonly IEventService _eventService;
-    private readonly IOrganizationUserRepository _organizationUserRepository;
+    private readonly IGlobalSettings _globalSettings;
 
     public ServiceAccountsController(
         ICurrentContext currentContext,
@@ -62,7 +63,7 @@ public class ServiceAccountsController : Controller
         IRevokeAccessTokensCommand revokeAccessTokensCommand,
         IPricingClient pricingClient,
         IEventService eventService,
-        IOrganizationUserRepository organizationUserRepository)
+        IGlobalSettings globalSettings)
     {
         _currentContext = currentContext;
         _userService = userService;
@@ -80,7 +81,7 @@ public class ServiceAccountsController : Controller
         _createAccessTokenCommand = createAccessTokenCommand;
         _updateSecretsManagerSubscriptionCommand = updateSecretsManagerSubscriptionCommand;
         _eventService = eventService;
-        _organizationUserRepository = organizationUserRepository;
+        _globalSettings = globalSettings;
     }
 
     [HttpGet("/organizations/{organizationId}/service-accounts")]
@@ -136,8 +137,13 @@ public class ServiceAccountsController : Controller
             .CountNewServiceAccountSlotsRequiredAsync(organizationId, 1);
         if (newServiceAccountSlotsRequired > 0)
         {
+            // Self-hosted instances can't autoscale their Stripe subscription, so reject before touching billing.
+            if (_globalSettings.SelfHosted)
+            {
+                throw new BadRequestException("Cannot autoscale on a self-hosted instance.");
+            }
+
             var org = await _organizationRepository.GetByIdAsync(organizationId);
-            // TODO: https://bitwarden.atlassian.net/browse/PM-17002
             var plan = await _pricingClient.GetPlanOrThrow(org!.PlanType);
             var update = new SecretsManagerSubscriptionUpdate(org, plan, true)
                 .AdjustServiceAccounts(newServiceAccountSlotsRequired);

--- a/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerCreateSelfHostTests.cs
+++ b/test/Api.IntegrationTest/SecretsManager/Controllers/ServiceAccountsControllerCreateSelfHostTests.cs
@@ -1,0 +1,91 @@
+﻿using System.Net;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
+using Bit.Api.SecretsManager.Models.Request;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Enums;
+using Bit.Core.Repositories;
+using Bit.Core.SecretsManager.Repositories;
+using Bit.Core.Settings;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.SecretsManager.Controllers;
+
+public class ServiceAccountsControllerCreateSelfHostTests
+    : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private const string _mockEncryptedName =
+        "2.3Uk+WNBIoU5xzmVFNcoWzz==|1MsPIYuRfdOHfu/0uY6H2Q==|/98sp4wb6pHP1VTZ9JcNCYgQjEUMFPlqJgCwRk1YXKg=";
+
+    private readonly ApiApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private readonly LoginHelper _loginHelper;
+
+    private Organization _organization = null!;
+    private string _ownerEmail = null!;
+    private GlobalSettings _globalSettings = null!;
+
+    public ServiceAccountsControllerCreateSelfHostTests(ApiApplicationFactory apiFactory)
+    {
+        _factory = apiFactory;
+        _client = _factory.CreateClient();
+        _loginHelper = new LoginHelper(_factory, _client);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _globalSettings = _factory.GetService<GlobalSettings>();
+        _globalSettings.SelfHosted = false;
+
+        _ownerEmail = $"sh-sa-create-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(_ownerEmail);
+
+        (_organization, var owner) = await OrganizationTestHelpers.SignUpAsync(_factory,
+            plan: PlanType.EnterpriseAnnually, ownerEmail: _ownerEmail, passwordManagerSeats: 5,
+            paymentMethod: PaymentMethodType.Card);
+
+        var organizationRepository = _factory.GetService<IOrganizationRepository>();
+        _organization.UseSecretsManager = true;
+        _organization.SmServiceAccounts = 0;
+        await organizationRepository.ReplaceAsync(_organization);
+
+        var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
+        owner.AccessSecretsManager = true;
+        await organizationUserRepository.ReplaceAsync(owner);
+    }
+
+    [Fact]
+    public async Task Create_WhenSelfHostedAndSlotsInsufficient_DoesNotChangeServiceAccounts()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        _globalSettings.SelfHosted = true;
+
+        var request = new ServiceAccountCreateRequestModel { Name = _mockEncryptedName };
+
+        var response = await _client.PostAsJsonAsync(
+            $"organizations/{_organization.Id}/service-accounts", request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Cannot autoscale on a self-hosted instance.", content);
+
+        var serviceAccountRepository = _factory.GetService<IServiceAccountRepository>();
+        var serviceAccountCount =
+            await serviceAccountRepository.GetServiceAccountCountByOrganizationIdAsync(_organization.Id);
+        Assert.Equal(0, serviceAccountCount);
+
+        var organizationRepository = _factory.GetService<IOrganizationRepository>();
+        var reloadedOrganization = await organizationRepository.GetByIdAsync(_organization.Id);
+        Assert.Equal(0, reloadedOrganization!.SmServiceAccounts);
+    }
+
+    public Task DisposeAsync()
+    {
+        _globalSettings.SelfHosted = false;
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking
[PM-17002](https://bitwarden.atlassian.net/browse/PM-17002)

## 📔 Objective

On self-host, creating a new service account for secrets manager would return a 404 because it wouldn't be able to retrieve the organization's plan. Adding a self-host check before the pricing/subscription calls, so it returns a clear 400 instead.

`Cannot autoscale on a self-hosted instance.`

Added an integration test for the self-host case.

[PM-17002]: https://bitwarden.atlassian.net/browse/PM-17002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ