### PR TITLE
Add PendingProtection for safe protect-cert rotation when secrets land before non-secrets

### DIFF
--- a/src/Core/Settings/GlobalSettings.cs
+++ b/src/Core/Settings/GlobalSettings.cs
@@ -577,10 +577,29 @@ public class GlobalSettings : IGlobalSettings
 
         public CertificateInfo[] UnprotectCertificates { get; set; } = [];
 
+        /// <summary>
+        /// Stages a new protection certificate so its secret (Password) can be deployed before
+        /// the non-secret (FileName) without causing a startup failure. When Enabled is false the
+        /// entry is completely ignored. When Enabled is true the pending cert becomes the active
+        /// protection certificate and BlobName/CertificatePassword are ignored entirely, which
+        /// means they can be updated to match the new cert at any time without coordination.
+        /// The old protection certificate must be added to UnprotectCertificates explicitly
+        /// before activating PendingProtection to keep existing keys readable.
+        /// </summary>
+        public PendingProtectionSettings? PendingProtection { get; set; }
+
         public class CertificateInfo
         {
             public required string FileName { get; set; }
             public required string Password { get; set; }
+            public bool Enabled { get; set; } = true;
+        }
+
+        public class PendingProtectionSettings
+        {
+            public string? FileName { get; set; }
+            public string? Password { get; set; }
+            public bool Enabled { get; set; }
         }
     }
 #nullable disable

--- a/src/SharedWeb/Utilities/DataProtectionServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/DataProtectionServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Azure;
 using Azure.Storage.Blobs;

--- a/src/SharedWeb/Utilities/DataProtectionServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/DataProtectionServiceCollectionExtensions.cs
@@ -28,33 +28,30 @@ public static class DataProtectionServiceCollectionExtensions
             var pending = globalSettings.DataProtection.PendingProtection;
 
             X509Certificate2? dataProtectionCert = null;
-            if (CoreHelpers.SettingHasValue(globalSettings.DataProtection.CertificateThumbprint))
+            if (pending is { Enabled: true })
+            {
+                dataProtectionCert = DownloadRequiredCertFromBlobStorage(
+                    globalSettings.Storage.ConnectionString,
+                    "certificates",
+                    pending.FileName,
+                    pending.Password,
+                    "pending protect"
+                );
+            }
+            else if (CoreHelpers.SettingHasValue(globalSettings.DataProtection.CertificateThumbprint))
             {
                 dataProtectionCert = CoreHelpers.GetCertificate(
                     globalSettings.DataProtection.CertificateThumbprint);
             }
             else if (CoreHelpers.SettingHasValue(globalSettings.DataProtection.CertificatePassword))
             {
-                if (pending is { Enabled: true })
-                {
-                    dataProtectionCert = DownloadRequiredCertFromBlobStorage(
-                        globalSettings.Storage.ConnectionString,
-                        "certificates",
-                        pending.FileName,
-                        pending.Password,
-                        "pending protect"
-                    );
-                }
-                else
-                {
-                    dataProtectionCert = DownloadRequiredCertFromBlobStorage(
-                        globalSettings.Storage.ConnectionString,
-                        "certificates",
-                        globalSettings.DataProtection.BlobName,
-                        globalSettings.DataProtection.CertificatePassword,
-                        "protect"
-                    );
-                }
+                dataProtectionCert = DownloadRequiredCertFromBlobStorage(
+                    globalSettings.Storage.ConnectionString,
+                    "certificates",
+                    globalSettings.DataProtection.BlobName,
+                    globalSettings.DataProtection.CertificatePassword,
+                    "protect"
+                );
             }
 
             if (!env.IsDevelopment())

--- a/src/SharedWeb/Utilities/DataProtectionServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/DataProtectionServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Azure;
 using Azure.Storage.Blobs;
