### PR TITLE
[SRE-4194] feat: support Entra ID auth for blob certificate reads

### DIFF
--- a/bitwarden_license/src/Commercial.Core/packages.lock.json
+++ b/bitwarden_license/src/Commercial.Core/packages.lock.json
@@ -1262,6 +1262,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/packages.lock.json
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/packages.lock.json
@@ -1418,6 +1418,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/src/Scim/packages.lock.json
+++ b/bitwarden_license/src/Scim/packages.lock.json
@@ -1099,6 +1099,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/src/Services/Pam/packages.lock.json
+++ b/bitwarden_license/src/Services/Pam/packages.lock.json
@@ -921,6 +921,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/src/Sso/packages.lock.json
+++ b/bitwarden_license/src/Sso/packages.lock.json
@@ -1138,6 +1138,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/test/Commercial.Core.Test/packages.lock.json
+++ b/bitwarden_license/test/Commercial.Core.Test/packages.lock.json
@@ -1477,6 +1477,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/test/SSO.Test/packages.lock.json
+++ b/bitwarden_license/test/SSO.Test/packages.lock.json
@@ -1658,6 +1658,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/test/Scim.IntegrationTest/packages.lock.json
+++ b/bitwarden_license/test/Scim.IntegrationTest/packages.lock.json
@@ -1303,6 +1303,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/test/Scim.Test/packages.lock.json
+++ b/bitwarden_license/test/Scim.Test/packages.lock.json
@@ -1618,6 +1618,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/test/Services/Pam.Test/packages.lock.json
+++ b/bitwarden_license/test/Services/Pam.Test/packages.lock.json
@@ -1353,6 +1353,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/bitwarden_license/test/Sso.IntegrationTest/packages.lock.json
+++ b/bitwarden_license/test/Sso.IntegrationTest/packages.lock.json
@@ -1341,6 +1341,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/perf/MicroBenchmarks/packages.lock.json
+++ b/perf/MicroBenchmarks/packages.lock.json
@@ -1556,6 +1556,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Admin/packages.lock.json
+++ b/src/Admin/packages.lock.json
@@ -1133,6 +1133,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Api/packages.lock.json
+++ b/src/Api/packages.lock.json
@@ -1169,6 +1169,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Billing/packages.lock.json
+++ b/src/Billing/packages.lock.json
@@ -1134,6 +1134,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Core/Billing/Services/Implementations/LicensingService.cs
+++ b/src/Core/Billing/Services/Implementations/LicensingService.cs
@@ -98,11 +98,11 @@ public class LicensingService : ILicensingService
         {
             _creationCertificate = CoreHelpers.GetCertificate(_globalSettings.LicenseCertificatePath, _globalSettings.LicenseCertificatePassword);
         }
-        else if (CoreHelpers.SettingHasValue(_globalSettings.Storage?.ConnectionString) &&
+        else if ((CoreHelpers.SettingHasValue(_globalSettings.Storage?.ConnectionString) || CoreHelpers.SettingHasValue(_globalSettings.Storage?.ServiceUri)) &&
             CoreHelpers.SettingHasValue(_globalSettings.LicenseCertificatePassword))
         {
             _creationCertificate = CoreHelpers.GetBlobCertificateAsync(globalSettings.Storage.ConnectionString, "certificates",
-                "licensing.pfx", _globalSettings.LicenseCertificatePassword)
+                "licensing.pfx", _globalSettings.LicenseCertificatePassword, _globalSettings.Storage.ServiceUri)
                 .GetAwaiter().GetResult();
         }
         else

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Bitwarden.Server.Sdk" />
 
   <PropertyGroup>
@@ -30,6 +30,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="[4.0.2.5]" />
     <PackageReference Include="Azure.Data.Tables" Version="[12.11.0]" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="[1.3.4]" />
+    <PackageReference Include="Azure.Identity" Version="[1.11.4]" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[10.0.8]" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.20.1]" />
     <PackageReference Include="Azure.Storage.Blobs" Version="[12.26.0]" />

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -451,6 +451,9 @@ public class GlobalSettings : IGlobalSettings
 
         private string _serviceUri;
 
