### PR TITLE
[BRE] Add login step for Chainguard repo

### DIFF
--- a/.github/workflows/build-gov.yml
+++ b/.github/workflows/build-gov.yml
@@ -146,7 +146,11 @@ jobs:
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
-          secrets: "GAMEWARDEN-REGISTRY-USERNAME,GAMEWARDEN-REGISTRY-PASSWORD,CHAINGUARD-REGISTRY-USERNAME,CHAINGUARD-REGISTRY-PASSWORD"
+          secrets: >-
+            GAMEWARDEN-REGISTRY-USERNAME,
+            GAMEWARDEN-REGISTRY-PASSWORD,
+            CHAINGUARD-REGISTRY-USERNAME,
+            CHAINGUARD-REGISTRY-PASSWORD
 
       - name: Log in to registry
         # use ACR for testing

--- a/.github/workflows/build-gov.yml
+++ b/.github/workflows/build-gov.yml
@@ -146,7 +146,7 @@ jobs:
         uses: bitwarden/gh-actions/get-keyvault-secrets@main
         with:
           keyvault: gh-org-bitwarden
-          secrets: "GAMEWARDEN-REGISTRY-USERNAME,GAMEWARDEN-REGISTRY-PASSWORD"
+          secrets: "GAMEWARDEN-REGISTRY-USERNAME,GAMEWARDEN-REGISTRY-PASSWORD,CHAINGUARD-REGISTRY-USERNAME,CHAINGUARD-REGISTRY-PASSWORD"
 
       - name: Log in to registry
         # use ACR for testing
@@ -154,6 +154,13 @@ jobs:
 
       - name: Log out from Azure
         uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Log in to Chainguard registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: cgr.dev
+          username: ${{ steps.get-kv-secrets.outputs.CHAINGUARD-REGISTRY-USERNAME }}
+          password: ${{ steps.get-kv-secrets.outputs.CHAINGUARD-REGISTRY-PASSWORD }}
 
       - name: Build Docker image
         id: build-artifacts
@@ -173,8 +180,10 @@ jobs:
           fail-build: false
           output-format: sarif
 
-      - name: Log out from registry
-        run: docker logout ${_REGISTRY}
+      - name: Log out from the registries
+        run: |
+          docker logout ${_REGISTRY}
+          docker logout cgr.dev
 
       - name: Upload Grype results to GitHub
         uses: github/codeql-action/upload-sarif@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-2073](https://bitwarden.atlassian.net/browse/BRE-2073)

## 📔 Objective
Added step that logs into the Chainguard container registry. This is required so the image build can use Chainguard base images.


[BRE-2073]: https://bitwarden.atlassian.net/browse/BRE-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