### PR TITLE
[PM-40694] fix: Derive Stripe tax ID type server-side

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Billing/Providers/Services/ProviderBillingService.cs
+++ b/bitwarden_license/src/Commercial.Core/Billing/Providers/Services/ProviderBillingService.cs
@@ -18,6 +18,7 @@ using Bit.Core.Billing.Providers.Models;
 using Bit.Core.Billing.Providers.Repositories;
 using Bit.Core.Billing.Providers.Services;
 using Bit.Core.Billing.Services;
+using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
@@ -48,7 +49,8 @@ public class ProviderBillingService(
     IProviderPlanRepository providerPlanRepository,
     IProviderUserRepository providerUserRepository,
     IStripeAdapter stripeAdapter,
-    ISubscriberService subscriberService)
+    ISubscriberService subscriberService,
+    ITaxService taxService)
     : IProviderBillingService
 {
     public async Task AddExistingOrganization(
@@ -507,12 +509,23 @@ public class ProviderBillingService(
 
         if (billingAddress.TaxId != null)
         {
+            var derivedTaxIdCode = taxService.GetStripeTaxCode(billingAddress.Country, billingAddress.TaxId.Value);
+
+            if (derivedTaxIdCode == null)
+            {
+                logger.LogWarning(
+                    "Could not derive Stripe tax ID type for country {Country}; falling back to client-supplied type {TaxIdType}",
+                    billingAddress.Country, billingAddress.TaxId.Code);
+            }
+
+            var taxIdCode = derivedTaxIdCode ?? billingAddress.TaxId.Code;
+
             options.TaxIdData =
             [
-                new CustomerTaxIdDataOptions { Type = billingAddress.TaxId.Code, Value = billingAddress.TaxId.Value }
+                new CustomerTaxIdDataOptions { Type = taxIdCode, Value = billingAddress.TaxId.Value }
             ];
 
-            if (billingAddress.TaxId.Code == TaxIdType.SpanishNIF)
+            if (taxIdCode == TaxIdType.SpanishNIF)
             {
                 options.TaxIdData.Add(new CustomerTaxIdDataOptions
                 {

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Providers/Services/ProviderBillingServiceTests.cs
@@ -15,6 +15,7 @@ using Bit.Core.Billing.Providers.Models;
 using Bit.Core.Billing.Providers.Repositories;
 using Bit.Core.Billing.Providers.Services;
 using Bit.Core.Billing.Services;
+using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Exceptions;
@@ -26,6 +27,7 @@ using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Braintree;
 using CsvHelper;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Stripe;
@@ -863,8 +865,10 @@ public class ProviderBillingServiceTests
         BillingAddress billingAddress)
     {
         provider.Name = "MSP";
-        billingAddress.Country = "AD";
-        billingAddress.TaxId = new TaxID("es_nif", "12345678Z");
+        billingAddress.Country = "GB";
+        billingAddress.TaxId = new TaxID(StripeConstants.TaxIdType.EUVAT, "GB123456789");
+
+        sutProvider.GetDependency<ITaxService>().GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         var tokenizedPaymentMethod = new TokenizedPaymentMethod { Type = TokenizablePaymentMethodType.BankAccount, Token = "token" };
@@ -886,7 +890,7 @@ public class ProviderBillingServiceTests
                 o.InvoiceSettings.CustomFields.FirstOrDefault().Name == provider.SubscriberType() &&
                 o.InvoiceSettings.CustomFields.FirstOrDefault().Value == provider.DisplayName() &&
                 o.Metadata["region"] == "" &&
-                o.TaxIdData.FirstOrDefault().Type == billingAddress.TaxId.Code &&
+                o.TaxIdData.FirstOrDefault().Type == "gb_vat" &&
                 o.TaxIdData.FirstOrDefault().Value == billingAddress.TaxId.Value))
             .Throws<StripeException>();
 
@@ -904,8 +908,10 @@ public class ProviderBillingServiceTests
         BillingAddress billingAddress)
     {
         provider.Name = "MSP";
-        billingAddress.Country = "AD";
-        billingAddress.TaxId = new TaxID("es_nif", "12345678Z");
+        billingAddress.Country = "GB";
+        billingAddress.TaxId = new TaxID(StripeConstants.TaxIdType.EUVAT, "GB123456789");
+
+        sutProvider.GetDependency<ITaxService>().GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
         var tokenizedPaymentMethod = new TokenizedPaymentMethod { Type = TokenizablePaymentMethodType.PayPal, Token = "token" };
@@ -926,7 +932,7 @@ public class ProviderBillingServiceTests
                 o.InvoiceSettings.CustomFields.FirstOrDefault().Value == provider.DisplayName() &&
                 o.Metadata["region"] == "" &&
                 o.Metadata["btCustomerId"] == "braintree_customer_id" &&
-                o.TaxIdData.FirstOrDefault().Type == billingAddress.TaxId.Code &&
+                o.TaxIdData.FirstOrDefault().Type == "gb_vat" &&
                 o.TaxIdData.FirstOrDefault().Value == billingAddress.TaxId.Value))
             .Throws<StripeException>();
 
@@ -943,8 +949,10 @@ public class ProviderBillingServiceTests
         BillingAddress billingAddress)
     {
         provider.Name = "MSP";
-        billingAddress.Country = "AD";
-        billingAddress.TaxId = new TaxID("es_nif", "12345678Z");
+        billingAddress.Country = "GB";
+        billingAddress.TaxId = new TaxID(StripeConstants.TaxIdType.EUVAT, "GB123456789");
+
+        sutProvider.GetDependency<ITaxService>().GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
 
@@ -973,7 +981,7 @@ public class ProviderBillingServiceTests
                 o.InvoiceSettings.CustomFields.FirstOrDefault().Name == provider.SubscriberType() &&
                 o.InvoiceSettings.CustomFields.FirstOrDefault().Value == provider.DisplayName() &&
                 o.Metadata["region"] == "" &&
-                o.TaxIdData.FirstOrDefault().Type == billingAddress.TaxId.Code &&
+                o.TaxIdData.FirstOrDefault().Type == "gb_vat" &&
                 o.TaxIdData.FirstOrDefault().Value == billingAddress.TaxId.Value))
             .Returns(expected);
 
@@ -992,8 +1000,10 @@ public class ProviderBillingServiceTests
         BillingAddress billingAddress)
     {
         provider.Name = "MSP";
-        billingAddress.Country = "AD";
-        billingAddress.TaxId = new TaxID("es_nif", "12345678Z");
+        billingAddress.Country = "GB";
+        billingAddress.TaxId = new TaxID(StripeConstants.TaxIdType.EUVAT, "GB123456789");
+
+        sutProvider.GetDependency<ITaxService>().GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
 
@@ -1021,7 +1031,7 @@ public class ProviderBillingServiceTests
                 o.InvoiceSettings.CustomFields.FirstOrDefault().Value == provider.DisplayName() &&
                 o.Metadata["region"] == "" &&
                 o.Metadata["btCustomerId"] == "braintree_customer_id" &&
-                o.TaxIdData.FirstOrDefault().Type == billingAddress.TaxId.Code &&
+                o.TaxIdData.FirstOrDefault().Type == "gb_vat" &&
                 o.TaxIdData.FirstOrDefault().Value == billingAddress.TaxId.Value))
             .Returns(expected);
 
