### PR TITLE
[BRE-2116] Bump actions/checkout to v7.0.1 in non-privileged workflows

### DIFF
--- a/.github/workflows/_move_edd_db_scripts.yml
+++ b/.github/workflows/_move_edd_db_scripts.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -76,7 +76,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/cleanup-rc-branch.yml
+++ b/.github/workflows/cleanup-rc-branch.yml
@@ -39,7 +39,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/code-references.yml
+++ b/.github/workflows/code-references.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -87,7 +87,7 @@ jobs:
             datadog/agent:7-full@sha256:7ea933dec3b8baa8c19683b1c3f6f801dbf3291f748d9ed59234accdaac4e479
 
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/protect-files.yml
+++ b/.github/workflows/protect-files.yml
@@ -31,7 +31,7 @@ jobs:
             label: "DB-migrations-changed"
     steps:
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
           persist-credentials: false

--- a/.github/workflows/repository-management.yml
+++ b/.github/workflows/repository-management.yml
@@ -67,7 +67,7 @@ jobs:
           version: ${{ inputs.version_number_override }}
 
       - name: Check out branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           token: ${{ github.token }}
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Check out target ref
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.target_ref }}
           token: ${{ github.token }}

--- a/.github/workflows/test-database.yml
+++ b/.github/workflows/test-database.yml
@@ -44,7 +44,7 @@ jobs:
       checks: write
     steps:
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -269,7 +269,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-2116

## 📔 Objective

Mechanical version bump (`v6.0.2` → `v7.0.1`, SHA-pinned) across 8 workflows that use `pull_request` / `push` / `schedule` / `workflow_dispatch` triggers — none of which are the privileged `pull_request_target` fork-checkout pattern that v7 guards. The `pull_request` workflows here still check out and run fork PRs normally; they're just not privileged, so v7's fork-block doesn't apply and no `allow-unsafe-pr-checkout` is needed. The privileged `pull_request_target` build workflows are handled separately.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
