### PR TITLE
[PM-39454] refactor(users): make UpdateUserData provider-agnostic and enlist EF delegates

### DIFF
--- a/src/Core/Repositories/IUserRepository.cs
+++ b/src/Core/Repositories/IUserRepository.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Billing.Premium.Models;
+﻿using System.Data.Common;
+using Bit.Core.Billing.Premium.Models;
 using Bit.Core.Entities;
 using Bit.Core.KeyManagement.Models.Data;
 using Bit.Core.KeyManagement.UserKey;
@@ -96,5 +97,15 @@ public interface IUserRepository : IRepository<User, Guid>
     UpdateUserData UpdateMasterPasswordUnlockData(Guid userId, RegisterFinishData registerFinishData);
 }
 
-public delegate Task UpdateUserData(Microsoft.Data.SqlClient.SqlConnection? connection = null,
-    Microsoft.Data.SqlClient.SqlTransaction? transaction = null);
+/// <summary>
+/// A deferred write against a user's row, run by <see cref="IUserRepository.UpdateUserDataAsync"/> or as part of a
+/// larger repository transaction such as
+/// <see cref="IUserRepository.SetV2AccountCryptographicStateAsync"/>.
+/// </summary>
+/// <remarks>
+/// The connection and transaction are provider-agnostic so that both the Dapper and Entity Framework
+/// implementations can hand the caller's ambient transaction to the action. An action given one must enlist in it:
+/// writing the same user row over a second connection blocks on the caller's uncommitted changes until the command
+/// times out.
+/// </remarks>
+public delegate Task UpdateUserData(DbConnection? connection = null, DbTransaction? transaction = null);

--- a/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
+++ b/src/Infrastructure.EntityFramework/Repositories/UserRepository.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+﻿using System.Data.Common;
+using AutoMapper;
 using Bit.Core.Billing.Premium.Models;
 using Bit.Core.Enums;
 using Bit.Core.KeyManagement.Kdf;
@@ -8,6 +9,7 @@ using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
 using Bit.Infrastructure.EntityFramework.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.Infrastructure.EntityFramework.Repositories;
@@ -17,6 +19,22 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
     public UserRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
         : base(serviceScopeFactory, mapper, (DatabaseContext context) => context.Users)
     { }