@@ -25,6 +25,8 @@ public static class DataProtectionServiceCollectionExtensions
 
         if (!globalSettings.SelfHosted && CoreHelpers.SettingHasValue(globalSettings.Storage?.ConnectionString))
         {
+            var pending = globalSettings.DataProtection.PendingProtection;
+
             X509Certificate2? dataProtectionCert = null;
             if (CoreHelpers.SettingHasValue(globalSettings.DataProtection.CertificateThumbprint))
             {
@@ -33,13 +35,26 @@ public static class DataProtectionServiceCollectionExtensions
             }
             else if (CoreHelpers.SettingHasValue(globalSettings.DataProtection.CertificatePassword))
             {
-                dataProtectionCert = DownloadRequiredCertFromBlobStorage(
-                    globalSettings.Storage.ConnectionString,
-                    "certificates",
-                    globalSettings.DataProtection.BlobName,
-                    globalSettings.DataProtection.CertificatePassword,
-                    "protect"
-                );
+                if (pending is { Enabled: true })
+                {
+                    dataProtectionCert = DownloadRequiredCertFromBlobStorage(
+                        globalSettings.Storage.ConnectionString,
+                        "certificates",
+                        pending.FileName,
+                        pending.Password,
+                        "pending protect"
+                    );
+                }
+                else
+                {
+                    dataProtectionCert = DownloadRequiredCertFromBlobStorage(
+                        globalSettings.Storage.ConnectionString,
+                        "certificates",
+                        globalSettings.DataProtection.BlobName,
+                        globalSettings.DataProtection.CertificatePassword,
+                        "protect"
+                    );
+                }
             }
 
             if (!env.IsDevelopment())
@@ -56,18 +71,19 @@ public static class DataProtectionServiceCollectionExtensions
                     .PersistKeysToAzureBlobStorage(globalSettings.Storage.ConnectionString, "aspnet-dataprotection", "keys.xml")
                     .ProtectKeysWithCertificate(dataProtectionCert);
 
-                if (globalSettings.DataProtection.UnprotectCertificates.Length > 0)
-                {
-                    var unprotectCertificates = globalSettings.DataProtection.UnprotectCertificates
-                        .Index()
-                        .Select(i => DownloadRequiredCertFromBlobStorage(
-                            globalSettings.Storage.ConnectionString,
-                            "certificates",
-                            i.Item.FileName,
-                            i.Item.Password,
-                            $"Unprotect {i.Index}"
-                        )).ToArray();
+                var unprotectCertificates = globalSettings.DataProtection.UnprotectCertificates
+                    .Index()
+                    .Where(i => i.Item.Enabled)
+                    .Select(i => DownloadRequiredCertFromBlobStorage(
+                        globalSettings.Storage.ConnectionString,
+                        "certificates",
+                        i.Item.FileName,
+                        i.Item.Password,
+                        $"Unprotect {i.Index}"
+                    )).ToArray();
 
+                if (unprotectCertificates.Length > 0)
+                {
                     builder.UnprotectKeysWithAnyCertificate(unprotectCertificates);
                 }
             }
@@ -77,8 +93,8 @@ public static class DataProtectionServiceCollectionExtensions
     private static X509Certificate2 DownloadRequiredCertFromBlobStorage(
         string connectionString,
         string container,
-        string file,
-        string password,
+        string? file,
+        string? password,
         string context)
     {
         try
@@ -98,6 +114,10 @@ public static class DataProtectionServiceCollectionExtensions
         catch (CryptographicException ex)
         {
             throw new InvalidOperationException($"Unable to load certificate downloaded from azure blob storage; verify the password is correct and the blob contains valid PKCS#12 data: {context}", ex);
+        }
+        catch (ArgumentNullException ex) when (ex.ParamName == "blobName")
+        {
+            throw new InvalidOperationException($"Unable to download certificate because the FileName given is null: {context}", ex);
         }
     }
 }

--- a/test/SharedWeb.Test/DataProtectionServicesTests.cs
+++ b/test/SharedWeb.Test/DataProtectionServicesTests.cs
@@ -218,6 +218,11 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
         // The goal of this test is an upgrade scenario where we want to start using a new certificate
         // encrypting keys at rest but want the upgrade to cause 0 issues with data protection
         // we also want to be able to revert the configuration changes in case there are issues.
