### PR TITLE
PM-40996 - Add async and post-commit step support to the seeder pipeline

### DIFF
--- a/test/SeederApi.IntegrationTest/CreateSsoConfigStepTests.cs
+++ b/test/SeederApi.IntegrationTest/CreateSsoConfigStepTests.cs
@@ -21,13 +21,13 @@ public class CreateSsoConfigStepTests
     // not here. These cover the guards that don't need a running IdP.
 
     [Fact]
-    public void Execute_NonSamlProvider_SkipsWithoutMutating()
+    public async Task Execute_NonSamlProvider_SkipsWithoutMutatingAsync()
     {
         var org = new Organization { Id = Guid.NewGuid(), Identifier = "unchanged" };
         var context = BuildContext(org);
         var step = new CreateSsoConfigStep("local-sso", "oidc", MemberDecryptionType.MasterPassword);
 
-        step.Execute(context);
+        await step.ExecuteAsync(context);
 
         Assert.Empty(context.SsoConfigs);
         Assert.Equal("unchanged", org.Identifier);

--- a/test/SeederApi.IntegrationTest/Pipeline/RecipeExecutorPostCommitTests.cs
+++ b/test/SeederApi.IntegrationTest/Pipeline/RecipeExecutorPostCommitTests.cs
@@ -1,0 +1,289 @@
+﻿using AutoMapper;
+using Bit.Core.Entities;
+using Bit.Core.Utilities;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Bit.Seeder;
+using Bit.Seeder.Pipeline;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Bit.SeederApi.IntegrationTest.Pipeline;
+
+/// <summary>
+/// Verifies the pre-commit / post-commit partition in <see cref="RecipeExecutor"/> against a real
+/// (in-memory SQLite) database. Row counts are the only signal that proves the commit actually ran —
+/// cleared entity lists prove nothing, because <c>BulkCommitter</c> early-returns on empty lists.
+/// </summary>
+public sealed class RecipeExecutorPostCommitTests : IDisposable
+{
+    private const string _recipe = "post-commit-test";
+
+    private readonly SqliteConnection _connection;
+    private readonly ServiceCollection _services = new();
+    private readonly List<Observation> _log = [];
+    private readonly List<SeederProgressEvent> _events = [];
+
+    private ServiceProvider? _provider;
+
+    public RecipeExecutorPostCommitTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        // DatabaseContext.OnModelCreating resolves IDataProtectionProvider for the
+        // User.Key / User.MasterPassword field converters, so DI must include it.
+        _services.AddLogging();
+        _services.AddDataProtection();
+        _services.AddDbContext<DatabaseContext>(opts => opts.UseSqlite(_connection));
+        _services.AddAutoMapper(typeof(UserRepository));
+        _services.AddSingleton(new SeederSettings());
+        _services.AddSingleton<IProgress<SeederProgressEvent>>(new RecordingProgress(_events));
+    }
+
+    public void Dispose()
+    {
+        _provider?.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task PostCommitStep_RunsAfterCommit_AndSeesCommittedRowAsync()
+    {
+        var owner = NewUser();
+        var builder = _services.AddRecipe(_recipe);
+        builder.AddStep(_ => new RecordingStep("pre", _log, StageOwner(owner)));
+        builder.AddAsyncStep(_ => new RecordingAsyncPostCommitStep("post", _log));
+
+        await BuildExecutor().ExecuteAsync();
+
+        Assert.Equal(["pre", "post"], _log.Select(o => o.Label));
+
+        var pre = _log[0];
+        var post = _log[1];
+
+        // The observation that list-clearing cannot fake: the row is only queryable after the commit.
+        Assert.Equal(0, pre.UsersInDb);
+        Assert.Equal(1, post.UsersInDb);
+
+        // BulkCommitter clears the entity lists, but the registry and the context scalars survive.
+        Assert.Equal(1, pre.UsersInContext);
+        Assert.Equal(0, post.UsersInContext);
+        Assert.Equal(1, post.UserDigestsInRegistry);
+        Assert.Equal(owner.Id, post.OwnerId);
+    }
+
+    [Fact]
+    public async Task PostCommitStep_CannotContributeToResultAsync()
+    {
+        // Pins the snapshot semantics documented on RecipeExecutor.ExecuteAsync: the result is captured
+        // before the commit, so anything a post-commit step adds to the context is invisible to it
+        // (and, because the commit already ran, never reaches the database either).
+        var builder = _services.AddRecipe(_recipe);
+        builder.AddStep(_ => new RecordingStep("pre", _log, StageOwner(NewUser())));
+        builder.AddAsyncStep(_ => new StagingPostCommitStep(NewUser()));
+
+        var result = await BuildExecutor().ExecuteAsync();
+
+        Assert.Equal(1, result.UsersCount);
+        Assert.Equal(1, UsersInDb());
+    }
+
+    [Fact]
+    public async Task PostCommitStep_IsActuallyAwaitedAsync()
+    {
+        // Fire-and-forget guard, with no dependence on scheduling luck. The step blocks on a gate
+        // nobody has completed yet, so an executor that awaits it *cannot* have finished: its task is
+        // observably incomplete. An executor that dropped the await would run the loop to the end and
+        // hand back an already-completed task, failing the first assert.
+        var gate = new TaskCompletionSource();
+        var builder = _services.AddRecipe(_recipe);
+        builder.AddStep(_ => new RecordingStep("pre", _log, StageOwner(NewUser())));
+        builder.AddAsyncStep(_ => new GatedPostCommitStep("post", _log, gate.Task));
+
+        var execution = BuildExecutor().ExecuteAsync();
+
+        Assert.False(execution.IsCompleted);
+        Assert.Equal(["pre"], _log.Select(o => o.Label));
+
+        gate.SetResult();
+        await execution;
+
+        Assert.Equal(["pre", "post"], _log.Select(o => o.Label));
+    }
+
+    [Fact]
+    public async Task PreCommitStep_IsActuallyAwaited_AndBlocksTheCommit()
+    {
+        // Same gate on the higher-consequence side. Dropping the pre-commit await would let
+        // BulkCommitter.Commit run while an async step was still mutating the context, committing
+        // partial data — and every other test here would still pass. Asserting an empty table while
+        // the step is parked is what pins it: the commit provably has not run yet.
+        var gate = new TaskCompletionSource();
+        var builder = _services.AddRecipe(_recipe);
+        builder.AddAsyncStep(_ => new GatedPreCommitStep("pre", _log, gate.Task, StageOwner(NewUser())));
+
+        var execution = BuildExecutor().ExecuteAsync();
+
+        Assert.False(execution.IsCompleted);
+        Assert.Empty(_log);
+        Assert.Equal(0, UsersInDb());
+
+        gate.SetResult();
+        await execution;
+
+        Assert.Equal(["pre"], _log.Select(o => o.Label));
+        Assert.Equal(1, UsersInDb());
+    }
+
+    [Fact]
+    public async Task NoPostCommitSteps_EmitsNoPostCommitPhaseAsync()
+    {
+        // The zero-behavior-change guard: without a post-commit step the progress stream must match
+        // the pre-refactor sequence exactly, or every CLI run gains a visible progress bar.
+        var builder = _services.AddRecipe(_recipe);
+        builder.AddStep(_ => new RecordingStep("pre", _log, StageOwner(NewUser())));
+
+        await BuildExecutor().ExecuteAsync();
+
+        Assert.Collection(_events,
+            e => Assert.Equal(new PhaseStarted(SeederPhases.CommittingToDatabase, null), e),
+            e => Assert.Equal(new PhaseCompleted(SeederPhases.CommittingToDatabase), e));
+    }
+
+    [Fact]
+    public async Task PostCommitStep_RegisteredFirst_StillRunsLastAsync()
+    {
+        // Proves the partition beats the order index rather than registration order happening to match.
+        // Uses the *synchronous* IStep + IPostCommitStep pairing, so the suite covers deferral through
+        // both step interfaces end-to-end (the other tests here defer an IAsyncStep).
+        var builder = _services.AddRecipe(_recipe);
+        builder.AddStep(_ => new RecordingSyncPostCommitStep("post", _log));
+        builder.AddStep(_ => new RecordingStep("pre-a", _log, StageOwner(NewUser())));
+        builder.AddStep(_ => new RecordingStep("pre-b", _log));
+
+        await BuildExecutor().ExecuteAsync();
+
+        Assert.Equal(["pre-a", "pre-b", "post"], _log.Select(o => o.Label));
+        Assert.Equal(1, _log[^1].UsersInDb);
+    }
+
+    /// <summary>
+    /// Builds the container, creates the schema, and wires an executor over the real
+    /// <see cref="BulkCommitter"/>. Call once per test, after every step is registered.
+    /// </summary>
+    private RecipeExecutor BuildExecutor()
+    {
+        _provider = _services.BuildServiceProvider();
+        _provider.GetRequiredService<DatabaseContext>().Database.EnsureCreated();
+
+        var committer = new BulkCommitter(
+            _provider.GetRequiredService<DatabaseContext>(),
+            _provider.GetRequiredService<IMapper>());
+
+        return new RecipeExecutor(_recipe, _provider, committer);
+    }
+
+    private int UsersInDb() => _provider!.GetRequiredService<DatabaseContext>().Users.Count();
+
+    /// <summary>
+    /// Stages a user for the commit the way a real step would: on the context's entity list, on the
+    /// registry, and as the context owner.
+    /// </summary>
+    private static Action<SeederContext> StageOwner(User user) => context =>
+    {
+        context.Users.Add(user);
+        context.Registry.UserDigests.Add(new EntityRegistry.UserDigest(user.Id, Guid.Empty, "unused-vault-key"));
+        context.Owner = user;
+    };
+
+    private static User NewUser() => new()
+    {
+        Id = CoreHelpers.GenerateComb(),
+        Email = $"post-commit-{Guid.NewGuid():N}@bw.example",
+        SecurityStamp = Guid.NewGuid().ToString(),
+        ApiKey = "test-api-key",
+    };
+
+    /// <summary>What a step could see at the moment it ran.</summary>
+    private sealed record Observation(
+        string Label,
+        int UsersInDb,
+        int UsersInContext,
+        int UserDigestsInRegistry,
+        Guid? OwnerId)
+    {
+        internal static Observation Capture(string label, SeederContext context) =>
+            new(label,
+                context.Services.GetRequiredService<DatabaseContext>().Users.Count(),
+                context.Users.Count,
+                context.Registry.UserDigests.Count,
+                context.Owner?.Id);
+    }
+
+    private sealed class RecordingProgress(List<SeederProgressEvent> events) : IProgress<SeederProgressEvent>
+    {
+        public void Report(SeederProgressEvent value) => events.Add(value);
+    }
+
+    private sealed class RecordingStep(string label, List<Observation> log, Action<SeederContext>? stage = null) : IStep
+    {
+        public void Execute(SeederContext context)
+        {
+            stage?.Invoke(context);
+            log.Add(Observation.Capture(label, context));
+        }
+    }
+
+    private sealed class RecordingSyncPostCommitStep(string label, List<Observation> log) : IStep, IPostCommitStep
+    {
+        public void Execute(SeederContext context) => log.Add(Observation.Capture(label, context));
+    }
+
+    /// <summary>Deliberately not <c>async</c>: CS1998 is a build error under TreatWarningsAsErrors.</summary>
+    private sealed class RecordingAsyncPostCommitStep(string label, List<Observation> log) : IAsyncStep, IPostCommitStep
+    {
+        public Task ExecuteAsync(SeederContext context)
+        {
+            log.Add(Observation.Capture(label, context));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class StagingPostCommitStep(User user) : IAsyncStep, IPostCommitStep
+    {
+        public Task ExecuteAsync(SeederContext context)
+        {
+            context.Users.Add(user);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>Blocks on <paramref name="gate"/> so the executor's own task stays observably incomplete.</summary>
+    private sealed class GatedPostCommitStep(string label, List<Observation> log, Task gate) : IAsyncStep, IPostCommitStep
+    {
+        public async Task ExecuteAsync(SeederContext context)
+        {
+            await gate;
+            log.Add(Observation.Capture(label, context));
+        }
+    }
+
+    /// <summary>
+    /// Pre-commit twin of <see cref="GatedPostCommitStep"/> — no <see cref="IPostCommitStep"/> marker.
+    /// Stages its entity only after the gate opens, so a dropped await commits an empty context.
+    /// </summary>
+    private sealed class GatedPreCommitStep(
+        string label,
+        List<Observation> log,
+        Task gate,
+        Action<SeederContext> stage) : IAsyncStep
+    {
+        public async Task ExecuteAsync(SeederContext context)
+        {
+            await gate;
+            stage(context);
+            log.Add(Observation.Capture(label, context));
+        }
+    }
+}

--- a/test/SeederApi.IntegrationTest/Pipeline/RecipeExecutorPostCommitTests.cs
+++ b/test/SeederApi.IntegrationTest/Pipeline/RecipeExecutorPostCommitTests.cs
@@ -199,7 +199,7 @@ public sealed class RecipeExecutorPostCommitTests : IDisposable
 
     private static User NewUser() => new()
     {
-        Id = CoreHelpers.GenerateComb(),
+        Id = CombGuid.Generate(),
         Email = $"post-commit-{Guid.NewGuid():N}@bw.example",
         SecurityStamp = Guid.NewGuid().ToString(),
         ApiKey = "test-api-key",

--- a/test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorIntegrationTests.cs
+++ b/test/SeederApi.IntegrationTest/Pipeline/RecipeOrchestratorIntegrationTests.cs
@@ -12,14 +12,14 @@ using EfUser = Bit.Infrastructure.EntityFramework.Models.User;
 namespace Bit.SeederApi.IntegrationTest.Pipeline;
 
 /// <summary>
-/// Verifies that BOTH <see cref="RecipeOrchestrator"/> <c>Execute</c> overloads
+/// Verifies that BOTH <see cref="RecipeOrchestrator"/> <c>ExecuteAsync</c> overloads
 /// (preset path + options path) actually invoke <c>EnsureOwnerEmailUnique</c>
 /// against the real database. Regression protection against a future change that
 /// silently removes the guard call from one overload.
 /// </summary>
 public sealed class RecipeOrchestratorIntegrationTests : IDisposable
 {
-    private const string CollidingEmail = "exists@bw.example";
+    private const string _collidingEmail = "exists@bw.example";
 
     private readonly SqliteConnection _connection;
     private readonly ServiceProvider _provider;
@@ -49,24 +49,24 @@ public sealed class RecipeOrchestratorIntegrationTests : IDisposable
     }
 
     [Fact]
-    public void Execute_Preset_OwnerEmailCollidesWithExistingUser_Throws()
+    public async Task Execute_Preset_OwnerEmailCollidesWithExistingUser_ThrowsAsync()
     {
-        SeedExistingUser(CollidingEmail);
+        SeedExistingUser(_collidingEmail);
         var orchestrator = NewOrchestrator(new NoOpManglerService());
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            orchestrator.Execute(
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            orchestrator.ExecuteAsync(
                 presetName: "any-preset-never-read",
-                ownerEmailOverride: CollidingEmail));
+                ownerEmailOverride: _collidingEmail));
 
-        Assert.Contains(CollidingEmail, ex.Message);
+        Assert.Contains(_collidingEmail, ex.Message);
         Assert.Contains("--mangle", ex.Message);
     }
 
     [Fact]
-    public void Execute_Options_OwnerEmailCollidesWithExistingUser_Throws()
+    public async Task Execute_Options_OwnerEmailCollidesWithExistingUser_ThrowsAsync()
     {
-        SeedExistingUser(CollidingEmail);
+        SeedExistingUser(_collidingEmail);
         var orchestrator = NewOrchestrator(new NoOpManglerService());
 
         var options = new OrganizationVaultOptions
@@ -74,29 +74,29 @@ public sealed class RecipeOrchestratorIntegrationTests : IDisposable
             Name = "Test Org",
             Domain = "test.example",
             Users = 1,
-            OwnerEmail = CollidingEmail,
+            OwnerEmail = _collidingEmail,
         };
 
-        var ex = Assert.Throws<InvalidOperationException>(() => orchestrator.Execute(options));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => orchestrator.ExecuteAsync(options));
 
-        Assert.Contains(CollidingEmail, ex.Message);
+        Assert.Contains(_collidingEmail, ex.Message);
     }
 
     [Fact]
-    public void Execute_Preset_ManglingEnabled_SkipsGuardEvenIfEmailExists()
+    public async Task Execute_Preset_ManglingEnabled_SkipsGuardEvenIfEmailExistsAsync()
     {
         // With --mangle, the per-run unique tag prevents collisions, so the guard
         // is skipped. We prove execution proceeded past the guard by using an
         // unknown preset name: failure comes from SeedReader ("not found"), not the
         // guard ("already exists"). Both throw InvalidOperationException, so we
         // discriminate by message content.
-        SeedExistingUser(CollidingEmail);
+        SeedExistingUser(_collidingEmail);
         var orchestrator = NewOrchestrator(new ManglerService());
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            orchestrator.Execute(
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            orchestrator.ExecuteAsync(
                 presetName: "non-existent-preset",
-                ownerEmailOverride: CollidingEmail));
+                ownerEmailOverride: _collidingEmail));
 
         Assert.Contains("not found", ex.Message);
         Assert.DoesNotContain("already exists", ex.Message);
@@ -118,7 +118,7 @@ public sealed class RecipeOrchestratorIntegrationTests : IDisposable
     {
         // Mapper, LicensingService, and AttachmentStorageService are not exercised by the pre-flight
         // guard, which fires before BulkCommitter or any AutoMapper usage. Null-forgive them; if the
-        // guard ever stops being the first thing in Execute, these tests will fail loudly.
+        // guard ever stops being the first thing in ExecuteAsync, these tests will fail loudly.
         var deps = new SeederDependencies(
             _db,
             null!,

--- a/test/SeederApi.IntegrationTest/RecipeBuilderValidationTests.cs
+++ b/test/SeederApi.IntegrationTest/RecipeBuilderValidationTests.cs
@@ -165,15 +165,14 @@ public class RecipeBuilderValidationTests
         builder.Validate();
 
         using var provider = services.BuildServiceProvider();
-        var steps = provider.GetKeyedServices<IStep>("test").ToList();
+        var steps = provider.GetKeyedServices<OrderedStep>("test").ToList();
 
         Assert.Equal(7, steps.Count);
 
         // Verify steps are wrapped in OrderedStep with sequential order values
-        var orderedSteps = steps.Cast<OrderedStep>().ToList();
-        for (var i = 0; i < orderedSteps.Count; i++)
+        for (var i = 0; i < steps.Count; i++)
         {
-            Assert.Equal(i, orderedSteps[i].Order);
+            Assert.Equal(i, steps[i].Order);
         }
     }
 
@@ -187,17 +186,69 @@ public class RecipeBuilderValidationTests
         services.AddSingleton<ILicensingService, StubLicensingService>();
 
         using var provider = services.BuildServiceProvider();
-        var steps = provider.GetKeyedServices<IStep>("test")
-            .OrderBy(s => s is OrderedStep os ? os.Order : int.MaxValue)
+        var steps = provider.GetKeyedServices<OrderedStep>("test")
+            .OrderBy(s => s.Order)
             .ToList();
 
         Assert.Equal(2, steps.Count);
         // First step must be the user creation step; second must be the license step.
         // If this order is reversed, GenerateSelfHostUserLicenseStep reads a null context.Owner.
-        var inner0 = ((OrderedStep)steps[0]).Inner;
-        var inner1 = ((OrderedStep)steps[1]).Inner;
+        var inner0 = steps[0].Inner;
+        var inner1 = steps[1].Inner;
         Assert.IsType<CreateIndividualUserStep>(inner0);
         Assert.IsType<GenerateSelfHostUserLicenseStep>(inner1);
+    }
+
+    [Fact]
+    public void AddStep_SyncPostCommitMarker_SetsIsPostCommit()
+    {
+        var services = new ServiceCollection();
+        var builder = services.AddRecipe("test");
+
+        builder.AddStep(_ => new PostCommitSyncStub());
+        builder.AddStep(_ => new SyncStub());
+
+        using var provider = services.BuildServiceProvider();
+        var steps = provider.GetKeyedServices<OrderedStep>("test").OrderBy(s => s.Order).ToList();
+
+        Assert.True(steps[0].IsPostCommit);
+        Assert.False(steps[1].IsPostCommit);
+    }
+
+    [Fact]
+    public void AddAsyncStep_PostCommitMarker_SetsIsPostCommit()
+    {
+        var services = new ServiceCollection();
+        var builder = services.AddRecipe("test");
+
+        builder.AddAsyncStep(_ => new PostCommitAsyncStub());
+        builder.AddAsyncStep(_ => new AsyncStub());
+
+        using var provider = services.BuildServiceProvider();
+        var steps = provider.GetKeyedServices<OrderedStep>("test").OrderBy(s => s.Order).ToList();
+
+        Assert.True(steps[0].IsPostCommit);
+        Assert.False(steps[1].IsPostCommit);
+    }
+
+    private sealed class SyncStub : IStep
+    {
+        public void Execute(SeederContext context) { }
+    }
+
+    private sealed class PostCommitSyncStub : IStep, IPostCommitStep
+    {
+        public void Execute(SeederContext context) { }
+    }
+
+    private sealed class AsyncStub : IAsyncStep
+    {
+        public Task ExecuteAsync(SeederContext context) => Task.CompletedTask;
+    }
+
+    private sealed class PostCommitAsyncStub : IAsyncStep, IPostCommitStep
+    {
+        public Task ExecuteAsync(SeederContext context) => Task.CompletedTask;
     }
 
     private static readonly ISeedReader _stubReader = new StubSeedReader(hasOwner: false);

--- a/test/SeederApi.IntegrationTest/Steps/CreateCipherAttachmentsStepTests.cs
+++ b/test/SeederApi.IntegrationTest/Steps/CreateCipherAttachmentsStepTests.cs
@@ -24,14 +24,14 @@ public sealed class CreateCipherAttachmentsStepTests : IDisposable
     private readonly string _tempDir = Path.Join(Path.GetTempPath(), "seeder-attach-" + Guid.NewGuid().ToString("N"));
 
     [Fact]
-    public void Execute_SeedsAttachmentsAcrossAllVersions()
+    public async Task Execute_SeedsAttachmentsAcrossAllVersionsAsync()
     {
         var context = BuildContext(out var baseDir);
         var userKey = RustSdkService.GenerateUserKeys("attach-test@example.com", "asdfasdfasdf").Key;
         context.Registry.UserDigests.Add(new EntityRegistry.UserDigest(Guid.NewGuid(), Guid.Empty, userKey));
 
         CreateCiphersStep.ForPersonalVault(_fixture).Execute(context);
-        CreateCipherAttachmentsStep.ForPersonalVault(_fixture).Execute(context);
+        await CreateCipherAttachmentsStep.ForPersonalVault(_fixture).ExecuteAsync(context);
 
         // v0 — one attachment with no attachment key; blob decryptable with the vault key.
         var v0Cipher = ByName(context, _v0Name);
@@ -62,7 +62,7 @@ public sealed class CreateCipherAttachmentsStepTests : IDisposable
     }
 
     [Fact]
-    public void Execute_V1AttachmentOnCipherKeyCipher_Throws()
+    public async Task Execute_V1AttachmentOnCipherKeyCipher_ThrowsAsync()
     {
         // v1 wraps the attachment key with the vault key, but a client unwraps it with the cipher
         // key when the host cipher has one — so v1 on a cipher-key cipher would be undecryptable.
@@ -89,13 +89,13 @@ public sealed class CreateCipherAttachmentsStepTests : IDisposable
         context.Registry.FixtureCipherNameToId["BadCombo"] = cipher.Id;
         context.Registry.UserDigests.Add(new EntityRegistry.UserDigest(Guid.NewGuid(), Guid.Empty, "unused-vault-key"));
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            CreateCipherAttachmentsStep.ForPersonalVault("bad").Execute(context));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            CreateCipherAttachmentsStep.ForPersonalVault("bad").ExecuteAsync(context));
         Assert.Contains("v1", ex.Message);
     }
 
     [Fact]
