### PR TITLE
[PM-41220] add integration tests capturing current middleware behavior

### DIFF
--- a/test/Icons.Test/CorsTests.cs
+++ b/test/Icons.Test/CorsTests.cs
@@ -1,5 +1,4 @@
-using System.Net.Http;
-using Xunit;
+﻿using Xunit;
 
 namespace Bit.Icons.Test;
 

--- a/test/Icons.Test/CorsTests.cs
+++ b/test/Icons.Test/CorsTests.cs
@@ -1,0 +1,77 @@
+using System.Net.Http;
+using Xunit;
+
+namespace Bit.Icons.Test;
+
+public sealed class CloudCorsTests : IAsyncDisposable
+{
+    private const string VaultOrigin = "https://vault.example.com";
+
+    private readonly IconsApplicationFactory _factory = new(selfHosted: false, vaultOrigin: VaultOrigin);
+
+    [Theory]
+    [InlineData(VaultOrigin)]
+    [InlineData("file://")]
+    [InlineData("bw-desktop-file://bundle")]
+    [InlineData("https://bitwarden.com")]
+    public async Task AllowedOrigin_ReturnsAccessControlAllowOrigin(string origin)
+    {
+        using var client = _factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/alive");
+        request.Headers.TryAddWithoutValidation("Origin", origin);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(origin, response.Headers.GetValues("Access-Control-Allow-Origin").Single());
+    }
+
+    [Fact]
+    public async Task UnknownOrigin_DoesNotReturnAccessControlAllowOrigin()
+    {
+        using var client = _factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/alive");
+        request.Headers.TryAddWithoutValidation("Origin", "https://attacker.example.com");
+
+        var response = await client.SendAsync(request);
+
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    public ValueTask DisposeAsync() => _factory.DisposeAsync();
+}
+
+public sealed class SelfHostedCorsTests : IAsyncDisposable
+{
+    private const string VaultOrigin = "https://vault.selfhosted.example.com";
+
+    private readonly IconsApplicationFactory _factory = new(selfHosted: true, vaultOrigin: VaultOrigin);
+
+    [Theory]
+    [InlineData(VaultOrigin)]
+    [InlineData("file://")]
+    [InlineData("bw-desktop-file://bundle")]
+    public async Task AllowedOrigin_ReturnsAccessControlAllowOrigin(string origin)
+    {
+        using var client = _factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/alive");
+        request.Headers.TryAddWithoutValidation("Origin", origin);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(origin, response.Headers.GetValues("Access-Control-Allow-Origin").Single());
+    }
+
+    [Fact]
+    public async Task BitwardenComOrigin_DoesNotReturnAccessControlAllowOrigin()
+    {
+        using var client = _factory.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Get, "/alive");
+        request.Headers.TryAddWithoutValidation("Origin", "https://bitwarden.com");
+
+        var response = await client.SendAsync(request);
+
+        Assert.False(response.Headers.Contains("Access-Control-Allow-Origin"));
+    }
+
+    public ValueTask DisposeAsync() => _factory.DisposeAsync();
+}

--- a/test/Icons.Test/Icons.Test.csproj
+++ b/test/Icons.Test/Icons.Test.csproj
@@ -9,6 +9,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[10.0.8]" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />

--- a/test/Icons.Test/IconsApplicationFactory.cs
+++ b/test/Icons.Test/IconsApplicationFactory.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc.Testing;
+﻿using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 
 namespace Bit.Icons.Test;

--- a/test/Icons.Test/IconsApplicationFactory.cs
+++ b/test/Icons.Test/IconsApplicationFactory.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace Bit.Icons.Test;
+
+/// <summary>
+/// Wraps a <see cref="WebApplicationFactory{TEntryPoint}"/> for the Icons service and exposes
+/// a single <see cref="CreateClient"/> method. Tests interact with the service through
+/// <see cref="HttpClient"/> only.
+/// </summary>
+public sealed class IconsApplicationFactory : IAsyncDisposable
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public IconsApplicationFactory(bool selfHosted = false, string vaultOrigin = "https://vault.example.com")
+    {
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "GlobalSettings:SelfHosted", selfHosted ? "true" : "false" },
+                    { "GlobalSettings:BaseServiceUri:Vault", vaultOrigin },
+                    { "OpenTelemetry:Enabled", "false" },
+                });
+            });
+        });
+    }
+
+    public HttpClient CreateClient() => _factory.CreateClient();
+
+    public ValueTask DisposeAsync() => _factory.DisposeAsync();
+}