@@ -1037,8 +1047,10 @@ public class ProviderBillingServiceTests
         BillingAddress billingAddress)
     {
         provider.Name = "MSP";
-        billingAddress.Country = "AD";
-        billingAddress.TaxId = new TaxID("es_nif", "12345678Z");
+        billingAddress.Country = "GB";
+        billingAddress.TaxId = new TaxID(StripeConstants.TaxIdType.EUVAT, "GB123456789");
+
+        sutProvider.GetDependency<ITaxService>().GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
 
         var stripeAdapter = sutProvider.GetDependency<IStripeAdapter>();
 
@@ -1063,7 +1075,7 @@ public class ProviderBillingServiceTests
                 o.InvoiceSettings.CustomFields.FirstOrDefault().Name == provider.SubscriberType() &&
                 o.InvoiceSettings.CustomFields.FirstOrDefault().Value == provider.DisplayName() &&
                 o.Metadata["region"] == "" &&
-                o.TaxIdData.FirstOrDefault().Type == billingAddress.TaxId.Code &&
+                o.TaxIdData.FirstOrDefault().Type == "gb_vat" &&
                 o.TaxIdData.FirstOrDefault().Value == billingAddress.TaxId.Value))
             .Returns(expected);
 
@@ -1119,6 +1131,97 @@ public class ProviderBillingServiceTests
                 options.TaxExempt == null));
 
         Assert.Equivalent(expected, actual);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SetupCustomer_NorthernIrelandTaxId_UsesEUVAT(
+        SutProvider<ProviderBillingService> sutProvider,
+        Provider provider,
+        BillingAddress billingAddress)
+    {
+        provider.Name = "MSP";
+        billingAddress.Country = "GB";
+        billingAddress.TaxId = new TaxID("gb_vat", "XI123456789");
+
+        sutProvider.GetDependency<ITaxService>().GetStripeTaxCode("GB", "XI123456789")
+            .Returns(StripeConstants.TaxIdType.EUVAT);
+
+        var tokenizedPaymentMethod = new TokenizedPaymentMethod { Type = TokenizablePaymentMethodType.Card, Token = "token" };
+
+        sutProvider.GetDependency<IStripeAdapter>().CreateCustomerAsync(Arg.Any<CustomerCreateOptions>())
+            .Returns(new Customer { Id = "customer_id" });
+
+        await sutProvider.Sut.SetupCustomer(provider, tokenizedPaymentMethod, billingAddress);
+
+        await sutProvider.GetDependency<IStripeAdapter>().Received(1).CreateCustomerAsync(
+            Arg.Is<CustomerCreateOptions>(options =>
+                options.TaxIdData.Count == 1 &&
+                options.TaxIdData[0].Type == StripeConstants.TaxIdType.EUVAT &&
+                options.TaxIdData[0].Value == "XI123456789"));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SetupCustomer_SpanishCIFSentAsEUVAT_AddsBothSpanishNIFAndEUVAT(
+        SutProvider<ProviderBillingService> sutProvider,
+        Provider provider,
+        BillingAddress billingAddress)
+    {
+        provider.Name = "MSP";
+        billingAddress.Country = "ES";
+        billingAddress.TaxId = new TaxID(StripeConstants.TaxIdType.EUVAT, "A12345678");
+
+        sutProvider.GetDependency<ITaxService>().GetStripeTaxCode("ES", "A12345678")
+            .Returns(StripeConstants.TaxIdType.SpanishNIF);
+
+        var tokenizedPaymentMethod = new TokenizedPaymentMethod { Type = TokenizablePaymentMethodType.Card, Token = "token" };
+
+        sutProvider.GetDependency<IStripeAdapter>().CreateCustomerAsync(Arg.Any<CustomerCreateOptions>())
+            .Returns(new Customer { Id = "customer_id" });
+
+        await sutProvider.Sut.SetupCustomer(provider, tokenizedPaymentMethod, billingAddress);
+
+        await sutProvider.GetDependency<IStripeAdapter>().Received(1).CreateCustomerAsync(
+            Arg.Is<CustomerCreateOptions>(options =>
+                options.TaxIdData.Count == 2 &&
+                options.TaxIdData.Any(taxId =>
+                    taxId.Type == StripeConstants.TaxIdType.SpanishNIF && taxId.Value == "A12345678") &&
+                options.TaxIdData.Any(taxId =>
+                    taxId.Type == StripeConstants.TaxIdType.EUVAT && taxId.Value == "ESA12345678")));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SetupCustomer_UnderivableTaxId_FallsBackToClientCodeAndWarns(
+        SutProvider<ProviderBillingService> sutProvider,
+        Provider provider,
+        BillingAddress billingAddress)
+    {
+        provider.Name = "MSP";
+        billingAddress.Country = "MK";
+        billingAddress.TaxId = new TaxID(StripeConstants.TaxIdType.EUVAT, "MK1234567890123");
+
+        sutProvider.GetDependency<ITaxService>().GetStripeTaxCode("MK", "MK1234567890123").Returns((string?)null);
+
+        var tokenizedPaymentMethod = new TokenizedPaymentMethod { Type = TokenizablePaymentMethodType.Card, Token = "token" };
+
+        sutProvider.GetDependency<IStripeAdapter>().CreateCustomerAsync(Arg.Any<CustomerCreateOptions>())
+            .Returns(new Customer { Id = "customer_id" });
+
+        await sutProvider.Sut.SetupCustomer(provider, tokenizedPaymentMethod, billingAddress);
+
+        await sutProvider.GetDependency<IStripeAdapter>().Received(1).CreateCustomerAsync(
+            Arg.Is<CustomerCreateOptions>(options =>
+                options.TaxIdData.Count == 1 &&
+                options.TaxIdData[0].Type == StripeConstants.TaxIdType.EUVAT &&
+                options.TaxIdData[0].Value == "MK1234567890123"));
+
+        sutProvider.GetDependency<ILogger<ProviderBillingService>>().Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => state.ToString()!.Contains("MK") &&
+                                    state.ToString()!.Contains(StripeConstants.TaxIdType.EUVAT) &&
+                                    !state.ToString()!.Contains("MK1234567890123")),
+            null,
+            Arg.Any<Func<object, Exception?, string>>());
     }
 
     #endregion

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Tax/TaxServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Tax/TaxServiceTests.cs
@@ -148,4 +148,17 @@ public class TaxServiceTests
 
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [BitAutoData("MK", "MK1234567890123")]
+    [BitAutoData("GB", "123456789")]
+    public void GetStripeTaxCode_WithUnsupportedCountryOrNonMatchingTaxId_ReturnsNull(
+        string country,
+        string taxId,
+        SutProvider<TaxService> sutProvider)
+    {
+        var result = sutProvider.Sut.GetStripeTaxCode(country, taxId);
+
+        Assert.Null(result);
+    }
 }

--- a/bitwarden_license/test/Commercial.Core.Test/Billing/Tax/TaxServiceTests.cs
+++ b/bitwarden_license/test/Commercial.Core.Test/Billing/Tax/TaxServiceTests.cs
@@ -131,6 +131,7 @@ public class TaxServiceTests
     [BitAutoData("AE", "123456789012345", "ae_trn")]
     [BitAutoData("GB", "XI123456789", "eu_vat")]
     [BitAutoData("GB", "GB123456789", "gb_vat")]
