### PR TITLE
[PM-41225] Extract exception handling into src/Libraries/ExceptionHandling

### DIFF
--- a/bitwarden-server.slnx
+++ b/bitwarden-server.slnx
@@ -20,6 +20,7 @@
     <Project Path="src/Billing/Billing.csproj" />
     <Project Path="src/Core/Core.csproj" />
     <Project Path="src/Libraries/Data/Data.csproj" />
+    <Project Path="src/Libraries/ExceptionHandling/ExceptionHandling.csproj" />
     <Project Path="src/Libraries/SsrfProtection/SsrfProtection.csproj" />
     <Project Path="src/Events/Events.csproj" />
     <Project Path="src/EventsProcessor/EventsProcessor.csproj" />
@@ -62,6 +63,7 @@
     <Project Path="test/Core.IntegrationTest/Core.IntegrationTest.csproj" />
     <Project Path="test/Core.Test/Core.Test.csproj" />
     <Project Path="test/Libraries/Data.Test/Data.Test.csproj" />
+    <Project Path="test/Libraries/ExceptionHandling.Test/ExceptionHandling.Test.csproj" />
     <Project Path="test/Libraries/SsrfProtection.Test/SsrfProtection.Test.csproj" />
     <Project Path="test/Events.IntegrationTest/Events.IntegrationTest.csproj" />
     <Project Path="test/Events.Test/Events.Test.csproj" />