-    public void Execute_V0AttachmentOnCipherKeyCipher_Throws()
+    public async Task Execute_V0AttachmentOnCipherKeyCipher_ThrowsAsync()
     {
         // v0 encrypts the blob and filename with the vault key, but a client decrypts attachment
         // fields with the cipher key when the host cipher has one — so v0 on a cipher-key cipher
@@ -123,8 +123,8 @@ public sealed class CreateCipherAttachmentsStepTests : IDisposable
         context.Registry.FixtureCipherNameToId["BadCombo"] = cipher.Id;
         context.Registry.UserDigests.Add(new EntityRegistry.UserDigest(Guid.NewGuid(), Guid.Empty, "unused-vault-key"));
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            CreateCipherAttachmentsStep.ForPersonalVault("bad").Execute(context));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            CreateCipherAttachmentsStep.ForPersonalVault("bad").ExecuteAsync(context));
         Assert.Contains("v0", ex.Message);
     }
 
@@ -140,7 +140,7 @@ public sealed class CreateCipherAttachmentsStepTests : IDisposable
     }
 
     [Fact]
-    public void Execute_NoopStorageWithAttachments_Throws()
+    public async Task Execute_NoopStorageWithAttachments_ThrowsAsync()
     {
         // A fixture that declares attachments but resolves to Noop storage would commit attachment
         // metadata with no blob written — the step must fail fast instead of silently succeeding.
@@ -150,13 +150,13 @@ public sealed class CreateCipherAttachmentsStepTests : IDisposable
 
         CreateCiphersStep.ForPersonalVault(_fixture).Execute(context);
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
-            CreateCipherAttachmentsStep.ForPersonalVault(_fixture).Execute(context));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            CreateCipherAttachmentsStep.ForPersonalVault(_fixture).ExecuteAsync(context));
         Assert.Contains("NoopAttachmentStorageService", ex.Message);
     }
 
     [Fact]