+    [BitAutoData("GB", "123456789", "gb_vat")]
     [BitAutoData("US", "12-3456789", "us_ein")]
     [BitAutoData("UY", "123456789012", "uy_ruc")]
     [BitAutoData("UZ", "123456789", "uz_tin")]
@@ -151,7 +152,7 @@ public class TaxServiceTests
 
     [Theory]
     [BitAutoData("MK", "MK1234567890123")]
-    [BitAutoData("GB", "123456789")]
+    [BitAutoData("GB", "12345678")]
     public void GetStripeTaxCode_WithUnsupportedCountryOrNonMatchingTaxId_ReturnsNull(
         string country,
         string taxId,

--- a/src/Core/Billing/Organizations/Commands/PreviewOrganizationTaxCommand.cs
+++ b/src/Core/Billing/Organizations/Commands/PreviewOrganizationTaxCommand.cs
@@ -8,6 +8,7 @@ using Bit.Core.Billing.Organizations.Models;
 using Bit.Core.Billing.Payment.Models;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Services;
+using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Microsoft.Extensions.Logging;
@@ -39,7 +40,8 @@ public class PreviewOrganizationTaxCommand(
     ILogger<PreviewOrganizationTaxCommand> logger,
     IPricingClient pricingClient,
     IStripeAdapter stripeAdapter,
-    ISubscriptionDiscountService subscriptionDiscountService)
+    ISubscriptionDiscountService subscriptionDiscountService,
+    ITaxService taxService)
     : BaseBillingCommand<PreviewOrganizationTaxCommand>(logger), IPreviewOrganizationTaxCommand
 {
     private readonly ILogger<PreviewOrganizationTaxCommand> _logger = logger;
@@ -454,12 +456,23 @@ public class PreviewOrganizationTaxCommand(
             return options;
         }
 
+        var derivedTaxIdCode = taxService.GetStripeTaxCode(country, taxId.Value);
+
+        if (derivedTaxIdCode == null)
+        {
+            _logger.LogWarning(
+                "Could not derive Stripe tax ID type for country {Country}; falling back to client-supplied type {TaxIdType}",
+                country, taxId.Code);
+        }
+
+        var taxIdCode = derivedTaxIdCode ?? taxId.Code;
+
         options.CustomerDetails.TaxIds =
         [
-            new InvoiceCustomerDetailsTaxIdOptions { Type = taxId.Code, Value = taxId.Value }
+            new InvoiceCustomerDetailsTaxIdOptions { Type = taxIdCode, Value = taxId.Value }
         ];
 
-        if (taxId.Code == TaxIdType.SpanishNIF)
+        if (taxIdCode == TaxIdType.SpanishNIF)
         {
             options.CustomerDetails.TaxIds.Add(new InvoiceCustomerDetailsTaxIdOptions
             {

--- a/src/Core/Billing/Payment/Commands/UpdateBillingAddressCommand.cs
+++ b/src/Core/Billing/Payment/Commands/UpdateBillingAddressCommand.cs
@@ -3,6 +3,7 @@ using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Extensions;
 using Bit.Core.Billing.Payment.Models;
 using Bit.Core.Billing.Services;
+using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Entities;
 using Microsoft.Extensions.Logging;
 using Stripe;
@@ -19,8 +20,11 @@ public interface IUpdateBillingAddressCommand
 public class UpdateBillingAddressCommand(
     ILogger<UpdateBillingAddressCommand> logger,
     ISubscriberService subscriberService,
-    IStripeAdapter stripeAdapter) : BaseBillingCommand<UpdateBillingAddressCommand>(logger), IUpdateBillingAddressCommand
+    IStripeAdapter stripeAdapter,
+    ITaxService taxService) : BaseBillingCommand<UpdateBillingAddressCommand>(logger), IUpdateBillingAddressCommand
 {
+    private readonly ILogger<UpdateBillingAddressCommand> _logger = logger;
+
     protected override Conflict DefaultConflict =>
         new("We had a problem updating your billing address. Please contact support for assistance.");
 
@@ -97,10 +101,21 @@ public class UpdateBillingAddressCommand(
             return BillingAddress.From(customer.Address);
         }
 
-        var updatedTaxId = await stripeAdapter.CreateTaxIdAsync(customer.Id,
-            new TaxIdCreateOptions { Type = billingAddress.TaxId.Code, Value = billingAddress.TaxId.Value });
+        var derivedTaxIdCode = taxService.GetStripeTaxCode(billingAddress.Country, billingAddress.TaxId.Value);
 
-        if (billingAddress.TaxId.Code == StripeConstants.TaxIdType.SpanishNIF)
+        if (derivedTaxIdCode == null)
+        {
+            _logger.LogWarning(
+                "Could not derive Stripe tax ID type for country {Country}; falling back to client-supplied type {TaxIdType}",
+                billingAddress.Country, billingAddress.TaxId.Code);
+        }
+
+        var taxIdCode = derivedTaxIdCode ?? billingAddress.TaxId.Code;
+
+        var updatedTaxId = await stripeAdapter.CreateTaxIdAsync(customer.Id,
+            new TaxIdCreateOptions { Type = taxIdCode, Value = billingAddress.TaxId.Value });
+
+        if (taxIdCode == StripeConstants.TaxIdType.SpanishNIF)
         {
             updatedTaxId = await stripeAdapter.CreateTaxIdAsync(customer.Id,
                 new TaxIdCreateOptions

--- a/src/Core/Billing/Premium/Commands/UpgradePremiumToOrganizationCommand.cs
+++ b/src/Core/Billing/Premium/Commands/UpgradePremiumToOrganizationCommand.cs
@@ -8,6 +8,7 @@ using Bit.Core.Billing.Payment.Queries;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Services;
 using Bit.Core.Billing.Subscriptions.Models;
+using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
@@ -65,7 +66,8 @@ public class UpgradePremiumToOrganizationCommand(
     IBraintreeService braintreeService,
     IGetPaymentMethodQuery getPaymentMethodQuery,
     IOrganizationAbilityCacheService organizationAbilityCacheService,
-    IPushNotificationService pushNotificationService)
+    IPushNotificationService pushNotificationService,
+    ITaxService taxService)
     : BaseBillingCommand<UpgradePremiumToOrganizationCommand>(logger), IUpgradePremiumToOrganizationCommand
 {
     private readonly ILogger<UpgradePremiumToOrganizationCommand> _logger = logger;
@@ -142,7 +144,7 @@ public class UpgradePremiumToOrganizationCommand(
         // Add tax ID to the customer for accurate tax calculation if provided
         if (billingAddress.TaxId != null)
         {
-            await AddTaxIdToCustomerAsync(user.GatewayCustomerId!, billingAddress.TaxId);
+            await AddTaxIdToCustomerAsync(user.GatewayCustomerId!, billingAddress.Country, billingAddress.TaxId);
         }
 
         // Release any scheduled price increase before updating subscription
@@ -389,13 +391,25 @@ public class UpgradePremiumToOrganizationCommand(
     /// If the tax ID is a Spanish NIF, also adds the corresponding EU VAT ID.
     /// </summary>
     /// <param name="customerId">The Stripe customer ID to add the tax ID to.</param>
+    /// <param name="country">The billing address country used to derive the tax ID type.</param>
     /// <param name="taxId">The tax ID to add, including the type and value.</param>
-    private async Task AddTaxIdToCustomerAsync(string customerId, TaxID taxId)
+    private async Task AddTaxIdToCustomerAsync(string customerId, string country, TaxID taxId)
     {
-        await stripeAdapter.CreateTaxIdAsync(customerId,
-            new TaxIdCreateOptions { Type = taxId.Code, Value = taxId.Value });
+        var derivedTaxIdCode = taxService.GetStripeTaxCode(country, taxId.Value);
 
-        if (taxId.Code == TaxIdType.SpanishNIF)
+        if (derivedTaxIdCode == null)
+        {
+            _logger.LogWarning(
+                "Could not derive Stripe tax ID type for country {Country}; falling back to client-supplied type {TaxIdType}",
+                country, taxId.Code);
+        }
+
+        var taxIdCode = derivedTaxIdCode ?? taxId.Code;
+
+        await stripeAdapter.CreateTaxIdAsync(customerId,
+            new TaxIdCreateOptions { Type = taxIdCode, Value = taxId.Value });
+
+        if (taxIdCode == TaxIdType.SpanishNIF)
         {
             await stripeAdapter.CreateTaxIdAsync(customerId,
                 new TaxIdCreateOptions { Type = TaxIdType.EUVAT, Value = $"ES{taxId.Value}" });

--- a/src/Core/Billing/Tax/Services/Implementations/TaxService.cs
+++ b/src/Core/Billing/Tax/Services/Implementations/TaxService.cs
@@ -834,6 +834,16 @@ public class TaxService : ITaxService
             Example = "GB123456789",
             ValidationExpression = new Regex("^GB[0-9]{9}$")
         },
+        // Checked after the XI and GB prefixed entries. A bare 9-digit value cannot distinguish
+        // mainland UK from Northern Ireland, so it resolves to gb_vat.
+        new()
+        {
+            Country = "GB",
+            Code = "gb_vat",
+            Description = "United Kingdom VAT number (unprefixed)",
+            Example = "123456789",
+            ValidationExpression = new Regex("^[0-9]{9}$")
+        },
         new()
         {
             Country = "US",

--- a/test/Core.Test/Billing/Organizations/Commands/PreviewOrganizationTaxCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/PreviewOrganizationTaxCommandTests.cs
@@ -5,6 +5,7 @@ using Bit.Core.Billing.Organizations.Models;
 using Bit.Core.Billing.Payment.Models;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Services;
+using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Entities;
 using Bit.Core.Test.Billing.Mocks.Plans;
 using Microsoft.Extensions.Logging;
@@ -21,13 +22,15 @@ public class PreviewOrganizationTaxCommandTests
     private readonly IPricingClient _pricingClient = Substitute.For<IPricingClient>();
     private readonly IStripeAdapter _stripeAdapter = Substitute.For<IStripeAdapter>();
     private readonly ISubscriptionDiscountService _subscriptionDiscountService = Substitute.For<ISubscriptionDiscountService>();
+    private readonly ITaxService _taxService = Substitute.For<ITaxService>();
     private readonly PreviewOrganizationTaxCommand _command;
     private readonly User _user;
 
     public PreviewOrganizationTaxCommandTests()
     {
         _user = new User { Id = Guid.NewGuid(), Email = "test@example.com" };
-        _command = new PreviewOrganizationTaxCommand(_logger, _pricingClient, _stripeAdapter, _subscriptionDiscountService);
+        _command = new PreviewOrganizationTaxCommand(_logger, _pricingClient, _stripeAdapter,
+            _subscriptionDiscountService, _taxService);
     }
 
     #region Subscription Purchase
@@ -172,6 +175,8 @@ public class PreviewOrganizationTaxCommandTests
             TaxId = new TaxID("gb_vat", "123456789")
         };
 
+        _taxService.GetStripeTaxCode("GB", "123456789").Returns((string?)null);
+
         var plan = new EnterprisePlan(true);
         _pricingClient.GetPlanOrThrow(purchase.PlanType).Returns(plan);
 
@@ -281,8 +286,10 @@ public class PreviewOrganizationTaxCommandTests
         {
             Country = "ES",
             PostalCode = "28001",
-            TaxId = new TaxID(TaxIdType.SpanishNIF, "12345678Z")
+            TaxId = new TaxID(TaxIdType.EUVAT, "A12345678")
         };
+
+        _taxService.GetStripeTaxCode("ES", "A12345678").Returns(TaxIdType.SpanishNIF);
 
         var plan = new EnterprisePlan(false);
         _pricingClient.GetPlanOrThrow(purchase.PlanType).Returns(plan);
@@ -309,12 +316,108 @@ public class PreviewOrganizationTaxCommandTests
             options.CustomerDetails.Address.Country == "ES" &&
             options.CustomerDetails.Address.PostalCode == "28001" &&
             options.CustomerDetails.TaxIds.Count == 2 &&
-            options.CustomerDetails.TaxIds.Any(t => t.Type == TaxIdType.SpanishNIF && t.Value == "12345678Z") &&
-            options.CustomerDetails.TaxIds.Any(t => t.Type == TaxIdType.EUVAT && t.Value == "ES12345678Z") &&
+            options.CustomerDetails.TaxIds.Any(t => t.Type == TaxIdType.SpanishNIF && t.Value == "A12345678") &&
+            options.CustomerDetails.TaxIds.Any(t => t.Type == TaxIdType.EUVAT && t.Value == "ESA12345678") &&
             options.SubscriptionDetails.Items.Count == 1 &&
             options.SubscriptionDetails.Items[0].Price == "2023-enterprise-seat-monthly" &&
             options.SubscriptionDetails.Items[0].Quantity == 15 &&
             options.Discounts == null));
+    }
+
+    [Fact]
+    public async Task Run_OrganizationSubscriptionPurchase_UKTaxIdSentAsEUVAT_UsesGBVAT()
+    {
+        var billingAddress = new BillingAddress
+        {
+            Country = "GB",
+            PostalCode = "SW1A 1AA",
+            TaxId = new TaxID(TaxIdType.EUVAT, "GB123456789")
+        };
+
+        _taxService.GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
+
+        await RunEnterpriseMonthlyPurchase(billingAddress);
+
+        await _stripeAdapter.Received(1).CreateInvoicePreviewAsync(Arg.Is<InvoiceCreatePreviewOptions>(options =>
+            options.CustomerDetails.TaxIds.Count == 1 &&
+            options.CustomerDetails.TaxIds[0].Type == "gb_vat" &&
+            options.CustomerDetails.TaxIds[0].Value == "GB123456789"));
+    }
+
+    [Fact]
+    public async Task Run_OrganizationSubscriptionPurchase_NorthernIrelandTaxId_UsesEUVAT()
+    {
+        var billingAddress = new BillingAddress
+        {
+            Country = "GB",
+            PostalCode = "BT1 5GS",
+            TaxId = new TaxID("gb_vat", "XI123456789")
+        };
+
+        _taxService.GetStripeTaxCode("GB", "XI123456789").Returns(TaxIdType.EUVAT);
+
+        await RunEnterpriseMonthlyPurchase(billingAddress);
+
+        await _stripeAdapter.Received(1).CreateInvoicePreviewAsync(Arg.Is<InvoiceCreatePreviewOptions>(options =>
+            options.CustomerDetails.TaxIds.Count == 1 &&
+            options.CustomerDetails.TaxIds[0].Type == TaxIdType.EUVAT &&
+            options.CustomerDetails.TaxIds[0].Value == "XI123456789"));
+    }
+
+    [Fact]
+    public async Task Run_OrganizationSubscriptionPurchase_UnderivableTaxId_FallsBackToClientCodeAndWarns()
+    {
+        var billingAddress = new BillingAddress
+        {
+            Country = "MK",
+            PostalCode = "1000",
+            TaxId = new TaxID(TaxIdType.EUVAT, "MK1234567890123")
+        };
+
+        _taxService.GetStripeTaxCode("MK", "MK1234567890123").Returns((string?)null);
+
+        await RunEnterpriseMonthlyPurchase(billingAddress);
+
+        await _stripeAdapter.Received(1).CreateInvoicePreviewAsync(Arg.Is<InvoiceCreatePreviewOptions>(options =>
+            options.CustomerDetails.TaxIds.Count == 1 &&
+            options.CustomerDetails.TaxIds[0].Type == TaxIdType.EUVAT &&
+            options.CustomerDetails.TaxIds[0].Value == "MK1234567890123"));
+
+        _logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => state.ToString()!.Contains("MK") &&
+                                    state.ToString()!.Contains(TaxIdType.EUVAT) &&
+                                    !state.ToString()!.Contains("MK1234567890123")),
+            null,
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    private async Task RunEnterpriseMonthlyPurchase(BillingAddress billingAddress)
+    {
+        var purchase = new OrganizationSubscriptionPurchase
+        {
+            Tier = ProductTierType.Enterprise,
+            Cadence = PlanCadenceType.Monthly,
+            PasswordManager = new OrganizationSubscriptionPurchase.PasswordManagerSelections
+            {
+                Seats = 15,
+                AdditionalStorage = 0,
+                Sponsored = false
+            }
+        };
+
+        _pricingClient.GetPlanOrThrow(purchase.PlanType).Returns(new EnterprisePlan(false));
+
+        _stripeAdapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>()).Returns(new Invoice
+        {
+            TotalTaxes = [new InvoiceTotalTax { Amount = 2100 }],
+            Total = 12100
+        });
+
+        var result = await _command.Run(_user, purchase, billingAddress);
+
+        Assert.True(result.IsT0);
     }
 
     [Fact]
@@ -2323,6 +2426,8 @@ public class PreviewOrganizationTaxCommandTests
             }
         };
 
+        _taxService.GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
+
         var subscription = new Subscription
         {
             Customer = customer
@@ -2403,6 +2508,8 @@ public class PreviewOrganizationTaxCommandTests
             }
         };
 
+        _taxService.GetStripeTaxCode("ES", "12345678Z").Returns((string?)null);
+
         var subscription = new Subscription
         {
             Customer = customer
@@ -2446,6 +2553,57 @@ public class PreviewOrganizationTaxCommandTests
             options.Discounts != null &&
             options.Discounts.Count == 1 &&
             options.Discounts[0].Coupon == "ENTERPRISE_DISCOUNT_20"));
+    }
+
+    // The stored Stripe tax ID may already be corrupt (a GB-prefixed eu_vat). Deriving from the stored
+    // country and value corrects the preview without waiting on data remediation.
+    [Fact]
+    public async Task Run_OrganizationSubscriptionUpdate_StoredTaxIdTypedAsEUVAT_UsesGBVAT()
+    {
+        var organization = new Organization
+        {
+            Id = Guid.NewGuid(),
+            PlanType = PlanType.EnterpriseMonthly,
+            GatewayCustomerId = "cus_test123",
+            GatewaySubscriptionId = "sub_test123"
+        };
+
+        var update = new OrganizationSubscriptionUpdate
+        {
+            PasswordManager = new OrganizationSubscriptionUpdate.PasswordManagerSelections { Seats = 10 }
+        };
+
+        _pricingClient.GetPlanOrThrow(organization.PlanType).Returns(new EnterprisePlan(false));
+
+        var customer = new Customer
+        {
+            Address = new Address { Country = "GB", PostalCode = "SW1A 1AA" },
+            Discount = null,
+            TaxIds = new StripeList<TaxId>
+            {
+                Data = [new TaxId { Type = TaxIdType.EUVAT, Value = "GB123456789" }]
+            }
+        };
+
+        _stripeAdapter.GetSubscriptionAsync("sub_test123", Arg.Any<SubscriptionGetOptions>())
+            .Returns(new Subscription { Customer = customer });
+
+        _taxService.GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
+
+        _stripeAdapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>()).Returns(new Invoice
+        {
+            TotalTaxes = [new InvoiceTotalTax { Amount = 0 }],
+            Total = 10000
+        });
+
+        var result = await _command.Run(organization, update);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).CreateInvoicePreviewAsync(Arg.Is<InvoiceCreatePreviewOptions>(options =>
+            options.CustomerDetails.TaxIds.Count == 1 &&
+            options.CustomerDetails.TaxIds[0].Type == "gb_vat" &&
+            options.CustomerDetails.TaxIds[0].Value == "GB123456789"));
     }
 
     // PM-40440: the update-overload preview must also read subscription-level discounts, not just the customer

