### PR TITLE
[PM-41268] Declare the PartialData cipher response field

### DIFF
--- a/src/Api/Vault/Models/Response/CipherResponseModel.cs
+++ b/src/Api/Vault/Models/Response/CipherResponseModel.cs
@@ -1,6 +1,7 @@
 ﻿
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Bit.Core.Entities;
 using Bit.Core.Models.Api;
 using Bit.Core.Models.Data.Organizations;
@@ -97,6 +98,19 @@ public class CipherMiniResponseModel : ResponseModel
     public Guid? OrganizationId { get; set; }
     public CipherType Type { get; set; }
     public string Data { get; set; }
+
+    /// <summary>
+    /// The reduced data blob returned in place of <see cref="Data"/> when the caller can only reach this
+    /// cipher through leasing-enabled collections (PAM credential leasing). Contains the encrypted title
+    /// and, for logins, the encrypted URIs — never the dropped secrets. Null for full responses.
+    /// </summary>
+    /// <remarks>
+    /// Declared ahead of the behavior that populates it, so the wire contract and the generated client
+    /// bindings exist first. Nothing sets it yet: every response is still full, and because the property
+    /// is omitted when null the serialized output is unchanged.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string PartialData { get; set; }
 
     [Obsolete("Use Data instead.")]
     public string Name { get; set; }

--- a/test/Api.Test/Vault/Models/Response/CipherResponseModelTests.cs
+++ b/test/Api.Test/Vault/Models/Response/CipherResponseModelTests.cs
@@ -308,4 +308,42 @@ public class CipherResponseModelTests
         Assert.Null(response.Fields);
         Assert.Null(response.PasswordHistory);
     }
+
+    [Fact]
+    public void Constructor_DoesNotSetPartialData()
+    {
+        var cipher = new Cipher
+        {
+            Id = Guid.NewGuid(),
+            Type = CipherType.Login,
+            Data = JsonSerializer.Serialize(new CipherLoginData { Name = "2.name|encrypted" }),
+            RevisionDate = DateTime.UtcNow,
+            CreationDate = DateTime.UtcNow,
+        };
+
+        var response = new CipherMiniResponseModel(cipher, _globalSettings, false);
+
+        // PartialData is the declared wire contract for PAM credential leasing; nothing populates it
+        // yet, so every response is still full.
+        Assert.Null(response.PartialData);
+        Assert.Equal(cipher.Data, response.Data);
+    }
+
+    [Fact]
+    public void Serialize_NullPartialData_OmitsTheProperty()
+    {
+        var cipher = new Cipher
+        {
+            Id = Guid.NewGuid(),
+            Type = CipherType.Login,
+            Data = JsonSerializer.Serialize(new CipherLoginData { Name = "2.name|encrypted" }),
+            RevisionDate = DateTime.UtcNow,
+            CreationDate = DateTime.UtcNow,
+        };
+
+        var json = JsonSerializer.Serialize(new CipherMiniResponseModel(cipher, _globalSettings, false));
+
+        // Null-suppressed, so adding the property leaves existing responses byte-identical.
+        Assert.DoesNotContain("partialData", json, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41268

Contract-only precursor to #8115.

## 📔 Objective

Adds a `PartialData` property to `CipherMiniResponseModel`, the base all four cipher
response types derive from, so the field appears on each of them in the generated
OpenAPI spec.

Under PAM credential leasing the server withholds a gated cipher's secret `Data` blob
and returns a reduced blob instead — the encrypted title plus, for logins, the
encrypted URIs. Its presence is the client-side signal that the cipher is gated.

**Contract only.** Nothing populates it yet, and because the property is
null-suppressed the serialized output is unchanged. Landing the declaration first lets
the client bindings be generated ahead of the behavior — the same approach as #8105,
where the cipher-lease endpoints were scaffolded to lock their contract first.

The behavior that populates it is #8115.

## 🚨 Breaking Changes

None — a new, null-suppressed, additive response field.