+        /// <summary>
+        /// Requires an AKS workload identity; without it, certificate loading fails at startup.
+        /// </summary>
         public string ServiceUri
         {
             get => _serviceUri;

--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -417,12 +417,19 @@ public class GlobalSettings : IGlobalSettings
     public class AzureQueueEventSettings : IConnectionStringSettings
     {
         private string _connectionString;
+        private string _serviceUri;
         private string _queueName;
 
         public string ConnectionString
         {
             get => _connectionString;
             set => _connectionString = value?.Trim('"');
+        }
+
+        public string ServiceUri
+        {
+            get => _serviceUri;
+            set => _serviceUri = value?.Trim('"');
         }
 
         public string QueueName
@@ -440,6 +447,14 @@ public class GlobalSettings : IGlobalSettings
         {
             get => _connectionString;
             set => _connectionString = value?.Trim('"');
+        }
+
+        private string _serviceUri;
+
+        public string ServiceUri
+        {
+            get => _serviceUri;
+            set => _serviceUri = value?.Trim('"');
         }
     }
 

--- a/src/Core/Settings/IConnectionStringSettings.cs
+++ b/src/Core/Settings/IConnectionStringSettings.cs
@@ -3,4 +3,5 @@
 public interface IConnectionStringSettings
 {
     string ConnectionString { get; set; }
+    string ServiceUri { get; set; }
 }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -159,10 +159,6 @@ public static class CoreHelpers
         {
             return null;
         }
-        catch (Exception)
-        {
-            return null;
-        }
     }
 
     private static X509Certificate2 LoadCertificateByContentType(byte[] data, string password) =>

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -36,6 +36,7 @@ public static class CoreHelpers
     private static readonly Random _random = new Random();
     private static readonly string RealConnectingIp = "X-Connecting-IP";
     private static readonly Regex _whiteSpaceRegex = new Regex(@"\s+");
+    private static readonly WorkloadIdentityCredential _workloadIdentityCredential = new WorkloadIdentityCredential();
     private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -139,7 +140,7 @@ public static class CoreHelpers
 
     public static BlobServiceClient BuildBlobServiceClient(string connectionString, string serviceUri = "")
     {
-        return SettingHasValue(serviceUri) ? new BlobServiceClient(new Uri(serviceUri), new WorkloadIdentityCredential()) : new BlobServiceClient(connectionString);
+        return SettingHasValue(serviceUri) ? new BlobServiceClient(new Uri(serviceUri), _workloadIdentityCredential) : new BlobServiceClient(connectionString);
     }
 
     public async static Task<X509Certificate2?> GetBlobCertificateAsync(string connectionString, string container, string file, string password, string serviceUri = "")

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Web;
 using Azure;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Queues.Models;
@@ -136,11 +137,16 @@ public static class CoreHelpers
         }
     }
 
-    public async static Task<X509Certificate2?> GetBlobCertificateAsync(string connectionString, string container, string file, string password)
+    public static BlobServiceClient BuildBlobServiceClient(string connectionString, string serviceUri = "")
+    {
+        return SettingHasValue(serviceUri) ? new BlobServiceClient(new Uri(serviceUri), new WorkloadIdentityCredential()) : new BlobServiceClient(connectionString);
+    }
+
+    public async static Task<X509Certificate2?> GetBlobCertificateAsync(string connectionString, string container, string file, string password, string serviceUri = "")
     {
         try
         {
-            var blobServiceClient = new BlobServiceClient(connectionString);
+            var blobServiceClient = BuildBlobServiceClient(connectionString, serviceUri);
             var containerRef2 = blobServiceClient.GetBlobContainerClient(container);
             var blobRef = containerRef2.GetBlobClient(file);
 
@@ -645,11 +651,11 @@ public static class CoreHelpers
                 globalSettings.IdentityServer.CertificateThumbprint);
         }
         else if (!globalSettings.SelfHosted &&
-            SettingHasValue(globalSettings.Storage?.ConnectionString) &&
+                (SettingHasValue(globalSettings.Storage?.ConnectionString) || SettingHasValue(globalSettings.Storage?.ServiceUri)) &&
             SettingHasValue(globalSettings.IdentityServer.CertificatePassword))
         {
             return GetBlobCertificateAsync(globalSettings.Storage.ConnectionString, "certificates",
-                "identity.pfx", globalSettings.IdentityServer.CertificatePassword).GetAwaiter().GetResult();
+                "identity.pfx", globalSettings.IdentityServer.CertificatePassword, globalSettings.Storage.ServiceUri).GetAwaiter().GetResult();
         }
         return null;
     }

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -159,6 +159,10 @@ public static class CoreHelpers
         {
             return null;
         }
+        catch (RequestFailedException ex)
+        {
+            throw new InvalidOperationException($"Unable to download certificate from Azure Blob Storage: {container}/{file}", ex);
+        }
     }
 
     private static X509Certificate2 LoadCertificateByContentType(byte[] data, string password) =>

--- a/src/Core/packages.lock.json
+++ b/src/Core/packages.lock.json
@@ -62,6 +62,18 @@
           "Microsoft.AspNetCore.DataProtection": "3.1.32"
         }
       },