--- a/test/Core.Test/Billing/Organizations/Commands/PreviewOrganizationTaxCommandTests.cs
+++ b/test/Core.Test/Billing/Organizations/Commands/PreviewOrganizationTaxCommandTests.cs
@@ -172,10 +172,10 @@ public class PreviewOrganizationTaxCommandTests
         {
             Country = "GB",
             PostalCode = "SW1A 1AA",
-            TaxId = new TaxID("gb_vat", "123456789")
+            TaxId = new TaxID(TaxIdType.EUVAT, "123456789")
         };
 
-        _taxService.GetStripeTaxCode("GB", "123456789").Returns((string?)null);
+        _taxService.GetStripeTaxCode("GB", "123456789").Returns("gb_vat");
 
         var plan = new EnterprisePlan(true);
         _pricingClient.GetPlanOrThrow(purchase.PlanType).Returns(plan);

--- a/test/Core.Test/Billing/Payment/Commands/UpdateBillingAddressCommandTests.cs
+++ b/test/Core.Test/Billing/Payment/Commands/UpdateBillingAddressCommandTests.cs
@@ -4,6 +4,7 @@ using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Payment.Commands;
 using Bit.Core.Billing.Payment.Models;
 using Bit.Core.Billing.Services;
+using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Test.Billing.Extensions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -16,16 +17,20 @@ using static StripeConstants;
 
 public class UpdateBillingAddressCommandTests
 {
+    private readonly ILogger<UpdateBillingAddressCommand> _logger =
+        Substitute.For<ILogger<UpdateBillingAddressCommand>>();
     private readonly ISubscriberService _subscriberService = Substitute.For<ISubscriberService>();
     private readonly IStripeAdapter _stripeAdapter = Substitute.For<IStripeAdapter>();
+    private readonly ITaxService _taxService = Substitute.For<ITaxService>();
     private readonly UpdateBillingAddressCommand _command;
 
     public UpdateBillingAddressCommandTests()
     {
         _command = new UpdateBillingAddressCommand(
-            Substitute.For<ILogger<UpdateBillingAddressCommand>>(),
+            _logger,
             _subscriberService,
-            _stripeAdapter);
+            _stripeAdapter,
+            _taxService);
 
         _stripeAdapter.ListSubscriptionSchedulesAsync(Arg.Any<SubscriptionScheduleListOptions>())
             .Returns(new StripeList<SubscriptionSchedule> { Data = new List<SubscriptionSchedule>() });
@@ -330,6 +335,8 @@ public class UpdateBillingAddressCommandTests
             }
         };
 