+        //
+        // NOTE: This test assumes all config changes land atomically. In practice secrets can land
+        // before non-secrets, which makes several steps here unsafe as written. Do not use this
+        // test as a basis for what to do in production — see UpgradePath_WithPendingProtection
+        // for a deployment sequence that is safe regardless of the order changes land.
 
         // Setup "existing" azure infrastructure.
         await using var azurite = new ContainerBuilder("mcr.microsoft.com/azure-storage/azurite")
@@ -333,6 +338,149 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
         Assert.Equal("NoNewConfig", revertedAppProtector.Unprotect(noNewConfigProtectedData));
         Assert.Equal("Prepared", revertedAppProtector.Unprotect(preparedProtectedData));
         Assert.Equal("UpdatedConfig", revertedAppProtector.Unprotect(updatedConfigData));
+    }
+
+    [Fact]
+    public async Task UpgradePath_WithPendingProtection()
+    {
+        // Full lifecycle of a protect-cert rotation using PendingProtection, including cleanup.
+        // Each phase uses the Enabled=false staging pattern so secrets can land before non-secrets.
+        //
+        // Step A — move old cert into UnprotectCertificates before activating PendingProtection:
+        //   Non-secret:   UnprotectCertificates:0:Enabled = false   (inert slot)
+        //   Secret lands: UnprotectCertificates:0:Password = OldPw  (safe, slot inactive)
+        //   Non-secrets:  UnprotectCertificates:0:FileName + Enabled = true
+        //
+        // Step B — activate PendingProtection:
+        //   Non-secret:   PendingProtection:Enabled = false          (inert slot)
+        //   Secret lands: PendingProtection:Password = NewPw         (safe, slot inactive)
+        //   Non-secrets:  PendingProtection:FileName + Enabled = true
+        //
+        // Step C — cleanup (BlobName/CertificatePassword ignored while pending active,
+        //           so secret/non-secret order no longer matters for them):
+        //   Secret:     CertificatePassword = NewPw
+        //   Non-secret: BlobName = "mynewcert.pfx"
+        //   Non-secret: PendingProtection:Enabled = false  → falls back to updated BlobName/CertificatePassword
+        await using var azurite = new ContainerBuilder("mcr.microsoft.com/azure-storage/azurite")
+            .WithPortBinding(10000, true)
+            .Build();
+
+        await azurite.StartAsync();
+
+        var azuriteConnectionString = $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://{azurite.Hostname}:{azurite.GetMappedPublicPort(10000)}/devstoreaccount1;";
+
+        var blobServiceClient = new BlobServiceClient(azuriteConnectionString);
+        var certificates = await blobServiceClient.CreateBlobContainerAsync("certificates");
+        var dataProtection = await blobServiceClient.CreateBlobContainerAsync("aspnet-dataprotection");
+
+        await certificates.Value.UploadBlobAsync("dataprotection.pfx", new BinaryData(FakeInitialCert));
+        await dataProtection.Value.UploadBlobAsync("keys.xml", new BinaryData(KeysData));
+
+        using var rsa = RSA.Create(2048);
+        var now = DateTimeOffset.UtcNow;
+        var newCertificate = new CertificateRequest("CN=New Dataprotected test certificate", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+            .CreateSelfSigned(now, now.AddDays(365));
+
+        const string NewCertPassword = "Undergrad-Police0-Maturely-Countless";
+        await certificates.Value.UploadBlobAsync(
+            "mynewcert.pfx",
+            new BinaryData(newCertificate.Export(X509ContentType.Pfx, NewCertPassword))
+        );
+
+        // A1: Old cert password staged, Enabled=false keeps the slot inert — old cert still protects
+        using var stepA1 = CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:CertificatePassword", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Enabled", "false" },
+        });
+        Assert.Equal("MyTestData", GetProtector(stepA1).Unprotect(SavedProtectedData));
+
+        // A2: FileName + Enabled=true land together; old cert now explicitly in UnprotectCertificates
+        using var stepA2 = CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:CertificatePassword", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:FileName", "dataprotection.pfx" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password", "Alongside-Unworthy-Query3-Cozy" },
+        });
+        Assert.Equal("MyTestData", GetProtector(stepA2).Unprotect(SavedProtectedData));
+
+        // B1: New cert password staged, Enabled=false keeps the slot inert — old cert still protects
+        using var stepB1 = CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:CertificatePassword", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:FileName", "dataprotection.pfx" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:PendingProtection:Password", NewCertPassword },
+            { "GlobalSettings:DataProtection:PendingProtection:Enabled", "false" },
+        });
+        Assert.Equal("MyTestData", GetProtector(stepB1).Unprotect(SavedProtectedData));
+
+        // B2: FileName + Enabled=true land together; new cert now protects; old cert in
+        // UnprotectCertificates keeps existing keys readable
+        using var stepB2 = CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:CertificatePassword", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:FileName", "dataprotection.pfx" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:PendingProtection:FileName", "mynewcert.pfx" },
+            { "GlobalSettings:DataProtection:PendingProtection:Password", NewCertPassword },
+            { "GlobalSettings:DataProtection:PendingProtection:Enabled", "true" },
+        });
+        Assert.Equal("MyTestData", GetProtector(stepB2).Unprotect(SavedProtectedData));
+        var step4ProtectedData = AssertRoundTrippable(GetProtector(stepB2), "Step4");
+
+        // C1: CertificatePassword updated to new cert's value (secret lands first during cleanup).
+        // BlobName still points to old cert blob. Since PendingProtection:Enabled=true,
+        // BlobName/CertificatePassword are not loaded — no mismatch, no failure.
+        using var stepC1 = CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:CertificatePassword", NewCertPassword },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:FileName", "dataprotection.pfx" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:PendingProtection:FileName", "mynewcert.pfx" },
+            { "GlobalSettings:DataProtection:PendingProtection:Password", NewCertPassword },
+            { "GlobalSettings:DataProtection:PendingProtection:Enabled", "true" },
+        });
+        Assert.Equal("MyTestData", GetProtector(stepC1).Unprotect(SavedProtectedData));
+        Assert.Equal("Step4", GetProtector(stepC1).Unprotect(step4ProtectedData));
+
+        // C2: BlobName updated to new cert blob (non-secret lands); still ignored while
+        // PendingProtection:Enabled=true, so the old-cert-blob/new-password mismatch window
+        // never exists.
+        using var stepC2 = CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:BlobName", "mynewcert.pfx" },
+            { "GlobalSettings:DataProtection:CertificatePassword", NewCertPassword },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:FileName", "dataprotection.pfx" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:PendingProtection:FileName", "mynewcert.pfx" },
+            { "GlobalSettings:DataProtection:PendingProtection:Password", NewCertPassword },
+            { "GlobalSettings:DataProtection:PendingProtection:Enabled", "true" },
+        });
+        Assert.Equal("MyTestData", GetProtector(stepC2).Unprotect(SavedProtectedData));
+        Assert.Equal("Step4", GetProtector(stepC2).Unprotect(step4ProtectedData));
+
+        // C3: PendingProtection deactivated — falls back to BlobName=mynewcert.pfx +
+        // CertificatePassword=NewPw via the standard path. PendingProtection block can now
+        // be removed entirely from config.
+        using var stepC3 = CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:BlobName", "mynewcert.pfx" },
+            { "GlobalSettings:DataProtection:CertificatePassword", NewCertPassword },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:FileName", "dataprotection.pfx" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password", "Alongside-Unworthy-Query3-Cozy" },
+        });
+        Assert.Equal("MyTestData", GetProtector(stepC3).Unprotect(SavedProtectedData));
+        Assert.Equal("Step4", GetProtector(stepC3).Unprotect(step4ProtectedData));
+        AssertRoundTrippable(GetProtector(stepC3), "CleanedUp");
     }
 
     [Fact]
