### PR TITLE
[PM-38270] perf: Speed up "claimed by organization" status checks on the Members page

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/GetOrganizationUsersClaimedStatusQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/GetOrganizationUsersClaimedStatusQuery.cs
@@ -26,11 +26,10 @@ public class GetOrganizationUsersClaimedStatusQuery : IGetOrganizationUsersClaim
 
             if (organizationAbility is { Enabled: true, UseOrganizationDomains: true })
             {
-                // Get all organization users with claimed domains by the organization
                 var organizationUsersWithClaimedDomain = await _organizationUserRepository.GetManyByOrganizationWithClaimedDomainsAsync(organizationId);
 
-                // Create a dictionary with the OrganizationUserId and a boolean indicating if the user is claimed by the organization
-                return organizationUserIds.ToDictionary(ouId => ouId, ouId => organizationUsersWithClaimedDomain.Any(ou => ou.Id == ouId));
+                var claimedIds = organizationUsersWithClaimedDomain.Select(ou => ou.Id).ToHashSet();
+                return organizationUserIds.ToDictionary(ouId => ouId, claimedIds.Contains);
             }
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38270

## 📔 Objective

`GetOrganizationUsersClaimedStatusQuery` used `.Any()` inside a `ToDictionary` to test each user ID against the full claimed-users list — an O(n·m) scan that worsens as the Members page grows. This replaces it with a `HashSet<Guid>` built once before the loop, reducing complexity to O(n+m). Mirrors the same fix applied to `TwoFactorIsEnabledQuery` in PM-38265.