+        _taxService.GetStripeTaxCode(input.Country, input.TaxId.Value).Returns(TaxIdType.SpanishNIF);
+
         _stripeAdapter.GetCustomerAsync(organization.GatewayCustomerId)
             .Returns(new Customer { TaxExempt = TaxExempt.None });
 
@@ -377,6 +384,8 @@ public class UpdateBillingAddressCommandTests
             State = "NY",
             TaxId = new TaxID("us_ein", "987654321")
         };
+
+        _taxService.GetStripeTaxCode(input.Country, input.TaxId.Value).Returns("us_ein");
 
         var existingTaxId = new TaxId { Id = "tax_id_123", Type = "us_ein", Value = "987654321" };
 
@@ -438,6 +447,194 @@ public class UpdateBillingAddressCommandTests
         await _stripeAdapter.Received(1).DeleteTaxIdAsync(customer.Id, existingTaxId.Id);
         await _stripeAdapter.Received(1).CreateTaxIdAsync(customer.Id, Arg.Is<TaxIdCreateOptions>(
             options => options.Type == "us_ein" && options.Value == "987654321"));
+    }
+
+    [Fact]
+    public async Task Run_BusinessOrganization_UKTaxIdSentAsEUVAT_CreatesGBVATTaxId()
+    {
+        var organization = new Organization
+        {
+            PlanType = PlanType.EnterpriseAnnually,
+            GatewayCustomerId = "cus_123",
+            GatewaySubscriptionId = "sub_123"
+        };
+
+        var input = new BillingAddress
+        {
+            Country = "GB",
+            PostalCode = "SW1A 1AA",
+            TaxId = new TaxID(TaxIdType.EUVAT, "GB123456789")
+        };
+
+        var customer = BusinessCustomer(organization, input);
+
+        _taxService.GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
+
+        _stripeAdapter.UpdateCustomerAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(customer);
+
+        _stripeAdapter.CreateTaxIdAsync(customer.Id, Arg.Any<TaxIdCreateOptions>())
+            .Returns(new TaxId { Type = "gb_vat", Value = input.TaxId.Value });
+
+        var result = await _command.Run(organization, input);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(customer.Id, Arg.Is<TaxIdCreateOptions>(
+            options => options.Type == "gb_vat" && options.Value == "GB123456789"));
+    }
+
+    [Fact]
+    public async Task Run_BusinessOrganization_NorthernIrelandTaxId_CreatesEUVATTaxId()
+    {
+        var organization = new Organization
+        {
+            PlanType = PlanType.EnterpriseAnnually,
+            GatewayCustomerId = "cus_123",
+            GatewaySubscriptionId = "sub_123"
+        };
+
+        var input = new BillingAddress
+        {
+            Country = "GB",
+            PostalCode = "BT1 5GS",
+            TaxId = new TaxID("gb_vat", "XI123456789")
+        };
+
+        var customer = BusinessCustomer(organization, input);
+
+        _taxService.GetStripeTaxCode("GB", "XI123456789").Returns(TaxIdType.EUVAT);
+
+        _stripeAdapter.UpdateCustomerAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(customer);
+
+        _stripeAdapter.CreateTaxIdAsync(customer.Id, Arg.Any<TaxIdCreateOptions>())
+            .Returns(new TaxId { Type = TaxIdType.EUVAT, Value = input.TaxId.Value });
+
+        var result = await _command.Run(organization, input);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(customer.Id, Arg.Is<TaxIdCreateOptions>(
+            options => options.Type == TaxIdType.EUVAT && options.Value == "XI123456789"));
+    }
+
+    [Fact]
+    public async Task Run_BusinessOrganization_SpanishCIFSentAsEUVAT_CreatesBothSpanishNIFAndEUVATTaxIds()
+    {
+        var organization = new Organization
+        {
+            PlanType = PlanType.EnterpriseAnnually,
+            GatewayCustomerId = "cus_123",
+            GatewaySubscriptionId = "sub_123"
+        };
+
+        var input = new BillingAddress
+        {
+            Country = "ES",
+            PostalCode = "28001",
+            TaxId = new TaxID(TaxIdType.EUVAT, "A12345678")
+        };
+
+        var customer = BusinessCustomer(organization, input);
+
+        _taxService.GetStripeTaxCode("ES", "A12345678").Returns(TaxIdType.SpanishNIF);
+
+        _stripeAdapter.UpdateCustomerAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(customer);
+
+        _stripeAdapter.CreateTaxIdAsync(customer.Id,
+                Arg.Is<TaxIdCreateOptions>(options => options.Type == TaxIdType.EUVAT))
+            .Returns(new TaxId { Type = TaxIdType.EUVAT, Value = "ESA12345678" });
+
+        var result = await _command.Run(organization, input);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(customer.Id, Arg.Is<TaxIdCreateOptions>(
+            options => options.Type == TaxIdType.SpanishNIF && options.Value == "A12345678"));
+
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(customer.Id, Arg.Is<TaxIdCreateOptions>(
+            options => options.Type == TaxIdType.EUVAT && options.Value == "ESA12345678"));
+    }
+
+    [Fact]
+    public async Task Run_BusinessOrganization_CanadianBusinessNumberSentAsGSTHST_CreatesCABNTaxId()
+    {
+        var organization = new Organization
+        {
+            PlanType = PlanType.EnterpriseAnnually,
+            GatewayCustomerId = "cus_123",
+            GatewaySubscriptionId = "sub_123"
+        };
+
+        var input = new BillingAddress
+        {
+            Country = "CA",
+            PostalCode = "M5H 2N2",
+            TaxId = new TaxID("ca_gst_hst", "987654321")
+        };
+
+        var customer = BusinessCustomer(organization, input);
+
+        _taxService.GetStripeTaxCode("CA", "987654321").Returns("ca_bn");
+
+        _stripeAdapter.UpdateCustomerAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(customer);
+
+        _stripeAdapter.CreateTaxIdAsync(customer.Id, Arg.Any<TaxIdCreateOptions>())
+            .Returns(new TaxId { Type = "ca_bn", Value = input.TaxId.Value });
+
+        var result = await _command.Run(organization, input);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(customer.Id, Arg.Is<TaxIdCreateOptions>(
+            options => options.Type == "ca_bn" && options.Value == "987654321"));
+    }
+
+    [Fact]
+    public async Task Run_BusinessOrganization_UnderivableTaxId_FallsBackToClientCodeAndWarns()
+    {
+        var organization = new Organization
+        {
+            PlanType = PlanType.EnterpriseAnnually,
+            GatewayCustomerId = "cus_123",
+            GatewaySubscriptionId = "sub_123"
+        };
+
+        var input = new BillingAddress
+        {
+            Country = "MK",
+            PostalCode = "1000",
+            TaxId = new TaxID(TaxIdType.EUVAT, "MK1234567890123")
+        };
+
+        var customer = BusinessCustomer(organization, input);
+
+        _taxService.GetStripeTaxCode("MK", "MK1234567890123").Returns((string?)null);
+
+        _stripeAdapter.UpdateCustomerAsync(organization.GatewayCustomerId, Arg.Any<CustomerUpdateOptions>())
+            .Returns(customer);
+
+        _stripeAdapter.CreateTaxIdAsync(customer.Id, Arg.Any<TaxIdCreateOptions>())
+            .Returns(new TaxId { Type = TaxIdType.EUVAT, Value = input.TaxId.Value });
+
+        var result = await _command.Run(organization, input);
+
+        Assert.True(result.IsT0);
+
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(customer.Id, Arg.Is<TaxIdCreateOptions>(
+            options => options.Type == TaxIdType.EUVAT && options.Value == "MK1234567890123"));
+
+        _logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => state.ToString()!.Contains("MK") &&
+                                    state.ToString()!.Contains(TaxIdType.EUVAT) &&
+                                    !state.ToString()!.Contains(input.TaxId.Value)),
+            null,
+            Arg.Any<Func<object, Exception?, string>>());
     }
 
     [Fact]