-    public void Execute_NoopStorageNoAttachments_DoesNotThrow()
+    public async Task Execute_NoopStorageNoAttachments_DoesNotThrowAsync()
     {
         // The guard only fires when the fixture actually declares attachments; a fixture with none
         // must still complete under Noop storage (the early return runs before the guard).
@@ -175,7 +175,7 @@ public sealed class CreateCipherAttachmentsStepTests : IDisposable
         var context = BuildNoopContext(new SeederStepTestHelpers.StubSeedReader().Add("ciphers.none", seedFile));
         context.Registry.UserDigests.Add(new EntityRegistry.UserDigest(Guid.NewGuid(), Guid.Empty, "unused-vault-key"));
 
-        CreateCipherAttachmentsStep.ForPersonalVault("none").Execute(context); // must not throw
+        await CreateCipherAttachmentsStep.ForPersonalVault("none").ExecuteAsync(context); // must not throw
     }
 
     private static Cipher ByName(SeederContext context, string name) =>

--- a/util/Seeder/CLAUDE.md
+++ b/util/Seeder/CLAUDE.md
@@ -36,16 +36,18 @@ Need to create test data?
 
 **Modern pattern for composable fixture-based and generated seeding.**
 
-**Flow**: Preset JSON or Options → RecipeOrchestrator → RecipeBuilder → IStep[] → RecipeExecutor → SeederContext → BulkCommitter
+**Flow**: Preset JSON or Options → RecipeOrchestrator → RecipeBuilder → IStep/IAsyncStep[] → RecipeExecutor → SeederContext → BulkCommitter → IPostCommitStep[]
 
 **Key actors**:
 
 - **RecipeBuilder**: Fluent API with dependency validation
-- **IStep**: Isolated units of work (CreateOrganizationStep, CreateUsersStep, etc.)
+- **IStep / IAsyncStep**: Isolated units of work (CreateOrganizationStep, CreateUsersStep, etc.). Use `IAsyncStep` for steps that do real I/O. A step additionally marked `IPostCommitStep` is deferred until after the bulk commit, so it observes committed rows — but sees cleared entity lists, since only the `EntityRegistry` and the context's scalar properties survive the commit.
 - **SeederContext**: Shared mutable state bag (NOT thread-safe)
-- **RecipeExecutor**: Executes steps sequentially, captures statistics, commits via BulkCommitter
+- **RecipeExecutor**: Awaits steps sequentially, captures statistics, commits via BulkCommitter, then runs any post-commit steps
 - **RecipeOrchestrator**: Orchestrates recipe building and execution (from presets or options)
