### PR TITLE
[DIRT] Expose feature flag for browser extension Health tab

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -300,6 +300,7 @@ public static class FeatureFlagKeys
     public const string PasskeyDirectoryReport = "inno-passkey-directory-report";
     public const string AccessIntelligenceAdoptionUxImprovements = "pm-34723-access-intelligence-adoption-ux-improvements";
     public const string EventManagementForGenericHec = "event-management-for-generic-hec";
+    public const string BrowserExtensionHealthReport = "pm-35928-premium-user-health-reports";
 
     /* UIF Team */
     public const string RouterFocusManagement = "router-focus-management";


### PR DESCRIPTION
## 🎟️ Tracking
N/A

## 📔 Objective
**BREAKING NEWS**

![](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWN2dnUxeTFudXQydm10Y3JicmYzbjF4OTM0bHNkbWFreHNuNHJleSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/HIWNaM05qJAENE1TJM/giphy.gif)

 Feature flags don't work if the server doesn't know about them 