@@ -1127,4 +1324,21 @@ public class UpdateBillingAddressCommandTests
 
         await _stripeAdapter.DidNotReceive().GetCustomerAsync(organization.GatewayCustomerId);
     }
+
+    private static Customer BusinessCustomer(Organization organization, BillingAddress billingAddress) => new()
+    {
+        Address = new Address { Country = billingAddress.Country, PostalCode = billingAddress.PostalCode },
+        Id = organization.GatewayCustomerId,
+        Subscriptions = new StripeList<Subscription>
+        {
+            Data =
+            [
+                new Subscription
+                {
+                    Id = organization.GatewaySubscriptionId,
+                    AutomaticTax = new SubscriptionAutomaticTax { Enabled = true }
+                }
+            ]
+        }
+    };
 }

--- a/test/Core.Test/Billing/Premium/Commands/UpgradePremiumToOrganizationCommandTests.cs
+++ b/test/Core.Test/Billing/Premium/Commands/UpgradePremiumToOrganizationCommandTests.cs
@@ -8,6 +8,7 @@ using Bit.Core.Billing.Premium.Commands;
 using Bit.Core.Billing.Pricing;
 using Bit.Core.Billing.Services;
 using Bit.Core.Billing.Subscriptions.Models;
+using Bit.Core.Billing.Tax.Services;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
@@ -148,6 +149,7 @@ public class UpgradePremiumToOrganizationCommandTests
     private readonly IGetPaymentMethodQuery _getPaymentMethodQuery = Substitute.For<IGetPaymentMethodQuery>();
     private readonly IPushNotificationService _pushNotificationService = Substitute.For<IPushNotificationService>();
     private readonly ILogger<UpgradePremiumToOrganizationCommand> _logger = Substitute.For<ILogger<UpgradePremiumToOrganizationCommand>>();
