### PR TITLE
Add CI check to verify NuGet lock files are up to date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,14 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
 
+      - name: Verify NuGet lock files are up to date
+        run: |
+          dotnet restore bitwarden-server.slnx --force-evaluate
+          if ! git diff --exit-code -- '**/packages.lock.json'; then
+            echo "One or more packages.lock.json files are out of date. Run 'dotnet restore bitwarden-server.slnx --force-evaluate' locally and commit the changes." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
       - name: Install rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:


### PR DESCRIPTION
## Summary
- Adds an early step to the `Testing` workflow that runs `dotnet restore bitwarden-server.slnx --force-evaluate` and fails the build if it produces any diff on `packages.lock.json` files.
- `--locked-mode` only catches genuine `PackageReference` drift (e.g. Renovate PRs that bump a package version without regenerating the lock file); it does not catch stale internal `ProjectReference` version pins left behind when `Directory.Build.props`'s `Version` bumps without a lock file regeneration (see #8093-era investigation). This check catches both classes of drift before they leak into unrelated PRs.
- Complements the companion fix that regenerates lock files as part of the version-bump workflow itself.

## Test plan
- [x] Verified locally: `dotnet restore bitwarden-server.slnx --force-evaluate` followed by `git diff --exit-code -- '**/packages.lock.json'` passes cleanly on the current up-to-date repo state.
- [x] Verified the check fails (NU1004-style drift or stale internal version pins) when lock files are intentionally left out of sync.
- [ ] Confirm CI run on this PR passes the new step.