-- **SeederDependencies** (`Options/`): Bundles infrastructure services (`DatabaseContext`, `IMapper`, `IPasswordHasher<User>`, `IManglerService`) into a single record. Recipes and the Orchestrator accept this instead of loose parameters. The CLI utility builds it via `SeederServiceFactory.Create().ToDependencies()`.
+- **SeederDependencies** (`Options/`): Bundles infrastructure services (`DatabaseContext`, `IMapper`, `IPasswordHasher<User>`, `IManglerService`, `ILicensingService`, `IAttachmentStorageService`) into a single record. Recipes and the Orchestrator accept this instead of loose parameters. The CLI utility builds it via `SeederServiceFactory.Create().ToDependencies()`.
+
+**Why two step interfaces, not one async contract?** Deliberate — don't unify. Collapsing to one `Task ExecuteAsync(SeederContext)` costs: rewrite 22 step classes (18 in `Steps/`, 4 test doubles); force 20 `.Execute(context)` sites in `test/SeederApi.IntegrationTest/Steps/` to `await`, their test methods to `async`; and `TreatWarningsAsErrors` is on repo-wide (`Directory.Build.props`), so CS1998 makes `async` without `await` a build error — every sync step needs `return Task.CompletedTask`. Permanent trap. The split costs less: two-arm union in `OrderedStep`, `object`-typed `Inner`, one duplicated `RecipeBuilder` registration. Diverges from `IScene`/`IQuery` — single `Task`-returning, no sync twin.
 
 **Fixture/preset separation**: Fixtures (organizations, rosters, ciphers) are independent and never reference each other. The preset is the only layer that composes fixtures and defines cross-cutting relationships (folder assignments, favorites). See `Seeds/docs/architecture.md`.
 
@@ -58,7 +60,7 @@ See `Pipeline/` folder for implementation.
 
 ## Parallelism
 
-Steps execute sequentially (phase order preserved by RecipeExecutor). Within a step, `CreateUsersStep` and `GeneratePersonalCiphersStep` use `Parallel.For` internally for CPU-bound Rust FFI work (key generation, encryption).
+Steps execute sequentially (phase order preserved by RecipeExecutor). Async steps are awaited one at a time and MUST NOT be batched with `Task.WhenAll` — `SeederContext` is not thread-safe and each step reads state written by the ones before it. Within a step, `CreateUsersStep` and `GeneratePersonalCiphersStep` use `Parallel.For` internally for CPU-bound Rust FFI work (key generation, encryption).
 
 **Thread-safety requirements:**
 
@@ -71,7 +73,7 @@ Steps execute sequentially (phase order preserved by RecipeExecutor). Within a s
 When measuring step-level performance changes, use paired worktrees:
 
 - Create `server-PM-XXXXX/perf-baseline` and `server-PM-XXXXX/perf-optimized` worktrees
-- Both worktrees get `Stopwatch` timing in `RecipeExecutor.Execute()` (the baseline measurement)
+- Both worktrees get `Stopwatch` timing in `RecipeExecutor.ExecuteAsync()` (the baseline measurement)
 - Only the optimized worktree gets actual code changes
 - Run presets with `--mangle` flag to avoid DB collisions between runs
 - Compare per-step timings across 3+ runs each, discard the first run (JIT warmup)