+    private readonly ITaxService _taxService = Substitute.For<ITaxService>();
     private readonly UpgradePremiumToOrganizationCommand _command;
 
     public UpgradePremiumToOrganizationCommandTests()
@@ -179,7 +181,8 @@ public class UpgradePremiumToOrganizationCommandTests
             _braintreeService,
             _getPaymentMethodQuery,
             _organizationAbilityCacheService,
-            _pushNotificationService);
+            _pushNotificationService,
+            _taxService);
     }
 
     private static Core.Billing.Payment.Models.BillingAddress CreateTestBillingAddress() =>
@@ -1290,6 +1293,8 @@ public class UpgradePremiumToOrganizationCommandTests
             TaxId = new Core.Billing.Payment.Models.TaxID("eu_vat", "DE123456789")
         };
 
+        _taxService.GetStripeTaxCode("DE", "DE123456789").Returns(StripeConstants.TaxIdType.EUVAT);
+
         // Act
         var result = await _command.Run(user, "My Organization", "encrypted-key", "public-key", "encrypted-private-key", "Default Collection", PlanType.TeamsAnnually, billingAddress);
 
@@ -1408,8 +1413,10 @@ public class UpgradePremiumToOrganizationCommandTests
         {
             Country = "ES",
             PostalCode = "28001",
-            TaxId = new Core.Billing.Payment.Models.TaxID(StripeConstants.TaxIdType.SpanishNIF, "A12345678")
+            TaxId = new Core.Billing.Payment.Models.TaxID(StripeConstants.TaxIdType.EUVAT, "A12345678")
         };
+
+        _taxService.GetStripeTaxCode("ES", "A12345678").Returns(StripeConstants.TaxIdType.SpanishNIF);
 
         // Act
         var result = await _command.Run(user, "My Organization", "encrypted-key", "public-key", "encrypted-private-key", "Default Collection", PlanType.TeamsAnnually, billingAddress);
