### PR TITLE
[PM-39454] feat(km): expose the user key id on sync and add the backfill endpoint

### DIFF
--- a/src/Api/KeyManagement/Controllers/AccountsKeyManagementController.cs
+++ b/src/Api/KeyManagement/Controllers/AccountsKeyManagementController.cs
@@ -51,6 +51,7 @@ public class AccountsKeyManagementController : Controller
     private readonly IKeyRotationDataQuery _keyRotationDataQuery;
     private readonly ISetKeyConnectorKeyCommand _setKeyConnectorKeyCommand;
     private readonly IConvertUserToKeyConnectorCommand _convertUserToKeyConnectorCommand;
+    private readonly ISetUserKeyIdCommand _setUserKeyIdCommand;
 
     public AccountsKeyManagementController(IUserService userService,
         IOrganizationUserRepository organizationUserRepository,
@@ -70,7 +71,8 @@ public class AccountsKeyManagementController : Controller
             webAuthnKeyValidator,
         IRotationValidator<IEnumerable<OtherDeviceKeysUpdateRequestModel>, IEnumerable<Device>> deviceValidator,
         ISetKeyConnectorKeyCommand setKeyConnectorKeyCommand,
-        IConvertUserToKeyConnectorCommand convertUserToKeyConnectorCommand)
+        IConvertUserToKeyConnectorCommand convertUserToKeyConnectorCommand,
+        ISetUserKeyIdCommand setUserKeyIdCommand)
     {
         _userService = userService;
         _regenerateUserAsymmetricKeysCommand = regenerateUserAsymmetricKeysCommand;
@@ -88,6 +90,21 @@ public class AccountsKeyManagementController : Controller
         _keyRotationDataQuery = keyRotationDataQuery;
         _setKeyConnectorKeyCommand = setKeyConnectorKeyCommand;
         _convertUserToKeyConnectorCommand = convertUserToKeyConnectorCommand;
+        _setUserKeyIdCommand = setUserKeyIdCommand;
+    }
+
+    /// <summary>
+    /// Reports the key id of the caller's current user key to the server.
+    /// </summary>
+    /// <remarks>
+    /// This is meant for backfilling the user-key id for existing users for whom
+    /// the key id is not yet recorded.
+    /// </remarks>
+    [HttpPost("key-management/user-key-id")]
+    public async Task PostUserKeyIdAsync([FromBody] SetUserKeyIdRequestModel request)
+    {
+        var user = await _userService.GetUserByPrincipalAsync(User) ?? throw new UnauthorizedAccessException();
+        await _setUserKeyIdCommand.SetUserKeyIdAsync(user.Id, request.ToKeyId());
     }
 
     [HttpPost("key-management/regenerate-keys")]

--- a/src/Api/Vault/Models/Response/SyncResponseModel.cs
+++ b/src/Api/Vault/Models/Response/SyncResponseModel.cs
@@ -99,7 +99,8 @@ public class SyncResponseModel() : ResponseModel("sync")
                     WrappedUserKey1 = tokenData.WrappedUserKey1,
                     WrappedUserKey2 = tokenData.WrappedUserKey2
                 }
-                : null
+                : null,
+            UserKeyId = user.UserKeyId
         };
     }
 

--- a/src/Core/Auth/UserFeatures/UserMasterPassword/MasterPasswordService.cs
+++ b/src/Core/Auth/UserFeatures/UserMasterPassword/MasterPasswordService.cs
@@ -159,6 +159,7 @@ internal class MasterPasswordService(
         }
 
         user.Key = updateExistingData.MasterPasswordUnlock.MasterKeyWrappedUserKey;
+        updateExistingData.MasterPasswordUnlock.ValidateUserKeyUnchangedForUser(user);
 
         // Always override the master password hint, even if it's null
         user.MasterPasswordHint = updateExistingData.MasterPasswordHint;