@@ -109,9 +111,9 @@ New files under `Data/` belong in the matching subfolder (`Distributions/`, `Enu
 Recipes follow strict rules:
 
 1. A Recipe SHALL accept `SeederDependencies` as its single constructor parameter
-2. A Recipe SHALL have exactly one public method named `Seed()`
+2. A Recipe SHALL have exactly one public entry point — `Seed()` when synchronous, `SeedAsync()` when it returns `Task`/`Task<T>`. Pipeline-backed Recipes (`OrganizationRecipe`, `IndividualUserRecipe`) are async; the direct-to-database Recipes (`CollectionsRecipe`, `GroupsRecipe`, `OrganizationDomainRecipe`, `OrganizationWithUsersRecipe`) remain synchronous.
 3. A Recipe MUST produce one cohesive result
-4. A Recipe MAY have overloaded `Seed()` methods with different parameters
+4. A Recipe MAY overload that entry point with different parameters
 5. A Recipe SHALL use private helper methods for internal steps
 6. A Recipe SHALL use BulkCopy for performance when creating multiple entities
 7. A Recipe SHALL compose Factories for individual entity creation

--- a/util/Seeder/IAsyncStep.cs
+++ b/util/Seeder/IAsyncStep.cs
@@ -1,0 +1,20 @@
+﻿using Bit.Seeder.Pipeline;
+
+namespace Bit.Seeder;
+
+/// <summary>
+/// An asynchronous unit of pipeline work. Register with <c>RecipeBuilder.AddAsyncStep</c>.
+/// </summary>
+/// <remarks>
+/// Parallel to <see cref="IStep"/> rather than derived from it: a step is either synchronous or
+/// asynchronous, never both.
+/// <para>
+/// <strong>Steps are awaited strictly sequentially.</strong> Never dispatch steps with
+/// <c>Task.WhenAll</c> or any other concurrent scheduling. <see cref="SeederContext"/> and the
+/// pipeline's progress ticker are not thread-safe, and later steps read state earlier steps write.
+/// </para>
+/// </remarks>
+public interface IAsyncStep
+{
+    Task ExecuteAsync(SeederContext context);
+}

--- a/util/Seeder/IPostCommitStep.cs
+++ b/util/Seeder/IPostCommitStep.cs
@@ -1,0 +1,13 @@
+﻿namespace Bit.Seeder;
+
+/// <summary>
+/// Marker applied alongside <see cref="IStep"/> or <see cref="IAsyncStep"/> to defer a step until
+/// after <c>BulkCommitter.Commit</c> has flushed the pipeline's entities to the database.
+/// </summary>
+/// <remarks>
+/// Post-commit steps observe committed rows but see cleared entity lists on the
+/// <c>SeederContext</c>; the <c>EntityRegistry</c> and the context's scalar properties survive.
+/// The execution result is snapshotted before the commit, so a post-commit step cannot contribute
+/// to it.
+/// </remarks>
+public interface IPostCommitStep;

--- a/util/Seeder/Pipeline/OrderedStep.cs
+++ b/util/Seeder/Pipeline/OrderedStep.cs
@@ -1,14 +1,62 @@
 ﻿namespace Bit.Seeder.Pipeline;
 
 /// <summary>
-/// Wraps an <see cref="IStep"/> with an order index for keyed DI registration
-/// where GetKeyedServices does not guarantee order.
+/// Wraps an <see cref="IStep"/> or <see cref="IAsyncStep"/> with an order index and a post-commit
+/// flag for keyed DI registration, where GetKeyedServices does not guarantee order.
 /// </summary>
-internal sealed class OrderedStep(IStep inner, int order) : IStep
+/// <remarks>
+/// Deliberately does not implement <see cref="IAsyncStep"/>: nothing resolves that interface from DI,
+/// and implementing it would let an <see cref="OrderedStep"/> be passed back to
+/// <c>RecipeBuilder.AddAsyncStep</c> and silently double-wrapped.
+/// </remarks>
+internal sealed class OrderedStep
 {
-    internal int Order { get; } = order;
+    private readonly IStep? _sync;
 
-    internal IStep Inner { get; } = inner;
+    private readonly IAsyncStep? _async;
 
-    public void Execute(SeederContext context) => Inner.Execute(context);
+    // Guarded so exactly one arm is always populated: RecipeBuilder.AddStep/AddAsyncStep are public
+    // and take a caller-supplied factory, so a null return would otherwise leave both fields null and
+    // surface as a NullReferenceException from the *async* arm of ExecuteAsync.
+    internal OrderedStep(IStep step, int order, bool isPostCommit)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        _sync = step;
+        Order = order;
+        IsPostCommit = isPostCommit;
+    }
+
+    internal OrderedStep(IAsyncStep step, int order, bool isPostCommit)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+        _async = step;
+        Order = order;
+        IsPostCommit = isPostCommit;
+    }
+
+    internal int Order { get; }
+
+    internal bool IsPostCommit { get; }
+
+    /// <summary>
+    /// The wrapped step. Typed as <see cref="object"/> because <see cref="IStep"/> and
+    /// <see cref="IAsyncStep"/> share no base type; exposed only so tests can assert registration
+    /// order by concrete step type.
+    /// </summary>
+    internal object Inner => _sync ?? (object)_async!;
+
+    /// <summary>
+    /// Runs the wrapped step. Synchronous steps run inline on the calling thread and return an
+    /// already-completed task, so awaiting this never yields for them.
+    /// </summary>
+    internal Task ExecuteAsync(SeederContext context)
+    {
+        if (_sync is not null)
+        {
+            _sync.Execute(context);
+            return Task.CompletedTask;
+        }
+
+        return _async!.ExecuteAsync(context);
+    }
 }

--- a/util/Seeder/Pipeline/RecipeBuilder.cs
+++ b/util/Seeder/Pipeline/RecipeBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Bit.Seeder.Pipeline;
 
@@ -10,19 +9,13 @@ namespace Bit.Seeder.Pipeline;
 /// Wraps <see cref="IServiceCollection"/> and a recipe name, tracking step count for
 /// deterministic ordering and validation flags for dependency rules.
 /// </remarks>
-public class RecipeBuilder
+public class RecipeBuilder(string name, IServiceCollection services)
 {
     private int _stepOrder;
 
-    public RecipeBuilder(string name, IServiceCollection services)
-    {
-        Name = name;
-        Services = services;
-    }
+    public string Name { get; } = name;
 
-    public string Name { get; }
-
-    public IServiceCollection Services { get; }
+    public IServiceCollection Services { get; } = services;
 
     internal bool HasOrg { get; set; }
 
@@ -58,20 +51,27 @@ public class RecipeBuilder
     public RecipeBuilder AddStep(Func<IServiceProvider, IStep> factory)
     {
         var order = _stepOrder++;
-        Services.AddKeyedSingleton<IStep>(Name, (sp, _) => new OrderedStep(factory(sp), order));
+        Services.AddKeyedSingleton(Name, (sp, _) =>
+        {
+            var step = factory(sp);
+            return new OrderedStep(step, order, step is IPostCommitStep);
+        });
         return this;
     }
 
     /// <summary>
-    /// Registers a step type as a keyed singleton with preserved ordering.
+    /// Registers an asynchronous step as a keyed singleton service with preserved ordering.
     /// </summary>
-    /// <typeparam name="T">The step implementation type</typeparam>
+    /// <param name="factory">Factory function that creates the step from an IServiceProvider</param>
     /// <returns>This builder for fluent chaining</returns>
-    public RecipeBuilder AddStep<T>() where T : class, IStep
+    public RecipeBuilder AddAsyncStep(Func<IServiceProvider, IAsyncStep> factory)
     {
         var order = _stepOrder++;
-        Services.AddKeyedSingleton<IStep>(Name, (sp, _) => new OrderedStep(sp.GetRequiredService<T>(), order));
-        Services.TryAddSingleton<T>();
+        Services.AddKeyedSingleton(Name, (sp, _) =>
+        {
+            var step = factory(sp);
+            return new OrderedStep(step, order, step is IPostCommitStep);
+        });
         return this;
     }
 }

--- a/util/Seeder/Pipeline/RecipeBuilderExtensions.cs
+++ b/util/Seeder/Pipeline/RecipeBuilderExtensions.cs
@@ -139,7 +139,7 @@ public static class RecipeBuilderExtensions
             throw new InvalidOperationException("SSO configuration requires a non-empty identifier.");
         }
 
-        builder.AddStep(_ => new CreateSsoConfigStep(identifier, provider, memberDecryptionType));
+        builder.AddAsyncStep(_ => new CreateSsoConfigStep(identifier, provider, memberDecryptionType));
         return builder;
     }
 
@@ -172,7 +172,7 @@ public static class RecipeBuilderExtensions
         builder.AddStep(_ => new CreateIndividualUserStep(email, premium, maxStorageGb, true));
         if (selfHosted)
         {
-            builder.AddStep(sp => new GenerateSelfHostUserLicenseStep(sp.GetRequiredService<ILicensingService>()));
+            builder.AddAsyncStep(sp => new GenerateSelfHostUserLicenseStep(sp.GetRequiredService<ILicensingService>()));
         }
         return builder;
     }
@@ -396,7 +396,7 @@ public static class RecipeBuilderExtensions
                 "Cipher attachments require fixture ciphers. Call UseCiphers() or UsePersonalVaultCiphers() first.");
         }
 
-        builder.AddStep(_ => personal
+        builder.AddAsyncStep(_ => personal
             ? CreateCipherAttachmentsStep.ForPersonalVault(fixture)
             : CreateCipherAttachmentsStep.ForOrganization(fixture));
         return builder;

--- a/util/Seeder/Pipeline/RecipeExecutor.cs
+++ b/util/Seeder/Pipeline/RecipeExecutor.cs
@@ -22,23 +22,39 @@ internal sealed class RecipeExecutor
     }
 
     /// <summary>
-    /// Executes the recipe by resolving keyed steps, running them in order, and committing results.
+    /// Executes the recipe by resolving keyed steps, running the pre-commit steps in order, committing,
+    /// then running any steps marked <see cref="IPostCommitStep"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Clears the EntityRegistry at the start to ensure a clean slate for each run.
+    /// </para>
+    /// <para>
+    /// <strong>Steps are awaited strictly sequentially.</strong> Never batch them with
+    /// <c>Task.WhenAll</c>: <see cref="SeederContext"/> is not thread-safe and each step reads state
+    /// written by the ones before it. Synchronous steps return an already-completed task, so they
+    /// still run inline on the calling thread in registration order.
+    /// </para>
+    /// <para>
+    /// The returned <see cref="PipelineExecutionResult"/> is snapshotted <em>before</em> the commit,
+    /// because committing clears the context's entity lists. A post-commit step therefore cannot
+    /// contribute to it. A caller that needs post-commit values in the result should append
+    /// <c>return result with { ... };</c> after the post-commit loop rather than moving the snapshot —
+    /// several of its arguments read <c>.Count</c> off lists the committer has already cleared.
+    /// </para>
     /// </remarks>
-    internal PipelineExecutionResult Execute()
+    internal async Task<PipelineExecutionResult> ExecuteAsync()
     {
-        var steps = _serviceProvider.GetKeyedServices<IStep>(_recipeName)
-            .OrderBy(s => s is OrderedStep os ? os.Order : int.MaxValue)
+        var steps = _serviceProvider.GetKeyedServices<OrderedStep>(_recipeName)
+            .OrderBy(s => s.Order)
             .ToList();
 
         var context = new SeederContext(_serviceProvider);
         context.Registry.Clear();
 
-        foreach (var step in steps)
+        foreach (var step in steps.Where(s => !s.IsPostCommit))
         {
-            step.Execute(context);
+            await step.ExecuteAsync(context);
         }
 
         // Capture counts BEFORE committing (commit clears the lists)
@@ -66,6 +82,23 @@ internal sealed class RecipeExecutor
         finally
         {
             progress?.Report(new PhaseCompleted(SeederPhases.CommittingToDatabase));
+        }
+
+        var postCommit = steps.Where(s => s.IsPostCommit).ToList();
+        if (postCommit.Count > 0)
+        {
+            progress?.Report(new PhaseStarted(SeederPhases.PostCommit, null));
+            try
+            {
+                foreach (var step in postCommit)
+                {
+                    await step.ExecuteAsync(context);
+                }
+            }
+            finally
+            {
+                progress?.Report(new PhaseCompleted(SeederPhases.PostCommit));
+            }
         }
 
         return result;

--- a/util/Seeder/Pipeline/RecipeOrchestrator.cs
+++ b/util/Seeder/Pipeline/RecipeOrchestrator.cs
@@ -19,7 +19,7 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
     /// <param name="orgNameOverride">Optional organization name. Replaces the fixture/preset-supplied name when provided.</param>
     /// <param name="ownerEmailOverride">Optional owner email. Replaces the default <c>owner@&lt;domain&gt;</c> when provided.</param>
     /// <returns>Execution result with organization ID and entity counts</returns>
-    internal PipelineExecutionResult Execute(
+    internal async Task<PipelineExecutionResult> ExecuteAsync(
         string presetName,
         string? password = null,
         int? kdfIterations = null,
@@ -53,13 +53,13 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
 
         PresetLoader.RegisterRecipe(presetName, reader, services);
 
-        return BuildAndExecute(presetName, services);
+        return await BuildAndExecuteAsync(presetName, services);
     }
 
     /// <summary>
     /// Executes a recipe built programmatically from CLI options.
     /// </summary>
-    internal PipelineExecutionResult Execute(OrganizationVaultOptions options)
+    internal async Task<PipelineExecutionResult> ExecuteAsync(OrganizationVaultOptions options)
     {
         EnsureOwnerEmailUnique(
             options.OwnerEmail,
@@ -121,13 +121,13 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
 
         builder.Validate();
 
-        return BuildAndExecute(recipeName, services);
+        return await BuildAndExecuteAsync(recipeName, services);
     }
 
     /// <summary>
     /// Executes a recipe for an individual user built programmatically from CLI options.
     /// </summary>
-    internal PipelineExecutionResult Execute(IndividualUserOptions options)
+    internal async Task<PipelineExecutionResult> ExecuteAsync(IndividualUserOptions options)
     {
         var firstName = options.FirstName ?? new Bogus.Faker().Name.FirstName();
         var lastName = options.LastName ?? new Bogus.Faker().Name.LastName();
@@ -161,15 +161,15 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
 
         builder.Validate();
 
-        return BuildAndExecute(recipeName, services);
+        return await BuildAndExecuteAsync(recipeName, services);
     }
 
-    private PipelineExecutionResult BuildAndExecute(string recipeName, ServiceCollection services)
+    private async Task<PipelineExecutionResult> BuildAndExecuteAsync(string recipeName, ServiceCollection services)
     {
-        using var serviceProvider = services.BuildServiceProvider();
+        await using var serviceProvider = services.BuildServiceProvider();
         var committer = new BulkCommitter(deps.Db, deps.Mapper);
         var executor = new RecipeExecutor(recipeName, serviceProvider, committer);
-        return executor.Execute();
+        return await executor.ExecuteAsync();
     }
 
     /// <summary>

--- a/util/Seeder/Pipeline/SeederContext.cs
+++ b/util/Seeder/Pipeline/SeederContext.cs
@@ -8,7 +8,7 @@ using Bit.Seeder.Data;
 namespace Bit.Seeder.Pipeline;
 
 /// <summary>
-/// Shared mutable state bag passed through every <see cref="IStep"/> in a pipeline run.
+/// Shared mutable state bag passed through every <see cref="IStep"/> and <see cref="IAsyncStep"/> in a pipeline run.
 /// WARNING: This class is NOT thread-safe. Each pipeline execution must use its own context instance.
 /// Do not share a context instance between concurrent pipeline runs.
 /// </summary>
@@ -21,9 +21,10 @@ namespace Bit.Seeder.Pipeline;
 /// <strong>Context Lifecycle:</strong>
 /// <list type="number">
 /// <item><description>Create fresh context for each pipeline run</description></item>
-/// <item><description>Pass to RecipeExecutor.Execute()</description></item>
+/// <item><description>Pass to RecipeExecutor.ExecuteAsync()</description></item>
 /// <item><description>Steps mutate context progressively</description></item>
 /// <item><description>BulkCommitter flushes entity lists to database</description></item>
+/// <item><description>Steps marked <see cref="IPostCommitStep"/> run against the committed rows</description></item>
 /// <item><description>Return org ID from context</description></item>
 /// <item><description>Discard context (do not reuse)</description></item>
 /// </list>

--- a/util/Seeder/Pipeline/SeederPhases.cs
+++ b/util/Seeder/Pipeline/SeederPhases.cs
@@ -9,4 +9,5 @@ internal static class SeederPhases
     internal const string CreatingGroups = "Creating groups";
     internal const string CreatingUsers = "Creating users";
     internal const string CreatingPersonalCiphers = "Creating personal ciphers";
+    internal const string PostCommit = "Post-commit";
 }

--- a/util/Seeder/README.md
+++ b/util/Seeder/README.md
@@ -52,7 +52,7 @@ The Seeder is organized around six core patterns, each with a specific responsib
 
 **When to use:** New bulk operations, especially with presets. Provides ultimate flexibility.
 
-**Flow**: Preset JSON → Loader → Builder → Steps → Executor → Context → BulkCommitter
+**Flow**: Preset JSON → Loader → Builder → Steps (sync or async) → Executor → Context → BulkCommitter → post-commit steps
 
 **Why this architecture wins**:
 
@@ -94,10 +94,10 @@ The Seeder is organized around six core patterns, each with a specific responsib
 - Use BulkCopy for performance optimization
 - Interact with database directly
 - Compose Factories for individual entity creation
-- **SHALL have a `Seed()` method** that executes the complete recipe
+- **SHALL have a single public entry point** that executes the complete recipe — `Seed()` if synchronous, `SeedAsync()` if it returns a Task
 - Use method parameters (with defaults) for variations, not separate methods
 
-**Naming:** `{DomainConcept}Recipe` with a `Seed()` method
+**Naming:** `{DomainConcept}Recipe`, with `Seed()` when synchronous or `SeedAsync()` when async. Sharing the `SeedAsync()` name with Scenes is fine — the type suffix distinguishes the patterns.
 
 #### Models
 

--- a/util/Seeder/Recipes/IndividualUserRecipe.cs
+++ b/util/Seeder/Recipes/IndividualUserRecipe.cs
@@ -10,7 +10,7 @@ namespace Bit.Seeder.Recipes;
 /// <remarks>
 /// Thin facade over the internal Pipeline architecture (RecipeOrchestrator).
 /// All orchestration logic is encapsulated within the Pipeline, keeping this Recipe simple.
-/// The CLI remains "dumb" - it creates this recipe and calls Seed().
+/// The CLI remains "dumb" - it creates this recipe and calls SeedAsync().
 /// </remarks>
 public class IndividualUserRecipe(SeederDependencies deps)
 {
@@ -23,10 +23,10 @@ public class IndividualUserRecipe(SeederDependencies deps)
     /// <param name="password">Optional password for the seeded account</param>
     /// <param name="kdfIterations">Optional KDF iteration count override</param>
     /// <returns>The user ID and summary statistics.</returns>
-    public UserSeedResult Seed(string presetName,
+    public async Task<UserSeedResult> SeedAsync(string presetName,
         string? password = null, int? kdfIterations = null)
     {
-        var result = _orchestrator.Execute(presetName, password, kdfIterations);
+        var result = await _orchestrator.ExecuteAsync(presetName, password, kdfIterations);
 
         if (result.UserId is null)
         {
@@ -42,9 +42,9 @@ public class IndividualUserRecipe(SeederDependencies deps)
     /// </summary>
     /// <param name="options">Options specifying what to seed.</param>
     /// <returns>The user ID and summary statistics.</returns>
-    public UserSeedResult Seed(IndividualUserOptions options)
+    public async Task<UserSeedResult> SeedAsync(IndividualUserOptions options)
     {
-        var result = _orchestrator.Execute(options);
+        var result = await _orchestrator.ExecuteAsync(options);
         return UserSeedResult.From(result);
     }
 }

--- a/util/Seeder/Recipes/OrganizationRecipe.cs
+++ b/util/Seeder/Recipes/OrganizationRecipe.cs
@@ -10,7 +10,7 @@ namespace Bit.Seeder.Recipes;
 /// <remarks>
 /// Thin facade over the internal Pipeline architecture (RecipeOrchestrator).
 /// All orchestration logic is encapsulated within the Pipeline, keeping this Recipe simple.
-/// The CLI remains "dumb" - it creates this recipe and calls Seed().
+/// The CLI remains "dumb" - it creates this recipe and calls SeedAsync().
 /// </remarks>
 public class OrganizationRecipe(SeederDependencies deps)
 {
@@ -25,14 +25,14 @@ public class OrganizationRecipe(SeederDependencies deps)
     /// <param name="orgName">Optional organization name override. Replaces the preset/fixture name when provided.</param>
     /// <param name="ownerEmail">Optional owner email override. Replaces the default <c>owner@&lt;domain&gt;</c> when provided.</param>
     /// <returns>The organization ID and summary statistics.</returns>
-    public OrganizationSeedResult Seed(
+    public async Task<OrganizationSeedResult> SeedAsync(
         string presetName,
         string? password = null,
         int? kdfIterations = null,
         string? orgName = null,
         string? ownerEmail = null)
     {
-        var result = _orchestrator.Execute(presetName, password, kdfIterations, orgName, ownerEmail);
+        var result = await _orchestrator.ExecuteAsync(presetName, password, kdfIterations, orgName, ownerEmail);
 
         if (result.OrganizationId is null)
         {
@@ -48,9 +48,9 @@ public class OrganizationRecipe(SeederDependencies deps)
     /// </summary>
     /// <param name="options">Options specifying what to seed.</param>
     /// <returns>The organization ID and summary statistics.</returns>
-    public OrganizationSeedResult Seed(OrganizationVaultOptions options)
+    public async Task<OrganizationSeedResult> SeedAsync(OrganizationVaultOptions options)
     {
-        var result = _orchestrator.Execute(options);
+        var result = await _orchestrator.ExecuteAsync(options);
         return OrganizationSeedResult.From(result);
     }
 }

--- a/util/Seeder/Steps/CreateCipherAttachmentsStep.cs
+++ b/util/Seeder/Steps/CreateCipherAttachmentsStep.cs
@@ -16,7 +16,7 @@ namespace Bit.Seeder.Steps;
 /// A no-op when the fixture declares no attachments. A v2 (cipher-key-wrapped) attachment requires the host
 /// cipher to have been created with <see cref="CipherEncryptionType.CipherKey"/> so <c>Cipher.Key</c> is populated.
 /// </remarks>
-internal sealed class CreateCipherAttachmentsStep : IStep
+internal sealed class CreateCipherAttachmentsStep : IAsyncStep
 {
     private readonly string _fixtureName;
     private readonly bool _personal;
@@ -33,7 +33,7 @@ internal sealed class CreateCipherAttachmentsStep : IStep
     internal static CreateCipherAttachmentsStep ForPersonalVault(string fixtureName) =>
         new(fixtureName, personal: true);
 
-    public void Execute(SeederContext context)
+    public async Task ExecuteAsync(SeederContext context)
     {
         var seedFile = context.GetSeedReader().Read<SeedFile>($"ciphers.{_fixtureName}");
         var itemsWithAttachments = seedFile.Items.Where(i => i.Attachments is { Count: > 0 }).ToList();
@@ -114,7 +114,7 @@ internal sealed class CreateCipherAttachmentsStep : IStep
                 cipher.AddAttachment(id, meta);
 
                 using var stream = new MemoryStream(blob);
-                storage.UploadNewAttachmentAsync(stream, cipher, meta).GetAwaiter().GetResult();
+                await storage.UploadNewAttachmentAsync(stream, cipher, meta);
 
                 progress?.Report(new PhaseAdvanced(SeederPhases.CreatingAttachments, 1));
             }

--- a/util/Seeder/Steps/CreateSsoConfigStep.cs
+++ b/util/Seeder/Steps/CreateSsoConfigStep.cs
@@ -18,11 +18,11 @@ namespace Bit.Seeder.Steps;
 internal sealed class CreateSsoConfigStep(
     string identifier,
     string? provider,
-    MemberDecryptionType memberDecryptionType) : IStep
+    MemberDecryptionType memberDecryptionType) : IAsyncStep
 {
     private static readonly XNamespace _ds = "http://www.w3.org/2000/09/xmldsig#";
 
-    public void Execute(SeederContext context)
+    public async Task ExecuteAsync(SeederContext context)
     {
         if (!string.Equals(provider ?? "saml", "saml", StringComparison.OrdinalIgnoreCase))
         {
@@ -40,11 +40,15 @@ internal sealed class CreateSsoConfigStep(
         organization.Identifier = context.GetMangler().Mangle(identifier);
         context.SsoIdentifier = organization.Identifier;
 
+        // Fetched after the two mutations above, matching where the inline call used to sit in the
+        // argument list: an unreachable IdP must still throw with the identifier already applied.
+        var signingCertificate = await FetchIdpSigningCertificateAsync(LocalSamlIdp.EntityId);
+
         var ssoConfig = SsoConfigSeeder.CreateSaml2(
             organization.Id,
             LocalSamlIdp.EntityId,
             LocalSamlIdp.SingleSignOnServiceUrl,
-            FetchIdpSigningCertificate(LocalSamlIdp.EntityId),
+            signingCertificate,
             memberDecryptionType);
 
         context.SsoConfigs.Add(ssoConfig);
@@ -55,13 +59,13 @@ internal sealed class CreateSsoConfigStep(
     /// (public, image-specific) cert out of source so nothing trips secret/SAST scanners, and tracks the
     /// running image automatically. Requires the local <c>idp</c> container to be running.
     /// </summary>
-    private static string FetchIdpSigningCertificate(string metadataUrl)
+    private static async Task<string> FetchIdpSigningCertificateAsync(string metadataUrl)
     {
         string metadataXml;
         try
         {
             using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
-            metadataXml = client.GetStringAsync(metadataUrl).GetAwaiter().GetResult();
+            metadataXml = await client.GetStringAsync(metadataUrl);
         }
         catch (Exception ex)
         {

--- a/util/Seeder/Steps/GenerateSelfHostUserLicenseStep.cs
+++ b/util/Seeder/Steps/GenerateSelfHostUserLicenseStep.cs
@@ -8,9 +8,9 @@ namespace Bit.Seeder.Steps;
 /// Writes a user premium license file to the LicenseDirectory.
 /// Required for self-hosted instances, which validate premium status by reading this file on every login.
 /// </summary>
-internal sealed class GenerateSelfHostUserLicenseStep(ILicensingService licenseService) : IStep
+internal sealed class GenerateSelfHostUserLicenseStep(ILicensingService licenseService) : IAsyncStep
 {
-    public void Execute(SeederContext context)
+    public async Task ExecuteAsync(SeederContext context)
     {
         var user = context.Owner;
         if (user is null || !user.Premium)
@@ -20,10 +20,11 @@ internal sealed class GenerateSelfHostUserLicenseStep(ILicensingService licenseS
 
         // Best-effort license write. Self-hosted instances hold only the public licensing
         // certificate, so token signing throws there (by design — see LicensingService.SignLicense).
-        // Don't let that failure abort the pipeline run.
+        // Don't let that failure abort the pipeline run. The await must stay inside the try —
+        // returning the task unawaited would make every catch below dead code.
         try
         {
-            SelfHostLicenseService.WriteLicenseAsync(licenseService, user).GetAwaiter().GetResult();
+            await SelfHostLicenseService.WriteLicenseAsync(licenseService, user);
         }
         catch (InvalidOperationException ex)
         {

--- a/util/SeederUtility/Commands/IndividualCommand.cs
+++ b/util/SeederUtility/Commands/IndividualCommand.cs
@@ -9,7 +9,7 @@ namespace Bit.SeederUtility.Commands;
 public class IndividualCommand
 {
     [DefaultCommand]
-    public void Execute(IndividualArgs args)
+    public async Task ExecuteAsync(IndividualArgs args)
     {
         try
         {
@@ -17,9 +17,9 @@ public class IndividualCommand
 
             using var deps = SeederServiceFactory.Create(new SeederServiceOptions { EnableMangling = args.Mangle });
 
-            var result = ConsoleProgressReporter.RunWithProgress(
+            var result = await ConsoleProgressReporter.RunWithProgressAsync(
                 deps.ToDependencies(),
-                d => new IndividualUserRecipe(d).Seed(args.ToOptions()));
+                d => new IndividualUserRecipe(d).SeedAsync(args.ToOptions()));
 
             ConsoleOutput.PrintRow("User", result.UserId);
             if (result.Email is not null)
@@ -39,7 +39,7 @@ public class IndividualCommand
         }
         catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
-            Console.Error.WriteLine($"Error: {ex}");
+            await Console.Error.WriteLineAsync($"Error: {ex}");
             Environment.Exit(1);
         }
     }

--- a/util/SeederUtility/Commands/OrganizationCommand.cs
+++ b/util/SeederUtility/Commands/OrganizationCommand.cs
@@ -9,7 +9,7 @@ namespace Bit.SeederUtility.Commands;
 public class OrganizationCommand
 {
     [DefaultCommand]
-    public void Execute(OrganizationArgs args)
+    public async Task ExecuteAsync(OrganizationArgs args)
     {
         try
         {
@@ -17,9 +17,9 @@ public class OrganizationCommand
 
             using var deps = SeederServiceFactory.Create(new SeederServiceOptions { EnableMangling = args.Mangle });
 
-            var result = ConsoleProgressReporter.RunWithProgress(
+            var result = await ConsoleProgressReporter.RunWithProgressAsync(
                 deps.ToDependencies(),
-                d => new OrganizationRecipe(d).Seed(args.ToOptions()));
+                d => new OrganizationRecipe(d).SeedAsync(args.ToOptions()));
 
             ConsoleOutput.PrintRow("Organization", result.OrganizationId);
             if (result.OwnerEmail is not null)
@@ -40,7 +40,7 @@ public class OrganizationCommand
         }
         catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
-            Console.Error.WriteLine($"Error: {ex}");
+            await Console.Error.WriteLineAsync($"Error: {ex}");
             Environment.Exit(1);
         }
     }

--- a/util/SeederUtility/Commands/PresetCommand.cs
+++ b/util/SeederUtility/Commands/PresetCommand.cs
@@ -11,7 +11,7 @@ namespace Bit.SeederUtility.Commands;
 public class PresetCommand
 {
     [DefaultCommand]
-    public void Execute(PresetArgs args)
+    public async Task ExecuteAsync(PresetArgs args)
     {
         try
         {
@@ -25,28 +25,28 @@ public class PresetCommand
 
             if (IsIndividualPreset(args.Name!))
             {
-                RunIndividualPreset(args);
+                await RunIndividualPresetAsync(args);
             }
             else
             {
-                RunOrganizationPreset(args);
+                await RunOrganizationPresetAsync(args);
             }
         }
         catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
-            Console.Error.WriteLine($"Error: {ex.Message}");
+            await Console.Error.WriteLineAsync($"Error: {ex.Message}");
             Environment.Exit(1);
         }
     }
 
-    private static void RunOrganizationPreset(PresetArgs args)
+    private static async Task RunOrganizationPresetAsync(PresetArgs args)
     {
         using var deps = SeederServiceFactory.Create(new SeederServiceOptions { EnableMangling = args.Mangle });
 
-        Console.Error.WriteLine($"Seeding organization from preset '{args.Name}'...");
-        var result = ConsoleProgressReporter.RunWithProgress(
+        await Console.Error.WriteLineAsync($"Seeding organization from preset '{args.Name}'...");
+        var result = await ConsoleProgressReporter.RunWithProgressAsync(
             deps.ToDependencies(),
-            d => new OrganizationRecipe(d).Seed(args.Name!, args.Password, args.KdfIterations, args.OrgName, args.OwnerEmail));
+            d => new OrganizationRecipe(d).SeedAsync(args.Name!, args.Password, args.KdfIterations, args.OrgName, args.OwnerEmail));
 
         ConsoleOutput.PrintRow("Organization", result.OrganizationId);
         if (result.OwnerEmail is not null)
@@ -71,14 +71,14 @@ public class PresetCommand
         }
     }
 
-    private static void RunIndividualPreset(PresetArgs args)
+    private static async Task RunIndividualPresetAsync(PresetArgs args)
     {
         using var deps = SeederServiceFactory.Create(new SeederServiceOptions { EnableMangling = args.Mangle });
 
-        Console.Error.WriteLine($"Seeding individual user from preset '{args.Name}'...");
-        var result = ConsoleProgressReporter.RunWithProgress(
+        await Console.Error.WriteLineAsync($"Seeding individual user from preset '{args.Name}'...");
+        var result = await ConsoleProgressReporter.RunWithProgressAsync(
             deps.ToDependencies(),
-            d => new IndividualUserRecipe(d).Seed(args.Name!, args.Password, args.KdfIterations));
+            d => new IndividualUserRecipe(d).SeedAsync(args.Name!, args.Password, args.KdfIterations));
 
         ConsoleOutput.PrintRow("User", result.UserId);
         if (result.Email is not null)

--- a/util/SeederUtility/Helpers/ConsoleProgressReporter.cs
+++ b/util/SeederUtility/Helpers/ConsoleProgressReporter.cs
@@ -65,35 +65,33 @@ internal sealed class ConsoleProgressReporter(ProgressContext ctx) : IProgress<S
     }
 
     /// <summary>
-    /// Runs <paramref name="seed"/> inside a Spectre progress context, wiring a reporter
+    /// Awaits <paramref name="seed"/> inside a Spectre progress context, wiring a reporter
     /// into <paramref name="deps"/>. The seeder's emitted events drive the live bars.
     /// </summary>
     /// <remarks>
     /// Progress output is written to stderr so stdout remains clean for downstream consumers
     /// that pipe the final summary rows (org ID, counts, etc.) into other tools.
     /// </remarks>
-    internal static TResult RunWithProgress<TResult>(
+    internal static Task<TResult> RunWithProgressAsync<TResult>(
         SeederDependencies deps,
-        Func<SeederDependencies, TResult> seed)
+        Func<SeederDependencies, Task<TResult>> seed)
     {
         var console = AnsiConsole.Create(new AnsiConsoleSettings
         {
             Out = new AnsiConsoleOutput(Console.Error),
         });
 
-        TResult result = default!;
-        console.Progress()
+        return console.Progress()
             .Columns(
                 new TaskDescriptionColumn(),
                 new ProgressBarColumn(),
                 new PercentageColumn(),
                 new RemainingTimeColumn(),
                 new SpinnerColumn())
-            .Start(ctx =>
+            .StartAsync(ctx =>
             {
                 var reporter = new ConsoleProgressReporter(ctx);
-                result = seed(deps with { Progress = reporter });
+                return seed(deps with { Progress = reporter });
             });
-        return result;
     }
 }

--- a/util/SeederUtility/Program.cs
+++ b/util/SeederUtility/Program.cs
@@ -5,12 +5,12 @@ namespace Bit.SeederUtility;
 
 public class Program
 {
-    private static int Main(string[] args)
+    private static async Task<int> Main(string[] args)
     {
         PrintBanner();
 
-        return new AppRunner<Program>()
-            .Run(args);
+        return await new AppRunner<Program>()
+            .RunAsync(args);
     }
 
     private static void PrintBanner()


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40996](https://bitwarden.atlassian.net/browse/PM-40996)
[PM-40993](https://bitwarden.atlassian.net/browse/PM-40993)

## 📔 Objective

This is a pure refactor of the seeder pipeline — no new behavior, no Stripe or billing code. Every step ran synchronously, and all of them ran before `BulkCommitter` wrote anything to the database. Initializing a Stripe subscription needs the opposite of both: an asynchronous call, made against an organization row that already exists. This adds the two capabilities so the opt-in billing work can land on top of it in small increments.

### Key changes

- Introduce `IAsyncStep` alongside `IStep` — a parallel interface rather than a derived one, so a step is either synchronous or asynchronous, never both
- Add the `IPostCommitStep` marker — applied to either kind, it defers a step until after `BulkCommitter.Commit()` so it observes persisted rows
- Rework `OrderedStep` into a two-constructor union that wraps whichever kind was registered and carries the order index plus the post-commit flag
- Partition the step list in `RecipeExecutor.ExecuteAsync()` — sort once, run the pre-commit steps, commit, then run the deferred ones
- Convert `GenerateSelfHostUserLicenseStep`, `CreateCipherAttachmentsStep`, and `CreateSsoConfigStep` from `.GetAwaiter().GetResult()` to genuine `await`, removing the last sync-over-async in the seeder
- Propagate the async signature up through `RecipeOrchestrator`, both pipeline recipes, the three CLI commands, and `Main` via `AppRunner.RunAsync()`
- Rename `Seed()` → `SeedAsync()` on the pipeline-backed recipes and `Execute()` → `ExecuteAsync()` on the command handlers
- Rewrite the Recipe Contract to key on whether a recipe is asynchronous instead of mandating one literal method name — the direct-to-database recipes are still synchronous and still use `Seed()`
- Delete `AddStep<T>()` and `AddAsyncStep<T>()` — neither ever had a caller

Synchronous steps are wrapped in an already-completed task, so they still execute inline, on the calling thread, in registration order. The post-commit phase emits no progress events unless a post-commit step is actually registered. Steps are awaited strictly one at a time and must never be batched with `Task.WhenAll` — `SeederContext` is not thread-safe and each step reads what the previous ones wrote.

**Not changed**: `BulkCommitter` stays synchronous, the other 18 `IStep` implementations are untouched, and nothing implements `IPostCommitStep` yet — async bulk-copy and the first real post-commit step both belong to the billing work that follows.

## 🧪 Testing

Every converted step was executed against a live database and verified in the client, not just in tests. All three sync→async conversions are covered end-to-end, including both branches of the attachment step and a full SAML round trip.

<details><summary>Expand for mutation testing, CLI parity, live seeding, attachments, SSO, and scale results</summary>

### Step 1: Full suite

```
dotnet test test/SeederApi.IntegrationTest/
Passed!  -  Failed: 0, Passed: 292, Skipped: 0, Total: 292
```

Builds clean with `0 Warning(s)` across `Seeder`, `SeederUtility`, and `Api.IntegrationTest`. `dotnet format --verify-no-changes` returns 0 on all three touched projects.

### Step 2: Prove the await tests aren't vacuous

A test that asserts "the executor awaited" is worthless if it passes when the await is gone. Dropping the `await` on the pre-commit loop — the higher-consequence side, where the commit would otherwise run while a step is still mutating the context:

```csharp
foreach (var step in steps.Where(s => !s.IsPostCommit))
{
    _ = step.ExecuteAsync(context);   // mutation
}
```

```
Failed Bit.SeederApi.IntegrationTest.Pipeline.RecipeExecutorPostCommitTests.PreCommitStep_IsActuallyAwaited_AndBlocksTheCommit
Failed!  -  Failed: 1, Passed: 291, Skipped: 0, Total: 292
```

Exactly one failure, and it is the new test. The assertion that pins it is `UsersInDb() == 0` while the step is parked on a `TaskCompletionSource` gate — an empty table proves the commit has not run, which is the actual harm. Asserting only `IsCompleted == false` would pass even if the commit had already fired.

### Step 3: Verify the CLI surface is unchanged

`--help` captured across `--help`, `organization --help`, `individual --help`, and `preset --help`, before and after the `Execute()` → `ExecuteAsync()` rename:

```
diff -q help-before.txt help-after.txt   →   IDENTICAL
```

Dispatch confirmed separately, since help alone doesn't prove CommandDotNet still finds the renamed method — `organization --users 0` reaches `args.Validate()` inside `ExecuteAsync()` and returns `Error: System.ArgumentException: Users must be at least 1.`

### Step 4: Seed against a live database

```
dotnet run -- organization -n Test001 -d Test001-Mangle.example -u 5 -c 25 -g 4 -o Spotify -m --mangle
```

| | |
|---|---|
| Users | 6 |
| Groups | 4 |
| Collections | 22 |
| Ciphers | 25 |

Progress rendered `Creating users`, `Creating groups`, `Creating collections`, `Committing to database` — and **no `Post-commit` bar**, which is the zero-behavior-change guarantee holding in the real CLI rather than only in a test.

### Step 5: Exercise the riskiest converted step

`GenerateSelfHostUserLicenseStep` is the one conversion that fails silently if botched — its four catch clauses would swallow the error and the seed would still look successful, just with no license on disk.

```
dotnet run -- individual --subscription premium --first-name Jane --last-name Smith --self-hosted --mangle
```

The license landed in `LicenseDirectory` with a signed 1328-character token, matching user id and email, `Premium = True`, expiry one year out. Real certificate signing, real filesystem write, through the `await` path.

### Step 6: Exercise both branches of `CreateCipherAttachmentsStep`

The step has two arms that unwrap with different keys — `ForOrganization` uses the org key, `ForPersonalVault` uses the user's symmetric key — so one seed can't cover it.

```
preset --name qa.enterprise-basic --mangle          # organization vault
preset --name individual.encryption-modes --mangle  # personal vault
```

| | Org (`enterprise-basic`) | Personal (`encryption-modes`) |
|---|---|---|
| Ciphers | 45 | 34 |
| Ciphers with attachments | 18 | 29 |
| Attachment entries | 18 | 33 |
| Wrapped key (v1/v2) / v0 keyless | 14 / 4 | 26 / 7 |
| Encrypted bytes | 7,810 | 15,921 |

Both counts match their fixtures exactly, and both span the v0/v1/v2 wrapping schemes whose mismatch guards throw at seed time.

Row counts alone would not have been enough. The `Attachments` column is metadata; the payload is Protected Data and is never decryptable server-side, so the database can only prove a blob was *registered*. **Both were downloaded and opened in the web vault** — client-side decryption is the only thing that proves the awaited `UploadNewAttachmentAsync` wrote a correctly key-wrapped blob.

### Step 7: Exercise `CreateSsoConfigStep` against a live IdP

This step early-returns for any non-SAML provider, so most SSO presets prove nothing about the `await` — `features.sso-enterprise` and `features.tde-enterprise` are both `oidc` and log a warning before the fetch. `features.local-sso` is the only preset that reaches `FetchIdpSigningCertificateAsync`.

```
docker compose --profile idp up -d
preset --name features.local-sso
```

| `SsoConfig` field | Value |
|---|---|
| `Enabled` | 1 |
| `configType` | 2 (SAML2) |
| `idpX509PublicCert` | **896 chars** |
| `idpEntityId` / `idpSingleSignOnServiceUrl` | match `LocalSamlIdp` |
| `Organization.Identifier` | `local-sso` |

896 is byte-for-byte the certificate length served by the running IdP's metadata endpoint. No hardcoded or cached value could produce it — the awaited HTTP fetch and XML parse genuinely happened.

A **full SAML round trip** then authenticated through SimpleSAMLphp into the vault, and an attachment was downloaded from inside that SSO-authenticated session — so both converted steps are also proven working together in one flow.

### Step 8: Scale — the untouched `Parallel.For` steps under the new async chain

`CreateUsersStep` and `GeneratePersonalCiphersStep` were deliberately left synchronous, but they now execute inside an async call chain, so their thread affinity changed even though their bodies did not. `ManglerService` is not thread-safe, which makes duplicate emails the symptom a race would produce.

```
preset --name scale.xs-central-perk --mangle
preset --name scale.sm-balanced-planet-express --mangle
preset --name scale.md-balanced-sterling-cooper --mangle
```

| Preset | Members | Groups | Collections | Ciphers | Wall clock |
|---|---|---|---|---|---|
| xs-central-perk | 7 | 2 | 10 | 200 | 36s |
| sm-balanced-planet-express | 51 | 8 | 100 | 750 | 39s |
| md-balanced-sterling-cooper | 251 | 50 | 500 | 5,000 org + 2,910 personal | 41s |

**366 users, 366 distinct emails, zero collisions** — per-organization and globally. No race. Sterling Cooper opened cleanly in the web vault at 500 collections and ~8k ciphers.

### Step 9: Zero behavior change, observed on every run

Across every live seed above, **no `Post-commit` progress bar was ever rendered**. Nothing implements `IPostCommitStep` yet, and the `if (postCommit.Count > 0)` guard suppressed the phase every time — in the real CLI, not only under test. Every run exited 0, and no `AggregateException` surfaced from `AppRunner.RunAsync`.

</details>


[PM-40996]: https://bitwarden.atlassian.net/browse/PM-40996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-40993]: https://bitwarden.atlassian.net/browse/PM-40993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