+
+    /// <summary>
+    /// Builds the context an <see cref="UpdateUserData"/> action writes through.
+    /// </summary>
+    private async Task<DatabaseContext> GetUpdateUserDataContextAsync(IServiceScope scope, DbConnection? connection,
+        DbTransaction? transaction)
+    {
+        var dbContext = GetDatabaseContext(scope);
+        if (connection != null)
+        {
+            dbContext.Database.SetDbConnection(connection);
+            await dbContext.Database.UseTransactionAsync(transaction);
+        }
+
+        return dbContext;
+    }
 
     public async Task<Core.Entities.User?> GetByGatewayCustomerIdAsync(string gatewayCustomerId)
     {
@@ -341,7 +359,7 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
         {
             foreach (var action in updateUserDataActions)
             {
-                await action();
+                await action(dbContext.Database.GetDbConnection(), transaction.GetDbTransaction());
             }
         }
         await transaction.CommitAsync();
@@ -511,10 +529,10 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
 
     public UpdateUserData SetKeyConnectorUserKey(Guid userId, string keyConnectorWrappedUserKey)
     {
-        return async (_, _) =>
+        return async (connection, transaction) =>
         {
             using var scope = ServiceScopeFactory.CreateScope();
-            var dbContext = GetDatabaseContext(scope);
+            var dbContext = await GetUpdateUserDataContextAsync(scope, connection, transaction);
 
             var userEntity = await dbContext.Users.FindAsync(userId);
             if (userEntity == null)
@@ -541,10 +559,10 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
     public UpdateUserData SetMasterPassword(Guid userId, MasterPasswordUnlockData masterPasswordUnlockData,
         string serverSideHashedMasterPasswordAuthenticationHash, string? masterPasswordHint)
     {
-        return async (_, _) =>
+        return async (connection, transaction) =>
         {
             using var scope = ServiceScopeFactory.CreateScope();
-            var dbContext = GetDatabaseContext(scope);
+            var dbContext = await GetUpdateUserDataContextAsync(scope, connection, transaction);
 
             var userEntity = await dbContext.Users.FindAsync(userId);
             if (userEntity == null)
@@ -581,7 +599,7 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
 
         foreach (var action in updateUserDataActions)
         {
-            await action();
+            await action(dbContext.Database.GetDbConnection(), transaction.GetDbTransaction());
         }
 
         await transaction.CommitAsync();
@@ -589,10 +607,10 @@ public class UserRepository : Repository<Core.Entities.User, User, Guid>, IUserR
 
     public UpdateUserData UpdateMasterPasswordUnlockData(Guid userId, RegisterFinishData registerFinishData)
     {
-        return async (_, _) =>
+        return async (connection, transaction) =>
         {
             using var scope = ServiceScopeFactory.CreateScope();
-            var dbContext = GetDatabaseContext(scope);
+            var dbContext = await GetUpdateUserDataContextAsync(scope, connection, transaction);
 
             var userEntity = await dbContext.Users.FindAsync(userId) ?? throw new ArgumentException("User not found", nameof(userId));
             var timestamp = DateTime.UtcNow;

--- a/test/Infrastructure.IntegrationTest/Repositories/UserRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Repositories/UserRepositoryTests.cs
@@ -2,6 +2,7 @@
 using Bit.Core.Auth.UserFeatures.UserMasterPassword;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.KeyManagement.Enums;
 using Bit.Core.KeyManagement.Kdf;
 using Bit.Core.KeyManagement.Models.Data;
 using Bit.Core.KeyManagement.UserKey;
@@ -879,6 +880,66 @@ public class UserRepositoryTests
         // Assert
         Assert.Null(result);
     }
+
+    [Theory, DatabaseData]
+    public async Task SetV2AccountCryptographicStateAsync_RunsDelegatesInTheCallerTransaction(
+        IUserRepository userRepository)
+    {
+        // Arrange
+        // The delegate writes the same user row the enclosing transaction has already written and not yet
+        // committed. If it does not enlist in that transaction it opens a second connection and blocks on
+        // the uncommitted row until the command times out, so this test failing as a timeout is the
+        // regression it guards against.
+        var email = $"test+{Guid.NewGuid()}@example.com";
+        var user = await userRepository.CreateAsync(new User
+        {
+            Name = "Test User",
+            Email = email,
+            ApiKey = "TEST",
+            SecurityStamp = "stamp",
+        });
+
+        var masterPasswordUnlockData = new MasterPasswordUnlockData
+        {
+            Kdf = new KdfSettings
+            {
+                KdfType = KdfType.PBKDF2_SHA256,
+                Iterations = KdfConstants.PBKDF2_ITERATIONS.Default,
+            },
+            MasterKeyWrappedUserKey = "wrapped-user-key",
+            Salt = email.ToLowerInvariant().Trim(),
+        };
+
+        // Act
+        await userRepository.SetV2AccountCryptographicStateAsync(user.Id, BuildV2AccountKeysData(),
+            [userRepository.SetMasterPassword(user.Id, masterPasswordUnlockData, "newHash", "hint")]);
+
+        // Assert
+        // Both halves of the transaction committed: the account keys and the delegate's write.
+        var updatedUser = await userRepository.GetByIdAsync(user.Id);
+        Assert.NotNull(updatedUser);
+        Assert.Equal("public-key", updatedUser.PublicKey);
+        Assert.Equal("newHash", updatedUser.MasterPassword);
+        Assert.Equal("hint", updatedUser.MasterPasswordHint);
+        Assert.Equal("wrapped-user-key", updatedUser.Key);
+    }
+
+    private static UserAccountKeysData BuildV2AccountKeysData() => new()
+    {
+        PublicKeyEncryptionKeyPairData = new PublicKeyEncryptionKeyPairData(
+            "wrapped-private-key",
+            "public-key",
+            "signed-public-key"),
+        SignatureKeyPairData = new SignatureKeyPairData(
+            SignatureAlgorithm.Ed25519,
+            "wrapped-signing-key",
+            "verifying-key"),
+        SecurityStateData = new SecurityStateData
+        {
+            SecurityState = "security-state",
+            SecurityVersion = 2
+        }
+    };
 
     private static async Task RunUpdateUserDataAsync(UpdateUserData task, Database database)
     {


### PR DESCRIPTION
When setting up a user, with entity framework we need to set the user-id as well. It doesn't make sense to make that part of the account cryptographic state sproc, so instead we compose sprocs within a transaction. This PR prevents multiple transactions from being opened in EF, similarly to Mssql.