@@ -1430,6 +1437,129 @@ public class UpgradePremiumToOrganizationCommandTests
             Arg.Is<TaxIdCreateOptions>(options =>
                 options.Type == StripeConstants.TaxIdType.EUVAT &&
                 options.Value == "ESA12345678"));
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_UKTaxIdSentAsEUVAT_CreatesGBVATTaxId(User user)
+    {
+        // Arrange
+        ArrangeSuccessfulUpgrade(user);
+
+        var billingAddress = new Core.Billing.Payment.Models.BillingAddress
+        {
+            Country = "GB",
+            PostalCode = "SW1A 1AA",
+            TaxId = new Core.Billing.Payment.Models.TaxID(StripeConstants.TaxIdType.EUVAT, "GB123456789")
+        };
+
+        _taxService.GetStripeTaxCode("GB", "GB123456789").Returns("gb_vat");
+
+        // Act
+        var result = await _command.Run(user, "My Organization", "encrypted-key", "public-key", "encrypted-private-key", null, PlanType.TeamsAnnually, billingAddress);
+
+        // Assert
+        Assert.True(result.Success);
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(
+            "cus_123",
+            Arg.Is<TaxIdCreateOptions>(options =>
+                options.Type == "gb_vat" &&
+                options.Value == "GB123456789"));
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_NorthernIrelandTaxId_CreatesEUVATTaxId(User user)
+    {
+        // Arrange
+        ArrangeSuccessfulUpgrade(user);
+
+        var billingAddress = new Core.Billing.Payment.Models.BillingAddress
+        {
+            Country = "GB",
+            PostalCode = "BT1 5GS",
+            TaxId = new Core.Billing.Payment.Models.TaxID("gb_vat", "XI123456789")
+        };
+
+        _taxService.GetStripeTaxCode("GB", "XI123456789").Returns(StripeConstants.TaxIdType.EUVAT);
+
+        // Act
+        var result = await _command.Run(user, "My Organization", "encrypted-key", "public-key", "encrypted-private-key", null, PlanType.TeamsAnnually, billingAddress);
+
+        // Assert
+        Assert.True(result.Success);
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(
+            "cus_123",
+            Arg.Is<TaxIdCreateOptions>(options =>
+                options.Type == StripeConstants.TaxIdType.EUVAT &&
+                options.Value == "XI123456789"));
+    }
+
+    [Theory, BitAutoData]
+    public async Task Run_UnderivableTaxId_FallsBackToClientCodeAndWarns(User user)
+    {
+        // Arrange
+        ArrangeSuccessfulUpgrade(user);
+
+        var billingAddress = new Core.Billing.Payment.Models.BillingAddress
+        {
+            Country = "MK",
+            PostalCode = "1000",
+            TaxId = new Core.Billing.Payment.Models.TaxID(StripeConstants.TaxIdType.EUVAT, "MK1234567890123")
+        };
+
+        _taxService.GetStripeTaxCode("MK", "MK1234567890123").Returns((string?)null);
+
+        // Act
+        var result = await _command.Run(user, "My Organization", "encrypted-key", "public-key", "encrypted-private-key", null, PlanType.TeamsAnnually, billingAddress);
+
+        // Assert
+        Assert.True(result.Success);
+        await _stripeAdapter.Received(1).CreateTaxIdAsync(
+            "cus_123",
+            Arg.Is<TaxIdCreateOptions>(options =>
+                options.Type == StripeConstants.TaxIdType.EUVAT &&
+                options.Value == "MK1234567890123"));
+
+        _logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => state.ToString()!.Contains("MK") &&
+                                    state.ToString()!.Contains(StripeConstants.TaxIdType.EUVAT) &&
+                                    !state.ToString()!.Contains("MK1234567890123")),
+            null,
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    private void ArrangeSuccessfulUpgrade(User user)
+    {
+        user.Premium = true;
+        user.GatewaySubscriptionId = "sub_123";
+        user.GatewayCustomerId = "cus_123";
+
+        var mockSubscription = new Subscription
+        {
+            Id = "sub_123",
+            Items = new StripeList<SubscriptionItem>
+            {
+                Data =
+                [
+                    new SubscriptionItem { Id = "si_premium", Price = new Price { Id = "premium-annually" } }
+                ]
+            },
+            Metadata = new Dictionary<string, string>()
+        };
+
+        _stripeAdapter.GetSubscriptionAsync("sub_123").Returns(mockSubscription);
+        _pricingClient.ListPremiumPlans().Returns(CreateTestPremiumPlansList());
+        _pricingClient.GetPlanOrThrow(PlanType.TeamsAnnually)
+            .Returns(CreateTestPlan(PlanType.TeamsAnnually, stripeSeatPlanId: "teams-seat-annually"));
+        _stripeAdapter.UpdateSubscriptionAsync(Arg.Any<string>(), Arg.Any<SubscriptionUpdateOptions>()).Returns(mockSubscription);
+        _stripeAdapter.UpdateCustomerAsync(Arg.Any<string>(), Arg.Any<CustomerUpdateOptions>()).Returns(Task.FromResult(new Customer()));
+        _stripeAdapter.CreateTaxIdAsync(Arg.Any<string>(), Arg.Any<TaxIdCreateOptions>()).Returns(new TaxId());
+        _organizationRepository.CreateAsync(Arg.Any<Organization>()).Returns(callInfo => Task.FromResult(callInfo.Arg<Organization>()));
+        _organizationApiKeyRepository.CreateAsync(Arg.Any<OrganizationApiKey>()).Returns(callInfo => Task.FromResult(callInfo.Arg<OrganizationApiKey>()));
+        _organizationUserRepository.CreateAsync(Arg.Any<OrganizationUser>()).Returns(callInfo => Task.FromResult(callInfo.Arg<OrganizationUser>()));
+        _organizationAbilityCacheService.UpsertOrganizationAbilityAsync(Arg.Any<Organization>()).Returns(Task.CompletedTask);
+        _userService.SaveUserAsync(user).Returns(Task.CompletedTask);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40694

## 📔 Objective

UK business customers were being charged 20% VAT they didn't owe.

The web client resolves a tax ID's Stripe type from the billing country alone, returning the first candidate flagged as impacting tax calculation. GB has two, and the Northern Ireland `eu_vat` entry is listed first — so every UK VAT ID reached Stripe typed `eu_vat`. Stripe stores it without complaint but will not apply reverse charge.

Four server write sites forwarded the client-supplied type verbatim. Each now derives it from `(country, value)` via `ITaxService.GetStripeTaxCode`:

- `UpdateBillingAddressCommand`
- `UpgradePremiumToOrganizationCommand`
- `ProviderBillingService.SetupCustomer`
- `PreviewOrganizationTaxCommand`

That method already existed and already distinguishes GB from XI. Before this PR its only non-test caller was `OrganizationBillingService` on the org-signup path — which is why creating an organization stored the correct type while editing the billing address afterwards overwrote it.

The second commit adds an unprefixed `^[0-9]{9}$` → `gb_vat` rule for GB. A UK VAT number is nine digits and the `GB` prefix is routinely omitted; without this, the fix misses exactly the customers the ticket is about.

### Design decisions

**Fallback rather than throw.** When derivation returns `null` the client-supplied type is kept and a warning logged. `TaxService` covers 83 countries; the client renders a tax ID field for 112. Throwing would break tax ID saves that work today. `OrganizationBillingService` does throw here — reconciling the two is deliberate follow-up, not part of this PR.

**No feature flag.** The fallback makes the null path byte-identical to previous behaviour, so there is no scenario where flag-off is safer than flag-on. Revert is four files with no schema or data dependency.

**Derivation sits after the `OneOf` match in `PreviewOrganizationTaxCommand`**, so it also corrects previews for customers whose *stored* type is already wrong, ahead of data remediation.

### Verified against Stripe (test account)

- `gb_vat` with an unprefixed value is accepted and verifies against HMRC, so the type is corrected without rewriting the stored value.
- `eu_vat` with an unprefixed value is **rejected** (`tax_id_invalid`). Customers in that state were never receiving reverse charge, so deriving a country-specific type for them is not a regression.
- On a live 13% Ontario registration: `ca_gst_hst` with a full `…RT0001` number zeroes the tax; `ca_bn` does not. A bare Business Number correctly grants no relief, and `ca_gst_hst` with a bare value is rejected by Stripe.

### Known caveat

Bare nine digits cannot distinguish mainland UK from Northern Ireland. An NI customer who omits `XI` now resolves to `gb_vat` instead of `eu_vat`. NI postcodes all start with `BT`, which is the disambiguator if this needs addressing.

### Follow-up, deliberately out of scope

- `TaxService` is 36 tax ID types behind Stripe's current table, and Nigeria's and Argentina's documented formats have drifted from ours. Adding missing types is low risk; changing the two live formats needs confirmation of which forms are actually in circulation.
- The client still sends the wrong type and still shows a misleading format hint after a failed verification. That is what closes PM-27010 — this PR fixes its blocking symptom (a bare Canadian BN now saves) but not the hint.
- Three ♻️ Refactor findings from review, deferred: the derive-fallback block is inlined at four sites, the warning carries no subscriber identifier, and `GetStripeTaxCode` is still declared non-nullable. All are best done alongside the fallback-policy reconciliation, which touches all five sites anyway.
- Stripe data remediation: existing `eu_vat` records with GB-prefixed values need delete-and-recreate as `gb_vat` (Stripe has no update endpoint). Must run *after* this ships, or the customer's next address save re-corrupts the record.

### Testing

298 unit tests passing across the five affected suites. The GB regression test sends `eu_vat` with a `GB`-prefixed value and asserts Stripe receives `gb_vat`, so it fails on `main`.

**QA note:** read the `customer.tax_id.created` event payload, not the Dashboard Details panel — Stripe renders a GB-prefixed `eu_vat` as "GB VAT", which masks the defect entirely.