+      "Azure.Identity": {
+        "type": "Direct",
+        "requested": "[1.11.4, 1.11.4]",
+        "resolved": "1.11.4",
+        "contentHash": "Sf4BoE6Q3jTgFkgBkx7qztYOFELBCo+wQgpYDwal/qJ1unBH73ywPztIJKXBXORRzAeNijsuxhk94h0TIMvfYg==",
+        "dependencies": {
+          "Azure.Core": "1.38.0",
+          "Microsoft.Identity.Client": "4.61.3",
+          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
+          "System.Security.Cryptography.ProtectedData": "4.7.0"
+        }
+      },
       "Azure.Messaging.ServiceBus": {
         "type": "Direct",
         "requested": "[7.20.1, 7.20.1]",
@@ -593,17 +605,6 @@
         "dependencies": {
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory.Data": "1.0.2"
-        }
-      },
-      "Azure.Identity": {
-        "type": "Transitive",
-        "resolved": "1.11.4",
-        "contentHash": "Sf4BoE6Q3jTgFkgBkx7qztYOFELBCo+wQgpYDwal/qJ1unBH73ywPztIJKXBXORRzAeNijsuxhk94h0TIMvfYg==",
-        "dependencies": {
-          "Azure.Core": "1.38.0",
-          "Microsoft.Identity.Client": "4.61.3",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.61.3",
-          "System.Security.Cryptography.ProtectedData": "4.7.0"
         }
       },
       "Azure.Storage.Common": {

--- a/src/Events/packages.lock.json
+++ b/src/Events/packages.lock.json
@@ -1099,6 +1099,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/EventsProcessor/packages.lock.json
+++ b/src/EventsProcessor/packages.lock.json
@@ -1099,6 +1099,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Icons/packages.lock.json
+++ b/src/Icons/packages.lock.json
@@ -1105,6 +1105,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Identity/packages.lock.json
+++ b/src/Identity/packages.lock.json
@@ -1099,6 +1099,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Infrastructure.Dapper/packages.lock.json
+++ b/src/Infrastructure.Dapper/packages.lock.json
@@ -1267,6 +1267,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Infrastructure.EntityFramework/packages.lock.json
+++ b/src/Infrastructure.EntityFramework/packages.lock.json
@@ -1425,6 +1425,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/Notifications/packages.lock.json
+++ b/src/Notifications/packages.lock.json
@@ -1144,6 +1144,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/src/SharedWeb/packages.lock.json
+++ b/src/SharedWeb/packages.lock.json
@@ -1453,6 +1453,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Admin.Test/packages.lock.json
+++ b/test/Admin.Test/packages.lock.json
@@ -1670,6 +1670,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Api.IntegrationTest/packages.lock.json
+++ b/test/Api.IntegrationTest/packages.lock.json
@@ -1411,6 +1411,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Api.Test/packages.lock.json
+++ b/test/Api.Test/packages.lock.json
@@ -1764,6 +1764,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Billing.IntegrationTest/packages.lock.json
+++ b/test/Billing.IntegrationTest/packages.lock.json
@@ -1939,6 +1939,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Billing.Test/packages.lock.json
+++ b/test/Billing.Test/packages.lock.json
@@ -1716,6 +1716,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Common/packages.lock.json
+++ b/test/Common/packages.lock.json
@@ -1421,6 +1421,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Core.IntegrationTest/packages.lock.json
+++ b/test/Core.IntegrationTest/packages.lock.json
@@ -1396,6 +1396,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -453,4 +453,32 @@ public class CoreHelpersTests
     {
         Assert.Equal("helloworld", CoreHelpers.ReplaceWhiteSpace(email, string.Empty));
     }
+
+    private const string _testConnectionString = "DefaultEndpointsProtocol=https;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;EndpointSuffix=core.windows.net";
+    private const string _testServiceUri = "https://storageblob.blob.core.windows.net";
+
+    [Fact]
+    public void BuildBlobServiceClient_ServiceUriSet_UsesTokenCredential()
+    {
+        var client = CoreHelpers.BuildBlobServiceClient(_testConnectionString, _testServiceUri);
+
+        Assert.False(client.CanGenerateAccountSasUri);
+    }
+
+    [Fact]
+    public void BuildBlobServiceClient_ConnectionStringOnly_UsesSharedKey()
+    {
+        var client = CoreHelpers.BuildBlobServiceClient(_testConnectionString, "");
+
+        Assert.True(client.CanGenerateAccountSasUri);
+    }
+
+    [Fact]
+    public void BuildBlobServiceClient_ServiceUriPlaceholder_FallbackToConnectionString()
+    {
+        var client = CoreHelpers.BuildBlobServiceClient(_testConnectionString, "secret");
+
+        Assert.True(client.CanGenerateAccountSasUri);
+    }
+
 }