--- a/test/Icons.Test/InfoEndpointTests.cs
+++ b/test/Icons.Test/InfoEndpointTests.cs
@@ -1,5 +1,4 @@
-using System.Net;
-using System.Net.Http;
+﻿using System.Net;
 using System.Net.Http.Json;
 using Xunit;
 

--- a/test/Icons.Test/InfoEndpointTests.cs
+++ b/test/Icons.Test/InfoEndpointTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace Bit.Icons.Test;
+
+public sealed class InfoEndpointTests : IAsyncDisposable
+{
+    private readonly IconsApplicationFactory _factory = new();
+
+    [Theory]
+    [InlineData("/alive")]
+    [InlineData("/now")]
+    public async Task GetAliveOrNow_Returns200WithDateTime(string path)
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.True(DateTime.TryParse(body.Trim('"'), out _));
+    }
+
+    [Fact]
+    public async Task GetVersion_Returns200WithParsableVersion()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/version");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var version = await response.Content.ReadFromJsonAsync<string>();
+        Assert.True(Version.TryParse(version, out _));
+    }
+
+    public ValueTask DisposeAsync() => _factory.DisposeAsync();
+}

--- a/test/Icons.Test/SecurityHeadersTests.cs
+++ b/test/Icons.Test/SecurityHeadersTests.cs
@@ -1,5 +1,4 @@
-using System.Net.Http;
-using Xunit;
+﻿using Xunit;
 
 namespace Bit.Icons.Test;
 

--- a/test/Icons.Test/SecurityHeadersTests.cs
+++ b/test/Icons.Test/SecurityHeadersTests.cs
@@ -1,0 +1,56 @@
+using System.Net.Http;
+using Xunit;
+
+namespace Bit.Icons.Test;
+
+public sealed class SecurityHeadersTests : IAsyncDisposable
+{
+    private readonly IconsApplicationFactory _factory = new();
+
+    [Fact]
+    public async Task GetAlive_ReturnsXFrameOptions()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/alive");
+        Assert.Equal("SAMEORIGIN", response.Headers.GetValues("x-frame-options").Single());
+    }
+
+    [Fact]
+    public async Task GetAlive_ReturnsXXssProtection()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/alive");
+        Assert.Equal("1; mode=block", response.Headers.GetValues("x-xss-protection").Single());
+    }
+
+    [Fact]
+    public async Task GetAlive_ReturnsXContentTypeOptions()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/alive");
+        Assert.Equal("nosniff", response.Headers.GetValues("x-content-type-options").Single());
+    }
+
+    [Fact]
+    public async Task GetAlive_ReturnsContentSecurityPolicy()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/alive");
+        Assert.Equal(
+            "default-src 'self'; script-src 'none'",
+            response.Headers.GetValues("Content-Security-Policy").Single());
+    }
+
+    [Fact]
+    public async Task GetAlive_ReturnsCacheControl()
+    {
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/alive");
+        var cacheControl = response.Headers.CacheControl;
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl.Public);
+        Assert.Equal(TimeSpan.FromDays(7), cacheControl.MaxAge);
+    }
+
+    public ValueTask DisposeAsync() => _factory.DisposeAsync();
+}

--- a/test/Icons.Test/packages.lock.json
+++ b/test/Icons.Test/packages.lock.json
@@ -8,6 +8,17 @@
         "resolved": "6.0.0",
         "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.8, 10.0.8]",
+        "resolved": "10.0.8",
+        "contentHash": "C9kMpUciPgx7ObqoO6W+eXEf3zHFWb7XpQgFJBzdO8GsmmVYrgcErTLMuki6e3EihycGpHbcJECYHDgM7XRMkg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.8",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Extensions.Hosting": "10.0.8"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.0.1, )",
@@ -484,6 +495,11 @@
         "resolved": "10.0.8",
         "contentHash": "NYxEmhe2tDPwwGgl0kNraUOJdOqaIYJpnZ1Lf7OlqWRf3aLagniVxMl8JSVmy0jiRtElsPYq8lTvLlbvRSwCLA=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HRH/XAke90wkHv9ykCsrvpVqvKOUt53jQzvHHIXrPIPZWAjyPq6B5/InCmPYWvme+WKMXD10rplMAitzNMtC3w=="