@@ -452,13 +600,69 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
         await certificates.Value.UploadBlobAsync("dataprotection.pfx", new BinaryData(FakeInitialCert));
         await dataProtection.Value.UploadBlobAsync("keys.xml", new BinaryData(KeysData));
 
-        var exception = Assert.Throws<ArgumentNullException>(() => CreateApp(new Dictionary<string, string?>
+        var exception = Assert.Throws<InvalidOperationException>(() => CreateApp(new Dictionary<string, string?>
         {
             { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
             { "GlobalSettings:DataProtection:CertificatePassword", "Alongside-Unworthy-Query3-Cozy" },
             { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password",  NewCertPassword },
         }));
-        Assert.Contains("blobName", exception.ParamName);
+        Assert.Contains("Unprotect 0", exception.Message);
+        Assert.Contains("FileName", exception.Message);
+    }
+
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task UnprotectCertificateCorrectPassword_NoFileName_EnabledFalse_Works(bool withPassword)
+    {
+        // This test shows how you can start to progressively stage information about an unprotect
+        // but as long as Enabled=false is in their that unprotect certificate will not attempt to be
+        // loaded and an otherwise invalid configuration does not cause startup issues and can be used.
+        // An unprotect certificate that has been used to actually protect keys should NEVER be disabled
+        await using var azurite = new ContainerBuilder("mcr.microsoft.com/azure-storage/azurite")
+            .WithPortBinding(10000, true)
+            .Build();
+
+        await azurite.StartAsync();
+
+        var azuriteConnectionString = $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://{azurite.Hostname}:{azurite.GetMappedPublicPort(10000)}/devstoreaccount1;";
+
+        var blobServiceClient = new BlobServiceClient(azuriteConnectionString);
+
+        var certificates = await blobServiceClient.CreateBlobContainerAsync("certificates");
+        var dataProtection = await blobServiceClient.CreateBlobContainerAsync("aspnet-dataprotection");
+
+        using var rsa = RSA.Create(2048);
+        var now = DateTimeOffset.UtcNow;
+        var certificate = new CertificateRequest("CN=New Dataprotected test certificate", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+            .CreateSelfSigned(now, now.AddDays(365));
+
+        const string NewCertPassword = "Undergrad-Police0-Maturely-Countless";
+        await certificates.Value.UploadBlobAsync(
+            "mynewcert.pfx",
+            new BinaryData(certificate.Export(X509ContentType.Pfx, NewCertPassword))
+        );
+
+        await certificates.Value.UploadBlobAsync("dataprotection.pfx", new BinaryData(FakeInitialCert));
+        await dataProtection.Value.UploadBlobAsync("keys.xml", new BinaryData(KeysData));
+
+        var config = new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:CertificatePassword", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Enabled", "false" },
+        };
+
+        if (withPassword)
+        {
+            config.Add("GlobalSettings:Dataprotection:UnprotectCertificates:0:Password", NewCertPassword);
+        }
+
+        using var app = CreateApp(config);
+        var protector = GetProtector(app);
+        AssertRoundTrippable(protector, "NotEnabled");
+        Assert.Equal("MyTestData", protector.Unprotect(SavedProtectedData));
     }
 
     [Fact]

--- a/test/SharedWeb.Test/DataProtectionServicesTests.cs
+++ b/test/SharedWeb.Test/DataProtectionServicesTests.cs
@@ -484,6 +484,50 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
     }
 
     [Fact]
+    public async Task PendingProtection_WithNoCertificatePassword_Works()
+    {
+        // PendingProtection:Enabled=true must fire even when CertificatePassword is absent.
+        // Previously, PendingProtection was nested inside the CertificatePassword branch, so
+        // an absent/placeholder CertificatePassword silently skipped pending and caused a
+        // misleading "check your blob storage connection string" startup failure.
+        await using var azurite = new ContainerBuilder("mcr.microsoft.com/azure-storage/azurite")
+            .WithPortBinding(10000, true)
+            .Build();
+
+        await azurite.StartAsync();
+
+        var azuriteConnectionString = $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://{azurite.Hostname}:{azurite.GetMappedPublicPort(10000)}/devstoreaccount1;";
+
+        var blobServiceClient = new BlobServiceClient(azuriteConnectionString);
+        var certificates = await blobServiceClient.CreateBlobContainerAsync("certificates");
+        var dataProtection = await blobServiceClient.CreateBlobContainerAsync("aspnet-dataprotection");
+
+        using var rsa = RSA.Create(2048);
+        var now = DateTimeOffset.UtcNow;
+        var newCertificate = new CertificateRequest("CN=New Dataprotected test certificate", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+            .CreateSelfSigned(now, now.AddDays(365));
+
+        const string NewCertPassword = "Undergrad-Police0-Maturely-Countless";
+        await certificates.Value.UploadBlobAsync(
+            "mynewcert.pfx",
+            new BinaryData(newCertificate.Export(X509ContentType.Pfx, NewCertPassword))
+        );
+        await dataProtection.Value.UploadBlobAsync("keys.xml", new BinaryData(KeysData));
+
+        // CertificatePassword is intentionally absent — only PendingProtection is configured.
+        using var app = CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:PendingProtection:FileName", "mynewcert.pfx" },
+            { "GlobalSettings:DataProtection:PendingProtection:Password", NewCertPassword },
+            { "GlobalSettings:DataProtection:PendingProtection:Enabled", "true" },
+        });
+
+        var protector = GetProtector(app);
+        AssertRoundTrippable(protector, "PendingNoCertPassword");
+    }
+
+    [Fact]
     public async Task UnprotectCertificateMissingFromBlobStorage_Throws()
     {
         // The previous implementation returned null on BlobNotFound and that null reached

--- a/test/SharedWeb.Test/DataProtectionServicesTests.cs
+++ b/test/SharedWeb.Test/DataProtectionServicesTests.cs
@@ -415,6 +415,52 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
         Assert.IsType<CryptographicException>(exception.InnerException);
     }
 