--- a/test/Core.Test/packages.lock.json
+++ b/test/Core.Test/packages.lock.json
@@ -1475,6 +1475,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Events.IntegrationTest/packages.lock.json
+++ b/test/Events.IntegrationTest/packages.lock.json
@@ -1738,6 +1738,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Events.Test/packages.lock.json
+++ b/test/Events.Test/packages.lock.json
@@ -1619,6 +1619,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/EventsProcessor.Test/packages.lock.json
+++ b/test/EventsProcessor.Test/packages.lock.json
@@ -1535,6 +1535,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Icons.Test/packages.lock.json
+++ b/test/Icons.Test/packages.lock.json
@@ -1623,6 +1623,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Identity.IntegrationTest/packages.lock.json
+++ b/test/Identity.IntegrationTest/packages.lock.json
@@ -1324,6 +1324,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Identity.Test/packages.lock.json
+++ b/test/Identity.Test/packages.lock.json
@@ -1655,6 +1655,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Infrastructure.Dapper.Test/packages.lock.json
+++ b/test/Infrastructure.Dapper.Test/packages.lock.json
@@ -1358,6 +1358,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Infrastructure.EFIntegration.Test/packages.lock.json
+++ b/test/Infrastructure.EFIntegration.Test/packages.lock.json
@@ -1634,6 +1634,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Infrastructure.IntegrationTest/packages.lock.json
+++ b/test/Infrastructure.IntegrationTest/packages.lock.json
@@ -1617,6 +1617,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/IntegrationTestCommon/packages.lock.json
+++ b/test/IntegrationTestCommon/packages.lock.json
@@ -1725,6 +1725,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Notifications.Test/packages.lock.json
+++ b/test/Notifications.Test/packages.lock.json
@@ -1718,6 +1718,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/SeederApi.IntegrationTest/packages.lock.json
+++ b/test/SeederApi.IntegrationTest/packages.lock.json
@@ -1318,6 +1318,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/Setup.Test/packages.lock.json
+++ b/test/Setup.Test/packages.lock.json
@@ -1482,6 +1482,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/test/SharedWeb.Test/packages.lock.json
+++ b/test/SharedWeb.Test/packages.lock.json
@@ -1676,6 +1676,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/Migrator/packages.lock.json
+++ b/util/Migrator/packages.lock.json
@@ -1280,6 +1280,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/MsSqlMigratorUtility/packages.lock.json
+++ b/util/MsSqlMigratorUtility/packages.lock.json
@@ -1298,6 +1298,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/MySqlMigrations/packages.lock.json
+++ b/util/MySqlMigrations/packages.lock.json
@@ -1539,6 +1539,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/PostgresMigrations/packages.lock.json
+++ b/util/PostgresMigrations/packages.lock.json
@@ -1539,6 +1539,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/Seeder/packages.lock.json
+++ b/util/Seeder/packages.lock.json
@@ -1449,6 +1449,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/SeederApi/packages.lock.json
+++ b/util/SeederApi/packages.lock.json
@@ -1096,6 +1096,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/SeederUtility/packages.lock.json
+++ b/util/SeederUtility/packages.lock.json
@@ -1468,6 +1468,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/Setup/packages.lock.json
+++ b/util/Setup/packages.lock.json
@@ -1286,6 +1286,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/SqlServerEFScaffold/packages.lock.json
+++ b/util/SqlServerEFScaffold/packages.lock.json
@@ -1675,6 +1675,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",

--- a/util/SqliteMigrations/packages.lock.json
+++ b/util/SqliteMigrations/packages.lock.json
@@ -1539,6 +1539,7 @@
           "AspNetCoreRateLimit.Redis": "[2.0.0, 2.0.0]",
           "Azure.Data.Tables": "[12.11.0, 12.11.0]",
           "Azure.Extensions.AspNetCore.DataProtection.Blobs": "[1.3.4, 1.3.4]",
+          "Azure.Identity": "[1.11.4, 1.11.4]",
           "Azure.Messaging.ServiceBus": "[7.20.1, 7.20.1]",
           "Azure.Storage.Blobs": "[12.26.0, 12.26.0]",
           "Azure.Storage.Blobs.Batch": "[12.23.0, 12.23.0]",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SRE-4194

## 📔 Objective

Adds an optional `globalSettings__storage__serviceUri` setting that, when set, authenticates blob certificate reads with a `WorkloadIdentityCredential` instead of a storage account key. When `serviceUri` is unset it defaults to the existing connection string path, making this opt-in and backwards compatible. 