+      },
       "Microsoft.Azure.Amqp": {
         "type": "Transitive",
         "resolved": "2.7.0",
@@ -786,6 +802,15 @@
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
         }
       },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "nQXq1a4MiInYh+0VF9fguxAl06q2ftmOyYQ+5e933s4rk57xjgkbTjUdFUySzjrcrvDeWsSqlZB+TE8+TbM2HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+        }
+      },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Transitive",
         "resolved": "10.0.8",
@@ -844,8 +869,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "5Ou6varcxLBzQ+Agfm0k0pnH7vrEITYlXMDuE6s7ZHlZHz6/G8XJ3iISZDr5rfwfge6RnXJ1+Wc479mMn52vjA=="
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -888,6 +913,35 @@
         "type": "Transitive",
         "resolved": "10.0.8",
         "contentHash": "IUQet3SY51xIFcFZKtAB6a54/Zdxs7T3SQ84kJtOD6yeXfZgiOMksACWD5qtTmXGQGFH4QYGBOT0KIO8Uy/dJw=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "VfEyM2BipThcSd0GG/FS2ZPCVCTiosVq2zLKEDsfeMIg78sOVZPEmS7CgWlb+dqTlgXvLSL4OG2q6sM4xRhHNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.8",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.8",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Json": "10.0.8",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
+          "Microsoft.Extensions.Logging.Console": "10.0.8",
+          "Microsoft.Extensions.Logging.Debug": "10.0.8",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.8",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -955,17 +1009,63 @@
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "resolved": "10.0.8",
+        "contentHash": "rxSLTO7xTbcC3DuEJHNEijBr8g14Jj62zQ+DeFu68bsoTYoU8jLcMhc1735PV21bESXsATlL5LsfaWH71FOWAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "6cv53sHsPnFS56PJw8X4GbNcjeX1KGyFJRxJWvxOgK63cnqeSB1k1eRwjUdkse0tBhwlH6qc9EOYDlan+CYTuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "4HW3M1lGHHDwEYcDZHRNptBQ48LCI2yW+XV4vuxdfQUqafTpVT8j9RqAsez08krZKhIiaArWu8iQq5uRKZ9Ffg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "kK/C3SLIoGrcZvddYQw4eMm6YaROiSYBO7YgUR5Hdv5l+GIjBmbvQK5cST2FqjeubiAOPqFEimBT2N/8wVI+3A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "System.Diagnostics.EventLog": "10.0.8"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HX2M0MgzwQM8jpLe3AYAEMd0YsUfOP5RgGrDuk+Ki9n7HSuMbvLm9TEV3qRI3Pg9aqxc56GfgK/KdMRBhfWwKw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -1473,8 +1573,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "9.0.13",
-        "contentHash": "675Rk4RwaVrWo09wrR2rpDVKixtgtnhd5NhPrn6O21uj92JvE61KTGupn76M2N6Ff/xJjY3SHSfSg0MIanEzGw=="
+        "resolved": "10.0.8",
+        "contentHash": "+Ro7WgIom+BDNH+YhTuZKL6QJ0ctfOpTyfUG/h3aU5KwXt3OaNf0wYWrTvoBUj+34Dy5V8dN9yCco1hAJQ4txw=="
       },
       "System.Formats.Cbor": {
         "type": "Transitive",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41220

## 📔 Objective

Adds integration tests for the Icons service that verify the current behavior of its middleware pipeline:

- `IconsApplicationFactory` wraps `WebApplicationFactory<Program>` and configures `GlobalSettings` (vault origin, self-hosted flag) via in-memory config
- **Security headers**: `x-frame-options`, `x-xss-protection`, `x-content-type-options`, `Content-Security-Policy`, `Cache-Control`
- **CORS origin filtering**: vault origin, `file://`, `bw-desktop-file://bundle`, and `https://bitwarden.com` (cloud-only) allowed; unknown origins rejected; self-hosted mode excludes `bitwarden.com`
- **Info endpoints**: `/alive`, `/now` return a parsable `DateTime`; `/version` returns a parsable `Version`

These tests serve as a regression baseline so the upcoming refactor (replacing `UseForwardedHeaders(globalSettings)` and `IsCorsOriginAllowed` with `IConfigureOptions<T>`-based bridges) can be validated against them.