### PR TITLE
[PM-40492] Regenerate NuGet lock files during version bump

### DIFF
--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -78,6 +78,9 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
+      - name: Set up .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+
       - name: Install xmllint
         run: |
           sudo apt-get update
@@ -131,6 +134,9 @@ jobs:
         with:
           file_path: "Directory.Build.props"
           version: ${{ steps.calculate-next-version.outputs.version }}
+
+      - name: Regenerate NuGet lock files
+        run: dotnet restore bitwarden-server.slnx --force-evaluate
 
       - name: Set final version output
         id: set-final-version-output


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-40492

## Summary
- `packages.lock.json` files pin internal `ProjectReference` versions (e.g. `"Core": "[2026.7.2, )"`), so bumping `Directory.Build.props`'s `Version` left every lock file stale until an unrelated PR happened to restore packages and picked up the churn as unrelated diff noise (e.g. #8066 carried ~20 incidental `2026.7.1 → 2026.7.2` lock-file line changes).
- Adds a `dotnet restore bitwarden-server.slnx --force-evaluate` step to the `bump_version` job right after the version bump, so refreshed lock files land in the same commit/PR as the version bump itself.

## Test plan
- [x] Verified locally: bumping `Directory.Build.props`'s `Version` and running `dotnet restore --force-evaluate` regenerates the internal `ProjectReference` version pins in `packages.lock.json`.
- [x] Verified the restore is a no-op (no diff) when the version hasn't changed.
- [ ] Confirm the workflow runs successfully end-to-end via `workflow_dispatch` on a test run.