@@ -195,6 +196,7 @@ internal class MasterPasswordService(
 
         user.Key = updateExistingData.MasterPasswordUnlock.MasterKeyWrappedUserKey;
         ApplyKdfStateOnUser(user, updateExistingData.MasterPasswordUnlock.Kdf);
+        updateExistingData.MasterPasswordUnlock.ValidateUserKeyUnchangedForUser(user);
 
         // Always override the master password hint, even if it's null
         user.MasterPasswordHint = updateExistingData.MasterPasswordHint;

--- a/src/Core/Auth/UserFeatures/UserMasterPassword/MasterPasswordService.cs
+++ b/src/Core/Auth/UserFeatures/UserMasterPassword/MasterPasswordService.cs
@@ -159,7 +159,6 @@ internal class MasterPasswordService(
         }
 
         user.Key = updateExistingData.MasterPasswordUnlock.MasterKeyWrappedUserKey;
-        updateExistingData.MasterPasswordUnlock.ValidateUserKeyUnchangedForUser(user);
 
         // Always override the master password hint, even if it's null
         user.MasterPasswordHint = updateExistingData.MasterPasswordHint;

--- a/src/Core/Auth/UserFeatures/UserMasterPassword/MasterPasswordService.cs
+++ b/src/Core/Auth/UserFeatures/UserMasterPassword/MasterPasswordService.cs
@@ -195,7 +195,7 @@ internal class MasterPasswordService(
 
         user.Key = updateExistingData.MasterPasswordUnlock.MasterKeyWrappedUserKey;
         ApplyKdfStateOnUser(user, updateExistingData.MasterPasswordUnlock.Kdf);
-        updateExistingData.MasterPasswordUnlock.ValidateUserKeyUnchangedForUser(user);
+        updateExistingData.MasterPasswordUnlock.ValidateUserKeyIdUnchangedForUser(user);
 
         // Always override the master password hint, even if it's null
         user.MasterPasswordHint = updateExistingData.MasterPasswordHint;

--- a/src/Core/KeyManagement/Commands/Interfaces/ISetUserKeyIdCommand.cs
+++ b/src/Core/KeyManagement/Commands/Interfaces/ISetUserKeyIdCommand.cs
@@ -1,0 +1,19 @@
+﻿namespace Bit.Core.KeyManagement.Commands.Interfaces;
+
+public interface ISetUserKeyIdCommand
+{
+    /// <summary>
+    /// Stores the hex-encoded key id of a user's current user key.
+    /// </summary>
+    /// <remarks>
+    /// This is a backfill primitive for accounts that pre-date the key id being reported alongside
+    /// key material. It therefore only accepts a value when the account does not already have one —
+    /// changing an existing key id must happen through a key rotation.
+    /// </remarks>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="userKeyId">Hex-encoded key id of the user's current user key.</param>
+    /// <exception cref="Bit.Core.Exceptions.BadRequestException">
+    /// Thrown when the account already has a key id.
+    /// </exception>
+    Task SetUserKeyIdAsync(Guid userId, Models.Data.KeyId userKeyId);
+}

--- a/src/Core/KeyManagement/Commands/SetUserKeyIdCommand.cs
+++ b/src/Core/KeyManagement/Commands/SetUserKeyIdCommand.cs
@@ -1,0 +1,26 @@
+﻿using Bit.Core.Exceptions;
+using Bit.Core.KeyManagement.Commands.Interfaces;
+using Bit.Core.Repositories;
+
+namespace Bit.Core.KeyManagement.Commands;
+
+public class SetUserKeyIdCommand : ISetUserKeyIdCommand
+{
+    private readonly IUserRepository _userRepository;
+
+    public SetUserKeyIdCommand(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task SetUserKeyIdAsync(Guid userId, Models.Data.KeyId userKeyId)
+    {
+        // The repository performs the "not already set" check and the write as one conditional
+        // statement, so two clients racing to backfill cannot both succeed.
+        var stored = await _userRepository.TrySetUserKeyIdAsync(userId, userKeyId);
+        if (!stored)
+        {
+            throw new BadRequestException("User key id is already set.");
+        }
+    }
+}

--- a/src/Core/KeyManagement/Kdf/Implementations/ChangeKdfCommand.cs
+++ b/src/Core/KeyManagement/Kdf/Implementations/ChangeKdfCommand.cs
@@ -47,9 +47,7 @@ public class ChangeKdfCommand : IChangeKdfCommand
         authenticationData.ValidateSaltUnchangedForUser(user);
         unlockData.ValidateSaltUnchangedForUser(user);
 
-        // A KDF change re-wraps the existing user key, it does not replace it, so its key id must not
-        // change. Also checked in the MasterPasswordService via
-        // UpdateExistingKdfConfigurationData.ValidateDataForUser.
+        // A KDF change re-wraps the existing user key, it does not replace it
         unlockData.ValidateUserKeyIdUnchangedForUser(user);
 
         // Currently KDF settings are not saved separately for authentication and unlock and must therefore be equal

--- a/src/Core/KeyManagement/KeyManagementServiceCollectionExtensions.cs
+++ b/src/Core/KeyManagement/KeyManagementServiceCollectionExtensions.cs
@@ -33,6 +33,7 @@ public static class KeyManagementServiceCollectionExtensions
         services.AddScoped<IChangeKdfCommand, ChangeKdfCommand>();
         services.AddScoped<ISetKeyConnectorKeyCommand, SetKeyConnectorKeyCommand>();
         services.AddScoped<IConvertUserToKeyConnectorCommand, ConvertUserToKeyConnectorCommand>();
+        services.AddScoped<ISetUserKeyIdCommand, SetUserKeyIdCommand>();
     }
 
     private static void AddKeyManagementQueries(this IServiceCollection services)

--- a/src/Core/KeyManagement/Models/Api/Response/UserDecryptionResponseModel.cs
+++ b/src/Core/KeyManagement/Models/Api/Response/UserDecryptionResponseModel.cs
@@ -21,4 +21,10 @@ public class UserDecryptionResponseModel
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public V2UpgradeTokenResponseModel? V2UpgradeToken { get; set; }
+
+    /// <summary>
+    /// Hex-encoded key id of the user's current user key, when the server knows it.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? UserKeyId { get; set; }
 }

--- a/test/Api.IntegrationTest/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
+++ b/test/Api.IntegrationTest/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
@@ -84,6 +84,70 @@ public class AccountsKeyManagementControllerTests : IClassFixture<ApiApplication
 
     [Theory]
     [BitAutoData]
+    public async Task PostUserKeyIdAsync_NotLoggedIn_Unauthorized(SetUserKeyIdRequestModel request)
+    {
+        var response = await _client.PostAsJsonAsync("/accounts/key-management/user-key-id", request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostUserKeyIdAsync_WhenUnset_BackfillsTheKeyId()
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+        var user = await _userRepository.GetByEmailAsync(_ownerEmail);
+        Assert.NotNull(user);
+        Assert.Null(user.UserKeyId);
+
+        const string userKeyId = "0123456789abcdef0123456789abcdef";
+        var response = await _client.PostAsJsonAsync("/accounts/key-management/user-key-id",
+            new SetUserKeyIdRequestModel { UserKeyId = userKeyId });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var updatedUser = await _userRepository.GetByEmailAsync(_ownerEmail);
+        Assert.NotNull(updatedUser);
+        Assert.Equal(userKeyId, updatedUser.UserKeyId);
+    }
+
+    [Fact]
+    public async Task PostUserKeyIdAsync_WhenAlreadySet_BadRequest()
+    {
+        // The backfill is only allowed to fill a gap. A second caller must not be able to rename the
+        // key the account is already known to use.
+        await _loginHelper.LoginAsync(_ownerEmail);
+        const string userKeyId = "0123456789abcdef0123456789abcdef";
+        var first = await _client.PostAsJsonAsync("/accounts/key-management/user-key-id",
+            new SetUserKeyIdRequestModel { UserKeyId = userKeyId });
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+
+        var response = await _client.PostAsJsonAsync("/accounts/key-management/user-key-id",
+            new SetUserKeyIdRequestModel { UserKeyId = "fedcba9876543210fedcba9876543210" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var updatedUser = await _userRepository.GetByEmailAsync(_ownerEmail);
+        Assert.NotNull(updatedUser);
+        Assert.Equal(userKeyId, updatedUser.UserKeyId);
+    }
+
+    [Theory]
+    [BitAutoData("not-hex")]
+    [BitAutoData("0123456789ABCDEF0123456789ABCDEF")]
+    [BitAutoData("")]
+    public async Task PostUserKeyIdAsync_MalformedKeyId_BadRequest(string userKeyId)
+    {
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.PostAsJsonAsync("/accounts/key-management/user-key-id",
+            new SetUserKeyIdRequestModel { UserKeyId = userKeyId });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var updatedUser = await _userRepository.GetByEmailAsync(_ownerEmail);
+        Assert.NotNull(updatedUser);
+        Assert.Null(updatedUser.UserKeyId);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task RegenerateKeysAsync_NotLoggedIn_Unauthorized(KeyRegenerationRequestModel request)
     {
         request.UserKeyEncryptedUserPrivateKey = _mockEncryptedString;

--- a/test/Api.Test/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
+++ b/test/Api.Test/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
@@ -32,6 +32,7 @@ using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Microsoft.AspNetCore.Identity;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using NSubstitute.ReturnsExtensions;
 using Xunit;
 
@@ -47,6 +48,53 @@ public class AccountsKeyManagementControllerTests
         "2.AOs41Hd8OQiCPXjyJKCiDA==|O6OHgt2U2hJGBSNGnimJmg==|iD33s8B69C8JhYYhSa4V1tArjvLr8eEaGqOV7BRo5Jk=";
     private static readonly string _mockEncryptedType7String = "7.AOs41Hd8OQiCPXjyJKCiDA==";
 
+
+    [Theory]
+    [BitAutoData]
+    public async Task PostUserKeyIdAsync_UserNull_Throws(
+        SutProvider<AccountsKeyManagementController> sutProvider,
+        SetUserKeyIdRequestModel data)
+    {
+        sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).ReturnsNull();
+
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => sutProvider.Sut.PostUserKeyIdAsync(data));
+
+        await sutProvider.GetDependency<ISetUserKeyIdCommand>().ReceivedWithAnyArgs(0)
+            .SetUserKeyIdAsync(Arg.Any<Guid>(), Arg.Any<KeyId>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task PostUserKeyIdAsync_Success_PassesKeyIdToCommand(
+        SutProvider<AccountsKeyManagementController> sutProvider,
+        User user)
+    {
+        const string userKeyId = "0123456789abcdef0123456789abcdef";
+        var data = new SetUserKeyIdRequestModel { UserKeyId = userKeyId };
+        sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+
+        await sutProvider.Sut.PostUserKeyIdAsync(data);
+
+        await sutProvider.GetDependency<ISetUserKeyIdCommand>().Received(1)
+            .SetUserKeyIdAsync(Arg.Is(user.Id),
+                Arg.Is<KeyId>(k => k == KeyId.FromHexEncodedString(userKeyId)));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task PostUserKeyIdAsync_KeyIdAlreadySet_PropagatesBadRequest(
+        SutProvider<AccountsKeyManagementController> sutProvider,
+        User user)
+    {
+        const string userKeyId = "0123456789abcdef0123456789abcdef";
+        var data = new SetUserKeyIdRequestModel { UserKeyId = userKeyId };
+        sutProvider.GetDependency<IUserService>().GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        sutProvider.GetDependency<ISetUserKeyIdCommand>()
+            .SetUserKeyIdAsync(Arg.Is(user.Id), Arg.Any<KeyId>())
+            .ThrowsAsync(new BadRequestException("User key id is already set."));
+
+        await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.PostUserKeyIdAsync(data));
+    }
 
     [Theory]
     [BitAutoData]

--- a/test/Core.Test/KeyManagement/Commands/SetUserKeyIdCommandTests.cs
+++ b/test/Core.Test/KeyManagement/Commands/SetUserKeyIdCommandTests.cs
@@ -1,0 +1,48 @@
+﻿using Bit.Core.Exceptions;
+using Bit.Core.KeyManagement.Commands;
+using Bit.Core.KeyManagement.Models.Data;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.KeyManagement.Commands;
+
+[SutProviderCustomize]
+public class SetUserKeyIdCommandTests
+{
+    private static readonly KeyId _userKeyId =
+        KeyId.FromHexEncodedString("0123456789abcdef0123456789abcdef");
+
+    [Theory, BitAutoData]
+    public async Task SetUserKeyIdAsync_WhenNoKeyIdStored_StoresIt(
+        Guid userId,
+        SutProvider<SetUserKeyIdCommand> sutProvider)
+    {
+        sutProvider.GetDependency<IUserRepository>()
+            .TrySetUserKeyIdAsync(userId, _userKeyId)
+            .Returns(true);
+
+        await sutProvider.Sut.SetUserKeyIdAsync(userId, _userKeyId);
+
+        await sutProvider.GetDependency<IUserRepository>()
+            .Received(1)
+            .TrySetUserKeyIdAsync(userId, _userKeyId);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SetUserKeyIdAsync_WhenKeyIdAlreadyStored_ThrowsBadRequest(
+        Guid userId,
+        SutProvider<SetUserKeyIdCommand> sutProvider)
+    {
+        sutProvider.GetDependency<IUserRepository>()
+            .TrySetUserKeyIdAsync(userId, _userKeyId)
+            .Returns(false);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.SetUserKeyIdAsync(userId, _userKeyId));
+
+        Assert.Equal("User key id is already set.", exception.Message);
+    }
+}

--- a/test/Core.Test/KeyManagement/Models/Data/MasterPasswordUnlockDataTests.cs
+++ b/test/Core.Test/KeyManagement/Models/Data/MasterPasswordUnlockDataTests.cs
@@ -8,99 +8,58 @@ namespace Bit.Core.Test.KeyManagement.Models.Data;
 
 public class MasterPasswordUnlockDataTests
 {
-    private const string StoredKeyId = "0123456789abcdef0123456789abcdef";
-    private const string DifferentKeyId = "fedcba9876543210fedcba9876543210";
+    private const string _keyIdA = "0123456789abcdef0123456789abcdef";
+    private const string _keyIdB = "fedcba9876543210fedcba9876543210";
 
-    private static User BuildUser(string? storedUserKeyId) => new()
+    private static MasterPasswordUnlockData MakeData(string? userKeyId) => new()
+    {
+        Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600000 },
+        MasterKeyWrappedUserKey = "wrapped-user-key",
+        Salt = "test@example.com",
+        UserKeyId = KeyId.FromHexEncodedString(userKeyId)
+    };
+
+    private static User MakeUser(string? userKeyId) => new()
     {
         Id = Guid.NewGuid(),
         Email = "test@example.com",
-        Kdf = KdfType.PBKDF2_SHA256,
-        KdfIterations = 600000,
-        UserKeyId = storedUserKeyId
-    };
-
-    private static MasterPasswordUnlockData BuildUnlockData(string? suppliedUserKeyId) => new()
-    {
-        Salt = "test@example.com",
-        MasterKeyWrappedUserKey = "wrapped-key",
-        Kdf = new KdfSettings { KdfType = KdfType.PBKDF2_SHA256, Iterations = 600000 },
-        UserKeyId = KeyId.FromHexEncodedString(suppliedUserKeyId)
+        UserKeyId = userKeyId
     };
 
     [Fact]
-    public void ValidateUserKeyIdUnchangedForUser_Accepts_WhenNeitherSideHasAKeyId()
+    public void ValidateUserKeyUnchangedForUser_WhenKeyIdsMatch_DoesNotThrow()
     {
-        var user = BuildUser(null);
-
-        BuildUnlockData(null).ValidateUserKeyIdUnchangedForUser(user);
+        MakeData(_keyIdA).ValidateUserKeyIdUnchangedForUser(MakeUser(_keyIdA));
     }
 
     [Fact]
-    public void ValidateUserKeyIdUnchangedForUser_Accepts_WhenAccountHasNoKeyId()
+    public void ValidateUserKeyUnchangedForUser_WhenKeyIdsDiffer_Throws()
     {
-        // Nothing to disagree with. The supplied id is not recorded here either — backfilling a
-        // legacy account belongs to TrySetUserKeyIdAsync, not to a password flow.
-        var user = BuildUser(null);
-
-        BuildUnlockData(DifferentKeyId).ValidateUserKeyIdUnchangedForUser(user);
-
-        Assert.Null(user.UserKeyId);
-    }
-
-    [Fact]
-    public void ValidateUserKeyIdUnchangedForUser_Accepts_WhenClientSuppliesNoKeyId()
-    {
-        // Clients predating the field send none; they must not be locked out of password changes.
-        var user = BuildUser(StoredKeyId);
-
-        BuildUnlockData(null).ValidateUserKeyIdUnchangedForUser(user);
-    }
-
-    [Fact]
-    public void ValidateUserKeyIdUnchangedForUser_Accepts_WhenKeyIdsAgree()
-    {
-        var user = BuildUser(StoredKeyId);
-
-        BuildUnlockData(StoredKeyId).ValidateUserKeyIdUnchangedForUser(user);
-    }
-
-    [Fact]
-    public void ValidateUserKeyIdUnchangedForUser_Throws_WhenKeyIdsDisagree()
-    {
-        var user = BuildUser(StoredKeyId);
-
         var exception = Assert.Throws<BadRequestException>(
-            () => BuildUnlockData(DifferentKeyId).ValidateUserKeyIdUnchangedForUser(user));
+            () => MakeData(_keyIdB).ValidateUserKeyIdUnchangedForUser(MakeUser(_keyIdA)));
 
         Assert.Equal("Invalid user key id.", exception.Message);
     }
 
     [Fact]
-    public void ValidateUserKeyIdUnchangedForUser_Accepts_WhenStoredKeyIdIsEmptyString()
+    public void ValidateUserKeyUnchangedForUser_WhenServerHasNoKeyId_DoesNotThrow()
     {
-        // An empty column value is treated as unset rather than as a malformed key id, so a legacy
-        // row does not fail every password change.
-        var user = BuildUser(string.Empty);
-
-        BuildUnlockData(DifferentKeyId).ValidateUserKeyIdUnchangedForUser(user);
+        // Backfill case: nothing to compare against yet.
+        MakeData(_keyIdA).ValidateUserKeyIdUnchangedForUser(MakeUser(null));
     }
 
     [Fact]
-    public void ValidateUserKeyIdUnchangedForUser_DoesNotMutateTheUser()
+    public void ValidateUserKeyUnchangedForUser_WhenRequestOmitsKeyId_DoesNotThrow()
     {
-        var user = BuildUser(StoredKeyId);
-
-        BuildUnlockData(StoredKeyId).ValidateUserKeyIdUnchangedForUser(user);
-
-        Assert.Equal(StoredKeyId, user.UserKeyId);
+        // Clients that predate the field must keep working.
+        MakeData(null).ValidateUserKeyIdUnchangedForUser(MakeUser(_keyIdA));
     }
 
     [Fact]
     public void Equals_ComparesKeyIdByValue()
     {
-        Assert.Equal(BuildUnlockData(StoredKeyId), BuildUnlockData(StoredKeyId));
-        Assert.NotEqual(BuildUnlockData(StoredKeyId), BuildUnlockData(DifferentKeyId));
-        Assert.NotEqual(BuildUnlockData(StoredKeyId), BuildUnlockData(null));
+        Assert.Equal(MakeData(_keyIdA), MakeData(_keyIdA));
+        Assert.NotEqual(MakeData(_keyIdA), MakeData(_keyIdB));
+        Assert.NotEqual(MakeData(_keyIdA), MakeData(null));
     }
 }


### PR DESCRIPTION
Add the user id on sync in the user decryption options, and add the endpoint for back-filling it for v1 users.