--- a/bitwarden_license/src/Commercial.Core/packages.lock.json
+++ b/bitwarden_license/src/Commercial.Core/packages.lock.json
@@ -1274,6 +1274,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1316,6 +1317,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "ssrfprotection": {

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/packages.lock.json
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/packages.lock.json
@@ -1430,6 +1430,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1472,6 +1473,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.entityframework": {

--- a/bitwarden_license/src/Scim/packages.lock.json
+++ b/bitwarden_license/src/Scim/packages.lock.json
@@ -1111,6 +1111,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1153,6 +1154,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/bitwarden_license/src/Services/Pam/packages.lock.json
+++ b/bitwarden_license/src/Services/Pam/packages.lock.json
@@ -933,6 +933,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -976,6 +977,12 @@
       },
       "data": {
         "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
       },
       "httpextensions": {
         "type": "Project"

--- a/bitwarden_license/src/Sso/packages.lock.json
+++ b/bitwarden_license/src/Sso/packages.lock.json
@@ -1150,6 +1150,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1192,6 +1193,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/bitwarden_license/test/Commercial.Core.Test/packages.lock.json
+++ b/bitwarden_license/test/Commercial.Core.Test/packages.lock.json
@@ -1489,6 +1489,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1545,6 +1546,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "ssrfprotection": {

--- a/bitwarden_license/test/SSO.Test/packages.lock.json
+++ b/bitwarden_license/test/SSO.Test/packages.lock.json
@@ -1670,6 +1670,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1712,6 +1713,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/bitwarden_license/test/Scim.IntegrationTest/packages.lock.json
+++ b/bitwarden_license/test/Scim.IntegrationTest/packages.lock.json
@@ -1315,6 +1315,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1357,6 +1358,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "identity": {

--- a/bitwarden_license/test/Scim.Test/packages.lock.json
+++ b/bitwarden_license/test/Scim.Test/packages.lock.json
@@ -1630,6 +1630,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1672,6 +1673,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/bitwarden_license/test/Services/Pam.Test/packages.lock.json
+++ b/bitwarden_license/test/Services/Pam.Test/packages.lock.json
@@ -1365,6 +1365,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1408,6 +1409,12 @@
       },
       "data": {
         "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
       },
       "httpextensions": {
         "type": "Project"

--- a/bitwarden_license/test/Sso.IntegrationTest/packages.lock.json
+++ b/bitwarden_license/test/Sso.IntegrationTest/packages.lock.json
@@ -1353,6 +1353,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1395,6 +1396,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "identity": {

--- a/perf/MicroBenchmarks/packages.lock.json
+++ b/perf/MicroBenchmarks/packages.lock.json
@@ -1568,6 +1568,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1610,6 +1611,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "identity": {

--- a/src/Admin/packages.lock.json
+++ b/src/Admin/packages.lock.json
@@ -1145,6 +1145,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1187,6 +1188,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/src/Api/packages.lock.json
+++ b/src/Api/packages.lock.json
@@ -1181,6 +1181,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1224,6 +1225,12 @@
       },
       "data": {
         "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
       },
       "httpextensions": {
         "type": "Project"

--- a/src/Billing/packages.lock.json
+++ b/src/Billing/packages.lock.json
@@ -1146,6 +1146,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1188,6 +1189,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -79,6 +79,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Libraries\Data\Data.csproj" />
+    <ProjectReference Include="..\Libraries\ExceptionHandling\ExceptionHandling.csproj" />
     <ProjectReference Include="..\Libraries\SsrfProtection\SsrfProtection.csproj" />
   </ItemGroup>
 

--- a/src/Core/packages.lock.json
+++ b/src/Core/packages.lock.json
@@ -1310,6 +1310,15 @@
       "data": {
         "type": "Project"
       },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
+        "type": "Project"
+      },
       "ssrfprotection": {
         "type": "Project"
       }

--- a/src/Events/packages.lock.json
+++ b/src/Events/packages.lock.json
@@ -1111,6 +1111,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1153,6 +1154,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/src/EventsProcessor/packages.lock.json
+++ b/src/EventsProcessor/packages.lock.json
@@ -1111,6 +1111,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1153,6 +1154,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/src/Icons/packages.lock.json
+++ b/src/Icons/packages.lock.json
@@ -1117,6 +1117,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1159,6 +1160,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/src/Identity/packages.lock.json
+++ b/src/Identity/packages.lock.json
@@ -1111,6 +1111,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1153,6 +1154,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/src/Infrastructure.Dapper/packages.lock.json
+++ b/src/Infrastructure.Dapper/packages.lock.json
@@ -1279,6 +1279,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1321,6 +1322,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "ssrfprotection": {

--- a/src/Infrastructure.EntityFramework/packages.lock.json
+++ b/src/Infrastructure.EntityFramework/packages.lock.json
@@ -1437,6 +1437,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1479,6 +1480,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "ssrfprotection": {

--- a/src/Libraries/ExceptionHandling/BadRequestException.cs
+++ b/src/Libraries/ExceptionHandling/BadRequestException.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Identity;
+﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Bit.Core.Exceptions;

--- a/src/Libraries/ExceptionHandling/BadRequestException.cs
+++ b/src/Libraries/ExceptionHandling/BadRequestException.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Bit.Core.Exceptions;
-
-#nullable enable
 
 public class BadRequestException : Exception
 {

--- a/src/Libraries/ExceptionHandling/ConflictException.cs
+++ b/src/Libraries/ExceptionHandling/ConflictException.cs
@@ -1,6 +1,4 @@
-﻿namespace Bit.Core.Exceptions;
-
-#nullable enable
+namespace Bit.Core.Exceptions;
 
 public class ConflictException : Exception
 {

--- a/src/Libraries/ExceptionHandling/ConflictException.cs
+++ b/src/Libraries/ExceptionHandling/ConflictException.cs
@@ -1,4 +1,4 @@
-namespace Bit.Core.Exceptions;
+﻿namespace Bit.Core.Exceptions;
 
 public class ConflictException : Exception
 {

--- a/src/Libraries/ExceptionHandling/ErrorResponseModel.cs
+++ b/src/Libraries/ExceptionHandling/ErrorResponseModel.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc.ModelBinding;
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Bit.Core.Models.Api;
 

--- a/src/Libraries/ExceptionHandling/ErrorResponseModel.cs
+++ b/src/Libraries/ExceptionHandling/ErrorResponseModel.cs
@@ -1,11 +1,8 @@
-﻿// FIXME: Update this file to be null safe and then delete the line below
-#nullable disable
-
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Bit.Core.Models.Api;
 
-public class ErrorResponseModel : ResponseModel
+public class ErrorResponseModel : Bit.HttpExtensions.ResponseModel
 {
     public ErrorResponseModel()
         : base("error")
@@ -67,10 +64,10 @@ public class ErrorResponseModel : ResponseModel
         ValidationErrors = errors;
     }
 
-    public string Message { get; set; }
-    public Dictionary<string, IEnumerable<string>> ValidationErrors { get; set; }
+    public string? Message { get; set; }
+    public Dictionary<string, IEnumerable<string>>? ValidationErrors { get; set; }
     // For use in development environments.
-    public string ExceptionMessage { get; set; }
-    public string ExceptionStackTrace { get; set; }
-    public string InnerExceptionMessage { get; set; }
+    public string? ExceptionMessage { get; set; }
+    public string? ExceptionStackTrace { get; set; }
+    public string? InnerExceptionMessage { get; set; }
 }

--- a/src/Libraries/ExceptionHandling/ExceptionHandlerEndpointFilter.cs
+++ b/src/Libraries/ExceptionHandling/ExceptionHandlerEndpointFilter.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Exceptions;
+﻿using Bit.Core.Exceptions;
 using Bit.Core.Models.Api;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/src/Libraries/ExceptionHandling/ExceptionHandlerEndpointFilter.cs
+++ b/src/Libraries/ExceptionHandling/ExceptionHandlerEndpointFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Bit.Core.Exceptions;
 using Bit.Core.Models.Api;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -16,11 +15,11 @@ namespace Bit.Core.Utilities;
 internal sealed class ExceptionHandlerEndpointFilter : IEndpointFilter
 {
     private readonly ILogger<ExceptionHandlerEndpointFilter> _logger;
-    private readonly IWebHostEnvironment _environment;
+    private readonly IHostEnvironment _environment;
 
     public ExceptionHandlerEndpointFilter(
         ILogger<ExceptionHandlerEndpointFilter> logger,
-        IWebHostEnvironment environment)
+        IHostEnvironment environment)
     {
         _logger = logger;
         _environment = environment;

--- a/src/Libraries/ExceptionHandling/ExceptionHandlerEndpointFilter.cs
+++ b/src/Libraries/ExceptionHandling/ExceptionHandlerEndpointFilter.cs
@@ -1,0 +1,96 @@
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Api;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Bit.Core.Utilities;
+
+/// <summary>
+/// An <see cref="IEndpointFilter"/> that translates thrown exceptions into Bitwarden's
+/// <see cref="ErrorResponseModel"/> with the same HTTP status codes that
+/// <c>ExceptionHandlerFilterAttribute</c> produces for MVC controllers.
+/// <see cref="AggregateException"/> is not handled and falls through to the default 500 branch.
+/// </summary>
+internal sealed class ExceptionHandlerEndpointFilter : IEndpointFilter
+{
+    private readonly ILogger<ExceptionHandlerEndpointFilter> _logger;
+    private readonly IWebHostEnvironment _environment;
+
+    public ExceptionHandlerEndpointFilter(
+        ILogger<ExceptionHandlerEndpointFilter> logger,
+        IWebHostEnvironment environment)
+    {
+        _logger = logger;
+        _environment = environment;
+    }
+
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        try
+        {
+            return await next(context);
+        }
+        catch (Exception exception)
+        {
+            return Handle(exception);
+        }
+    }
+
+    private IResult Handle(Exception exception)
+    {
+        var message = "An error has occurred.";
+        int statusCode;
+        ErrorResponseModel? validationModel = null;
+
+        switch (exception)
+        {
+            case BadRequestException badRequestException:
+                statusCode = StatusCodes.Status400BadRequest;
+                if (badRequestException.ModelState != null)
+                {
+                    validationModel = new ErrorResponseModel(badRequestException.ModelState);
+                }
+                else
+                {
+                    message = badRequestException.Message;
+                }
+                break;
+            case NotSupportedException when !string.IsNullOrWhiteSpace(exception.Message):
+                message = exception.Message;
+                statusCode = StatusCodes.Status400BadRequest;
+                break;
+            case ApplicationException:
+                statusCode = StatusCodes.Status402PaymentRequired;
+                break;
+            case NotFoundException:
+                message = "Resource not found.";
+                statusCode = StatusCodes.Status404NotFound;
+                break;
+            case UnauthorizedAccessException:
+                message = "Unauthorized.";
+                statusCode = StatusCodes.Status401Unauthorized;
+                break;
+            case ConflictException:
+                message = exception.Message;
+                statusCode = StatusCodes.Status409Conflict;
+                break;
+            default:
+                _logger.LogError(0, exception, "Unhandled exception");
+                message = "An unhandled server error has occurred.";
+                statusCode = StatusCodes.Status500InternalServerError;
+                break;
+        }
+
+        var errorModel = validationModel ?? new ErrorResponseModel(message);
+        if (_environment.IsDevelopment())
+        {
+            errorModel.ExceptionMessage = exception.Message;
+            errorModel.ExceptionStackTrace = exception.StackTrace;
+            errorModel.InnerExceptionMessage = exception.InnerException?.Message;
+        }
+
+        return Results.Json(errorModel, statusCode: statusCode);
+    }
+}

--- a/src/Libraries/ExceptionHandling/ExceptionHandling.csproj
+++ b/src/Libraries/ExceptionHandling/ExceptionHandling.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\HttpExtensions\HttpExtensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Libraries/ExceptionHandling/ExceptionHandlingEndpointExtensions.cs
+++ b/src/Libraries/ExceptionHandling/ExceptionHandlingEndpointExtensions.cs
@@ -1,7 +1,6 @@
-using Bit.Core.Models.Api;
+﻿using Bit.Core.Models.Api;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Metadata;
 
 namespace Bit.Core.Utilities;
 

--- a/src/Libraries/ExceptionHandling/ExceptionHandlingEndpointExtensions.cs
+++ b/src/Libraries/ExceptionHandling/ExceptionHandlingEndpointExtensions.cs
@@ -1,0 +1,60 @@
+using Bit.Core.Models.Api;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+
+namespace Bit.Core.Utilities;
+
+/// <summary>
+/// Extension methods for adding Bitwarden exception handling to Minimal API endpoint groups.
+/// </summary>
+public static class ExceptionHandlingEndpointExtensions
+{
+    private static readonly ProducesResponseTypeMetadata[] _errorResponses =
+    [
+        new(StatusCodes.Status400BadRequest, typeof(ErrorResponseModel), ["application/json"]),
+        new(StatusCodes.Status401Unauthorized, typeof(ErrorResponseModel), ["application/json"]),
+        new(StatusCodes.Status402PaymentRequired, typeof(ErrorResponseModel), ["application/json"]),
+        new(StatusCodes.Status404NotFound, typeof(ErrorResponseModel), ["application/json"]),
+        new(StatusCodes.Status409Conflict, typeof(ErrorResponseModel), ["application/json"]),
+        new(StatusCodes.Status500InternalServerError, typeof(ErrorResponseModel), ["application/json"]),
+    ];
+
+    /// <summary>
+    /// Adds the Bitwarden exception handling filter to the builder. The filter translates thrown exceptions into
+    /// <see cref="Bit.Core.Models.Api.ErrorResponseModel"/> responses with appropriate HTTP status codes,
+    /// mirroring the behavior of <c>ExceptionHandlerFilterAttribute</c> used by MVC controllers.
+    /// Place this before other filters on the group so it wraps the full endpoint pipeline.
+    /// </summary>
+    /// <remarks>
+    /// Differences from <c>ExceptionHandlerFilterAttribute</c>:
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     Stripe-specific exceptions (<c>StripeException</c>, <c>GatewayException</c>,
+    ///     <c>BillingException</c>) are not handled and fall through to the default 500 branch.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <c>SecurityTokenValidationException</c> (403 Forbidden) is not handled; token validation
+    ///     failures are expected to be caught by authentication middleware before reaching the endpoint.
+    ///   </description></item>
+    ///   <item><description>
+    ///     Always produces the internal <see cref="Bit.Core.Models.Api.ErrorResponseModel"/> shape;
+    ///     there is no public-API mode.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <see cref="AggregateException"/> is not handled and falls through to the default 500 branch.
+    ///     The known throw sites in the codebase (organization invite, license validation) accumulate
+    ///     inner exceptions via bare <c>catch (Exception)</c> blocks, so the inner exceptions are
+    ///     uncontrolled infrastructure errors rather than typed user-facing messages. Mapping them to
+    ///     400 and surfacing their messages would leak internal detail.
+    ///   </description></item>
+    /// </list>
+    /// </remarks>
+    public static TBuilder WithBasicExceptionHandling<TBuilder>(this TBuilder builder)
+        where TBuilder : IEndpointConventionBuilder
+    {
+        builder.AddEndpointFilter<TBuilder, ExceptionHandlerEndpointFilter>();
+        builder.WithMetadata(_errorResponses);
+        return builder;
+    }
+}

--- a/src/Libraries/ExceptionHandling/NotFoundException.cs
+++ b/src/Libraries/ExceptionHandling/NotFoundException.cs
@@ -1,4 +1,4 @@
-namespace Bit.Core.Exceptions;
+﻿namespace Bit.Core.Exceptions;
 
 public class NotFoundException : Exception
 {

--- a/src/Libraries/ExceptionHandling/NotFoundException.cs
+++ b/src/Libraries/ExceptionHandling/NotFoundException.cs
@@ -1,6 +1,4 @@
-﻿namespace Bit.Core.Exceptions;
-
-#nullable enable
+namespace Bit.Core.Exceptions;
 
 public class NotFoundException : Exception
 {

--- a/src/Libraries/ExceptionHandling/packages.lock.json
+++ b/src/Libraries/ExceptionHandling/packages.lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "httpextensions": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/Notifications/packages.lock.json
+++ b/src/Notifications/packages.lock.json
@@ -1156,6 +1156,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1198,6 +1199,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/src/SharedWeb/packages.lock.json
+++ b/src/SharedWeb/packages.lock.json
@@ -1465,6 +1465,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1507,6 +1508,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/test/Admin.Test/packages.lock.json
+++ b/test/Admin.Test/packages.lock.json
@@ -1682,6 +1682,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1724,6 +1725,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/test/Api.IntegrationTest/packages.lock.json
+++ b/test/Api.IntegrationTest/packages.lock.json
@@ -1423,6 +1423,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1466,6 +1467,12 @@
       },
       "data": {
         "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
       },
       "httpextensions": {
         "type": "Project"

--- a/test/Api.Test/packages.lock.json
+++ b/test/Api.Test/packages.lock.json
@@ -1776,6 +1776,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1833,6 +1834,12 @@
       },
       "data": {
         "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
       },
       "httpextensions": {
         "type": "Project"

--- a/test/Billing.IntegrationTest/packages.lock.json
+++ b/test/Billing.IntegrationTest/packages.lock.json
@@ -1951,6 +1951,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1994,6 +1995,12 @@
       },
       "data": {
         "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
       },
       "httpextensions": {
         "type": "Project"

--- a/test/Billing.Test/packages.lock.json
+++ b/test/Billing.Test/packages.lock.json
@@ -1728,6 +1728,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1784,6 +1785,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/test/Common/packages.lock.json
+++ b/test/Common/packages.lock.json
@@ -1433,6 +1433,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1475,6 +1476,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "ssrfprotection": {

--- a/test/Core.IntegrationTest/packages.lock.json
+++ b/test/Core.IntegrationTest/packages.lock.json
@@ -1408,6 +1408,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1450,6 +1451,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "ssrfprotection": {

--- a/test/Core.Test/packages.lock.json
+++ b/test/Core.Test/packages.lock.json
@@ -1487,6 +1487,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1529,6 +1530,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "ssrfprotection": {

--- a/test/Events.IntegrationTest/packages.lock.json
+++ b/test/Events.IntegrationTest/packages.lock.json
@@ -1750,6 +1750,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1808,6 +1809,15 @@
           "OpenTelemetry.Instrumentation.SqlClient": "[1.12.0-beta.3, )",
           "SharedWeb": "[2026.7.2, )"
         }
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
+        "type": "Project"
       },
       "identity": {
         "type": "Project",

--- a/test/Events.Test/packages.lock.json
+++ b/test/Events.Test/packages.lock.json
@@ -1631,6 +1631,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1689,6 +1690,15 @@
           "OpenTelemetry.Instrumentation.SqlClient": "[1.12.0-beta.3, )",
           "SharedWeb": "[2026.7.2, )"
         }
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
+        "type": "Project"
       },
       "infrastructure.dapper": {
         "type": "Project",

--- a/test/EventsProcessor.Test/packages.lock.json
+++ b/test/EventsProcessor.Test/packages.lock.json
@@ -1547,6 +1547,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1605,6 +1606,15 @@
           "OpenTelemetry.Instrumentation.SqlClient": "[1.12.0-beta.3, )",
           "SharedWeb": "[2026.7.2, )"
         }
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
+        "type": "Project"
       },
       "infrastructure.dapper": {
         "type": "Project",

--- a/test/Icons.Test/packages.lock.json
+++ b/test/Icons.Test/packages.lock.json
@@ -1635,6 +1635,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1677,6 +1678,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "icons": {

--- a/test/Identity.IntegrationTest/packages.lock.json
+++ b/test/Identity.IntegrationTest/packages.lock.json
@@ -1336,6 +1336,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1392,6 +1393,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "identity": {

--- a/test/Identity.Test/packages.lock.json
+++ b/test/Identity.Test/packages.lock.json
@@ -1667,6 +1667,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1709,6 +1710,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "identity": {

--- a/test/Infrastructure.Dapper.Test/packages.lock.json
+++ b/test/Infrastructure.Dapper.Test/packages.lock.json
@@ -1370,6 +1370,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1412,6 +1413,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/test/Infrastructure.EFIntegration.Test/packages.lock.json
+++ b/test/Infrastructure.EFIntegration.Test/packages.lock.json
@@ -1646,6 +1646,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1702,6 +1703,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/test/Infrastructure.IntegrationTest/packages.lock.json
+++ b/test/Infrastructure.IntegrationTest/packages.lock.json
@@ -1629,6 +1629,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1671,6 +1672,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/test/IntegrationTestCommon/packages.lock.json
+++ b/test/IntegrationTestCommon/packages.lock.json
@@ -1737,6 +1737,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1779,6 +1780,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "identity": {

--- a/test/Libraries/ExceptionHandling.Test/ExceptionHandlerEndpointFilterTests.cs
+++ b/test/Libraries/ExceptionHandling.Test/ExceptionHandlerEndpointFilterTests.cs
@@ -73,10 +73,6 @@ public class ExceptionHandlerEndpointFilterTests
         return JsonSerializer.Deserialize<JsonElement>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
     }
 
-    // -------------------------------------------------------------------------
-    // Exception → status code mapping
-    // -------------------------------------------------------------------------
-
     [Fact]
     public async Task BadRequestException_Returns400WithExceptionMessage()
     {
@@ -212,10 +208,6 @@ public class ExceptionHandlerEndpointFilterTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
-    // -------------------------------------------------------------------------
-    // Development vs production exception detail exposure
-    // -------------------------------------------------------------------------
-
     [Fact]
     public async Task DevelopmentEnvironment_ExposesExceptionDetails()
     {
@@ -244,10 +236,6 @@ public class ExceptionHandlerEndpointFilterTests
             !body.TryGetProperty("exceptionMessage", out var val) || val.ValueKind == JsonValueKind.Null,
             "exceptionMessage must not be present in production responses");
     }
-
-    // -------------------------------------------------------------------------
-    // ProducesResponseTypeMetadata registration
-    // -------------------------------------------------------------------------
 
     [Theory]
     [InlineData(StatusCodes.Status400BadRequest)]

--- a/test/Libraries/ExceptionHandling.Test/ExceptionHandlerEndpointFilterTests.cs
+++ b/test/Libraries/ExceptionHandling.Test/ExceptionHandlerEndpointFilterTests.cs
@@ -1,0 +1,271 @@
+using System.Net;
+using System.Text.Json;
+using Bit.Core.Exceptions;
+using Bit.Core.Models.Api;
+using Bit.Core.Utilities;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Bit.ExceptionHandling.Test;
+
+/// <summary>
+/// Tests for <see cref="ExceptionHandlingEndpointExtensions.WithBasicExceptionHandling{TBuilder}"/>,
+/// covering both the exception-to-response mapping produced by the endpoint filter and the
+/// <see cref="ProducesResponseTypeMetadata"/> that the extension registers on the endpoint.
+/// </summary>
+public class ExceptionHandlerEndpointFilterTests
+{
+    /// <summary>
+    /// Thin wrapper around a started <see cref="WebApplication"/> backed by <see cref="TestServer"/>.
+    /// The single endpoint GET /test has <c>WithBasicExceptionHandling</c> applied.
+    /// </summary>
+    private sealed class TestApp : IAsyncDisposable
+    {
+        private readonly WebApplication _app;
+        public HttpClient Client { get; }
+
+        private TestApp(WebApplication app)
+        {
+            _app = app;
+            Client = app.GetTestClient();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+
+        /// <summary>
+        /// Creates and starts a test app whose single endpoint delegates to <paramref name="handler"/>.
+        /// Set <paramref name="isDevelopment"/> to exercise the development-only exception detail path.
+        /// </summary>
+        public static async Task<TestApp> CreateAsync(Func<IResult> handler, bool isDevelopment = false)
+        {
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            {
+                EnvironmentName = isDevelopment ? Environments.Development : Environments.Production,
+            });
+            builder.Logging.ClearProviders();
+            builder.WebHost.UseTestServer();
+            var app = builder.Build();
+
+            app.MapGet("/test", handler).WithBasicExceptionHandling();
+
+            await app.StartAsync();
+            return new TestApp(app);
+        }
+
+        public IReadOnlyList<Endpoint> Endpoints =>
+            ((IEndpointRouteBuilder)_app).DataSources.SelectMany(ds => ds.Endpoints).ToList();
+    }
+
+    private static async Task<JsonElement> ReadJsonAsync(HttpResponseMessage response)
+    {
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<JsonElement>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+    }
+
+    // -------------------------------------------------------------------------
+    // Exception → status code mapping
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task BadRequestException_Returns400WithExceptionMessage()
+    {
+        await using var app = await TestApp.CreateAsync(() => throw new BadRequestException("bad input"));
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("bad input", body.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task BadRequestExceptionWithModelState_Returns400WithValidationErrors()
+    {
+        var modelState = new ModelStateDictionary();
+        modelState.AddModelError("email", "Email is required.");
+        await using var app = await TestApp.CreateAsync(() => throw new BadRequestException(modelState));
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var errorValues = body.GetProperty("validationErrors")
+                              .GetProperty("email")
+                              .EnumerateArray()
+                              .Select(e => e.GetString());
+        Assert.Contains("Email is required.", errorValues);
+    }
+
+    [Fact]
+    public async Task NotSupportedExceptionWithMessage_Returns400()
+    {
+        await using var app = await TestApp.CreateAsync(() => throw new NotSupportedException("feature not supported"));
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("feature not supported", body.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task NotSupportedExceptionWithEmptyMessage_FallsToDefault500()
+    {
+        // The filter only handles NotSupportedException when the message is non-whitespace.
+        await using var app = await TestApp.CreateAsync(() => throw new NotSupportedException(""));
+
+        var response = await app.Client.GetAsync("/test");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ApplicationException_Returns402()
+    {
+        await using var app = await TestApp.CreateAsync(() => throw new ApplicationException());
+
+        var response = await app.Client.GetAsync("/test");
+
+        Assert.Equal(HttpStatusCode.PaymentRequired, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task NotFoundException_Returns404WithStandardMessage()
+    {
+        // The filter always uses "Resource not found." regardless of the exception message.
+        await using var app = await TestApp.CreateAsync(() => throw new NotFoundException("ignored"));
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("Resource not found.", body.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task UnauthorizedAccessException_Returns401()
+    {
+        await using var app = await TestApp.CreateAsync(() => throw new UnauthorizedAccessException());
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("Unauthorized.", body.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task ConflictException_Returns409WithExceptionMessage()
+    {
+        await using var app = await TestApp.CreateAsync(() => throw new ConflictException("already exists"));
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+        Assert.Equal("already exists", body.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task AggregateException_FallsToDefault500()
+    {
+        await using var app = await TestApp.CreateAsync(
+            () => throw new AggregateException(
+                new InvalidOperationException("first error"),
+                new InvalidOperationException("second error")));
+
+        var response = await app.Client.GetAsync("/test");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnhandledException_Returns500WithGenericMessage()
+    {
+        await using var app = await TestApp.CreateAsync(() => throw new InvalidOperationException("internal detail"));
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("An unhandled server error has occurred.", body.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public async Task NoException_PassesThroughResult()
+    {
+        await using var app = await TestApp.CreateAsync(() => Results.Ok());
+
+        var response = await app.Client.GetAsync("/test");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // -------------------------------------------------------------------------
+    // Development vs production exception detail exposure
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task DevelopmentEnvironment_ExposesExceptionDetails()
+    {
+        await using var app = await TestApp.CreateAsync(
+            () => throw new InvalidOperationException("inner details"),
+            isDevelopment: true);
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.Equal("inner details", body.GetProperty("exceptionMessage").GetString());
+        Assert.False(string.IsNullOrEmpty(body.GetProperty("exceptionStackTrace").GetString()));
+    }
+
+    [Fact]
+    public async Task ProductionEnvironment_DoesNotExposeExceptionDetails()
+    {
+        await using var app = await TestApp.CreateAsync(
+            () => throw new InvalidOperationException("inner details"),
+            isDevelopment: false);
+
+        var response = await app.Client.GetAsync("/test");
+        var body = await ReadJsonAsync(response);
+
+        Assert.True(
+            !body.TryGetProperty("exceptionMessage", out var val) || val.ValueKind == JsonValueKind.Null,
+            "exceptionMessage must not be present in production responses");
+    }
+
+    // -------------------------------------------------------------------------
+    // ProducesResponseTypeMetadata registration
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(StatusCodes.Status400BadRequest)]
+    [InlineData(StatusCodes.Status401Unauthorized)]
+    [InlineData(StatusCodes.Status402PaymentRequired)]
+    [InlineData(StatusCodes.Status404NotFound)]
+    [InlineData(StatusCodes.Status409Conflict)]
+    [InlineData(StatusCodes.Status500InternalServerError)]
+    public async Task WithBasicExceptionHandling_RegistersProducesResponseTypeMetadataForStatusCode(int statusCode)
+    {
+        await using var app = await TestApp.CreateAsync(() => Results.Ok());
+
+        var metadata = app.Endpoints
+            .Single()
+            .Metadata
+            .GetOrderedMetadata<ProducesResponseTypeMetadata>();
+
+        Assert.Contains(metadata, m => m.StatusCode == statusCode && m.Type == typeof(ErrorResponseModel));
+    }
+}

--- a/test/Libraries/ExceptionHandling.Test/ExceptionHandlerEndpointFilterTests.cs
+++ b/test/Libraries/ExceptionHandling.Test/ExceptionHandlerEndpointFilterTests.cs
@@ -8,8 +8,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Bit.ExceptionHandling.Test;
@@ -49,12 +49,12 @@ public class ExceptionHandlerEndpointFilterTests
         /// </summary>
         public static async Task<TestApp> CreateAsync(Func<IResult> handler, bool isDevelopment = false)
         {
-            var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+            var builder = WebApplication.CreateEmptyBuilder(new WebApplicationOptions
             {
                 EnvironmentName = isDevelopment ? Environments.Development : Environments.Production,
             });
-            builder.Logging.ClearProviders();
             builder.WebHost.UseTestServer();
+            builder.Services.AddRouting();
             var app = builder.Build();
 
             app.MapGet("/test", handler).WithBasicExceptionHandling();

--- a/test/Libraries/ExceptionHandling.Test/ExceptionHandlerEndpointFilterTests.cs
+++ b/test/Libraries/ExceptionHandling.Test/ExceptionHandlerEndpointFilterTests.cs
@@ -1,11 +1,10 @@
-using System.Net;
+﻿using System.Net;
 using System.Text.Json;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Api;
 using Bit.Core.Utilities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;

--- a/test/Libraries/ExceptionHandling.Test/ExceptionHandling.Test.csproj
+++ b/test/Libraries/ExceptionHandling.Test/ExceptionHandling.Test.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[10.0.8]" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Libraries\ExceptionHandling\ExceptionHandling.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Libraries/ExceptionHandling.Test/packages.lock.json
+++ b/test/Libraries/ExceptionHandling.Test/packages.lock.json
@@ -1,0 +1,119 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
+      },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Direct",
+        "requested": "[10.0.8, 10.0.8]",
+        "resolved": "10.0.8",
+        "contentHash": "HRH/XAke90wkHv9ykCsrvpVqvKOUt53jQzvHHIXrPIPZWAjyPq6B5/InCmPYWvme+WKMXD10rplMAitzNMtC3w=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.0.1, )",
+        "resolved": "18.0.1",
+        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.0.1",
+          "Microsoft.TestPlatform.TestHost": "18.0.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.6.6, )",
+        "resolved": "2.6.6",
+        "contentHash": "MAbOOMtZIKyn2lrAmMlvhX0BhDOX/smyrTB+8WTXnSKkrmTGBS2fm8g1PZtHBPj91Dc5DJA7fY+/81TJ/yUFZw==",
+        "dependencies": {
+          "xunit.analyzers": "1.10.0",
+          "xunit.assert": "2.6.6",
+          "xunit.core": "[2.6.6]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.5.6, )",
+        "resolved": "2.5.6",
+        "contentHash": "CW6uhMXNaQQNMSG1IWhHkBT+V5eqHqn7MP0zfNMhU9wS/sgKX7FGL3rzoaUgt26wkY3bpf7pDVw3IjXhwfiP4w=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.10.0",
+        "contentHash": "Lw8CiDy5NaAWcO6keqD7iZHYUTIuCOcoFrUHw5Sv84ITZ9gFeDybdkVdH0Y2maSlP9fUjtENyiykT44zwFQIHA=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.6.6",
+        "contentHash": "74Cm9lAZOk5TKCz2MvCBCByKsS23yryOKDIMxH3XRDHXmfGM02jKZWzRA7g4mGB41GnBnv/pcWP3vUYkrCtEcg=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.6.6",
+        "contentHash": "tqi7RfaNBqM7t8zx6QHryuBPzmotsZXKGaWnopQG2Ez5UV7JoWuyoNdT6gLpDIcKdGYey6YTXJdSr9IXDMKwjg==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.6.6]",
+          "xunit.extensibility.execution": "[2.6.6]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.6.6",
+        "contentHash": "ty6VKByzbx4Toj4/VGJLEnlmOawqZiMv0in/tLju+ftA+lbWuAWDERM+E52Jfhj4ZYHrAYVa14KHK5T+dq0XxA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.6.6",
+        "contentHash": "UDjIVGj2TepVKN3n32/qXIdb3U6STwTb9L6YEwoQO2A8OxiJS5QAVv2l1aT6tDwwv/9WBmm8Khh/LyHALipcng==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.6.6]"
+        }
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/test/Notifications.Test/packages.lock.json
+++ b/test/Notifications.Test/packages.lock.json
@@ -1730,6 +1730,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1786,6 +1787,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/test/SeederApi.IntegrationTest/packages.lock.json
+++ b/test/SeederApi.IntegrationTest/packages.lock.json
@@ -1330,6 +1330,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1372,6 +1373,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "identity": {

--- a/test/Setup.Test/packages.lock.json
+++ b/test/Setup.Test/packages.lock.json
@@ -1494,6 +1494,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1536,6 +1537,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "migrator": {

--- a/test/SharedWeb.Test/packages.lock.json
+++ b/test/SharedWeb.Test/packages.lock.json
@@ -1688,6 +1688,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1730,6 +1731,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/util/Migrator/packages.lock.json
+++ b/util/Migrator/packages.lock.json
@@ -1292,6 +1292,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1334,6 +1335,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "ssrfprotection": {

--- a/util/MsSqlMigratorUtility/packages.lock.json
+++ b/util/MsSqlMigratorUtility/packages.lock.json
@@ -1310,6 +1310,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1352,6 +1353,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "migrator": {

--- a/util/MySqlMigrations/packages.lock.json
+++ b/util/MySqlMigrations/packages.lock.json
@@ -1551,6 +1551,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1593,6 +1594,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.entityframework": {

--- a/util/PostgresMigrations/packages.lock.json
+++ b/util/PostgresMigrations/packages.lock.json
@@ -1551,6 +1551,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1593,6 +1594,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.entityframework": {

--- a/util/Seeder/packages.lock.json
+++ b/util/Seeder/packages.lock.json
@@ -1461,6 +1461,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1503,6 +1504,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/util/SeederApi/packages.lock.json
+++ b/util/SeederApi/packages.lock.json
@@ -1108,6 +1108,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1150,6 +1151,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/util/SeederUtility/packages.lock.json
+++ b/util/SeederUtility/packages.lock.json
@@ -1480,6 +1480,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1522,6 +1523,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.dapper": {

--- a/util/Setup/packages.lock.json
+++ b/util/Setup/packages.lock.json
@@ -1298,6 +1298,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1340,6 +1341,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "migrator": {

--- a/util/SqlServerEFScaffold/packages.lock.json
+++ b/util/SqlServerEFScaffold/packages.lock.json
@@ -1687,6 +1687,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1730,6 +1731,12 @@
       },
       "data": {
         "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
       },
       "httpextensions": {
         "type": "Project"

--- a/util/SqliteMigrations/packages.lock.json
+++ b/util/SqliteMigrations/packages.lock.json
@@ -1551,6 +1551,7 @@
           "DnsClient": "[1.8.0, 1.8.0]",
           "Duende.IdentityServer": "[7.4.6, 7.4.6]",
           "DuoUniversal": "[1.3.1, 1.3.1]",
+          "ExceptionHandling": "[0.0.1, )",
           "Fido2.AspNet": "[3.0.1, 3.0.1]",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
@@ -1593,6 +1594,15 @@
         }
       },
       "data": {
+        "type": "Project"
+      },
+      "exceptionhandling": {
+        "type": "Project",
+        "dependencies": {
+          "HttpExtensions": "[2026.7.2, )"
+        }
+      },
+      "httpextensions": {
         "type": "Project"
       },
       "infrastructure.entityframework": {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41225

## 📔 Objective

Moves `BadRequestException`, `NotFoundException`, `ConflictException`, and `ErrorResponseModel` out of `src/Core/` into a new `src/Libraries/ExceptionHandling/` library, following the same extraction pattern as `SsrfProtection` (#8066). Types keep their `Bit.Core.*` namespaces so all existing consumers compile without modification.

Introduces `ExceptionHandlerEndpointFilter` (internal) and `WithBasicExceptionHandling<TBuilder>()` (public) — a Minimal API equivalent of the MVC `ExceptionHandlerFilterAttribute`, intended for libraries that expose Minimal API endpoints. The extension also registers `ProducesResponseTypeMetadata` for the standard error status codes (400, 401, 402, 404, 409, 500) for OpenAPI.

**Dependency graph:**
```
HttpExtensions  ←  ExceptionHandling  ←  Core  ←  (everything else)
```

**Behavioral notes:**

- **`ErrorResponseModel` base class change:** The old `Bit.Core.Models.Api.ResponseModel` base used Newtonsoft.Json's `[JsonProperty(Order = -200)]`, which is silently ignored by System.Text.Json. The new base (`Bit.HttpExtensions.ResponseModel`) uses `[JsonPropertyOrder(-200)]`, which STJ respects — `"object": "error"` will now correctly appear first in all STJ-serialized error responses, including those from the existing MVC filter.
- **`AggregateException` not handled:** The known throw sites use bare `catch (Exception)` accumulators, so inner exceptions are uncontrolled infrastructure errors rather than typed user-facing messages. They fall through to the default 500 branch.
- **`SecurityTokenValidationException` not handled:** Token validation failures are caught by authentication middleware before reaching the endpoint.

See the XML doc on `WithBasicExceptionHandling` for the full list of differences from `ExceptionHandlerFilterAttribute`.