+
+    [Fact]
+    public async Task UnprotectCertificateCorrectPassword_NoFileName_Throws()
+    {
+        // This test shows what more than likely went wrong when we initially tried to update the config
+        // we staged the password which is a secret and it caused a deploy at a different time than the
+        // rest of the information on the unprotect certificate was in the config. That caused it to
+        // become an object but with a null `FileName` which led to an ArgumentNullException that was
+        // swallowed and `null` was returned. In our new fail-fast code this properly leads to an exception
+        // at startup.
+        await using var azurite = new ContainerBuilder("mcr.microsoft.com/azure-storage/azurite")
+            .WithPortBinding(10000, true)
+            .Build();
+
+        await azurite.StartAsync();
+
+        var azuriteConnectionString = $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://{azurite.Hostname}:{azurite.GetMappedPublicPort(10000)}/devstoreaccount1;";
+
+        var blobServiceClient = new BlobServiceClient(azuriteConnectionString);
+
+        var certificates = await blobServiceClient.CreateBlobContainerAsync("certificates");
+        var dataProtection = await blobServiceClient.CreateBlobContainerAsync("aspnet-dataprotection");
+
+        using var rsa = RSA.Create(2048);
+        var now = DateTimeOffset.UtcNow;
+        var certificate = new CertificateRequest("CN=New Dataprotected test certificate", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+            .CreateSelfSigned(now, now.AddDays(365));
+
+        const string NewCertPassword = "Undergrad-Police0-Maturely-Countless";
+        await certificates.Value.UploadBlobAsync(
+            "mynewcert.pfx",
+            new BinaryData(certificate.Export(X509ContentType.Pfx, NewCertPassword))
+        );
+
+        await certificates.Value.UploadBlobAsync("dataprotection.pfx", new BinaryData(FakeInitialCert));
+        await dataProtection.Value.UploadBlobAsync("keys.xml", new BinaryData(KeysData));
+
+        var exception = Assert.Throws<ArgumentNullException>(() => CreateApp(new Dictionary<string, string?>
+        {
+            { "GlobalSettings:Storage:ConnectionString", azuriteConnectionString },
+            { "GlobalSettings:DataProtection:CertificatePassword", "Alongside-Unworthy-Query3-Cozy" },
+            { "GlobalSettings:DataProtection:UnprotectCertificates:0:Password",  NewCertPassword },
+        }));
+        Assert.Contains("blobName", exception.ParamName);
+    }
+
     [Fact]
     public async Task ProtectionCertificateMissingFromBlobStorage_Throws()
     {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Rotating the data protection certificate in production requires coordinating secret changes (`CertificatePassword`, `UnprotectCertificates[i].Password`) with non-secret changes (`BlobName`, `UnprotectCertificates[i].FileName`). Because secrets can land before non-secrets there are intermediate states where passwords and blob names are mismatched, causing `CryptographicException` at startup and preventing pods from starting.

This PR adds two mechanisms to make cert rotation safe regardless of deployment order.

### `UnprotectCertificates[i].Enabled`

Each entry in `UnprotectCertificates` now has an `Enabled` flag (default `true`). Setting `Enabled=false` causes the entry to be skipped entirely at startup, so the password (secret) can be deployed first while the filename (non-secret) is not yet configured. Once both are in place, flip `Enabled=true` alongside `FileName` in a single non-secret deploy.

The previous implementation swallowed errors when `FileName` was null (returning `null` which caused `NullReferenceException` downstream and led pods to auto-generate divergent key rings). The new implementation is fail-fast: a missing `FileName` with `Enabled=true` throws `InvalidOperationException` at startup with the index in the message so operators can identify which entry is misconfigured from the log alone.

### `PendingProtection`

Rotating the *protection* certificate has the same secret/non-secret ordering problem: `CertificatePassword` and `BlobName` must effectively change together. `PendingProtection` (`FileName`, `Password`, `Enabled`) solves this with the same `Enabled=false` staging pattern:

- `Enabled=false` — entry is completely ignored; the password secret can be deployed safely
- `Enabled=true` — the pending cert becomes the active protection certificate; `BlobName` and `CertificatePassword` are ignored entirely while pending is active, so they can be updated to match the new cert in any order without causing a startup failure

There is no auto-demotion of the old cert. The old cert must be added to `UnprotectCertificates` explicitly (using the `Enabled=false` staging pattern) before `PendingProtection` is activated. Once `BlobName`/`CertificatePassword` have been updated to the new cert's values, `PendingProtection` can be deactivated and the config returns to the standard path.

**Safe rotation procedure**

1. Stage old cert into `UnprotectCertificates` — `Enabled=false` first, then secret (`Password`), then `FileName` + `Enabled=true` as non-secrets
2. Stage `PendingProtection` — `Enabled=false` first, then secret (`Password`), then `FileName` + `Enabled=true` as non-secrets
3. Cleanup — update `BlobName`/`CertificatePassword` in any order (both ignored while pending active), then set `PendingProtection:Enabled=false`

**Tests added**

- `UnprotectCertificateCorrectPassword_NoFileName_Throws` — documents the fail-fast behaviour when `Enabled=true` but `FileName` is missing
- `UnprotectCertificateCorrectPassword_NoFileName_EnabledFalse_Works` — shows `Enabled=false` suppresses the error even with a missing filename or password, allowing progressive staging
- `UpgradePath_WithPendingProtection` — walks the full rotation lifecycle (Steps A, B, C) verifying each intermediate state starts cleanly and existing protected data remains accessible throughout; the existing `UpgradePath` test carries a warning that its atomic-deploy assumption is unsafe in practice

## 📸 Screenshots

N/A