### PR TITLE
Seeder: Add UsePam organization override

### DIFF
--- a/util/Seeder/Factories/PlanFeatures.cs
+++ b/util/Seeder/Factories/PlanFeatures.cs
@@ -110,6 +110,7 @@ public static class PlanFeatures
         org.UseInviteLinks = overrides.UseInviteLinks ?? org.UseInviteLinks;
         org.SyncSeats = overrides.SyncSeats ?? org.SyncSeats;
         org.UsePasswordManager = overrides.UsePasswordManager ?? org.UsePasswordManager;
+        org.UsePam = overrides.UsePam ?? org.UsePam;
     }
 
     /// <summary>

--- a/util/Seeder/Options/OrganizationOverrides.cs
+++ b/util/Seeder/Options/OrganizationOverrides.cs
@@ -33,4 +33,5 @@ public sealed record OrganizationOverrides
     public bool? UseInviteLinks { get; init; }
     public bool? SyncSeats { get; init; }
     public bool? UsePasswordManager { get; init; }
+    public bool? UsePam { get; init; }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a `UsePam` flag to `OrganizationOverrides` and applies it in `PlanFeatures.ApplyOrganizationOverrides`, so the seeder can create a usePam-enabled organization. Needed to reach the PAM access-rules feature (`Organization.canManageAccessRules = isAdmin && usePam`) in tests/local dev.
