### PR TITLE
[PM-41451] Migrate AC files off off `AssemblyHelpers.GetVersion()`

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/InfoController.cs
+++ b/bitwarden_license/src/Scim/Controllers/InfoController.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Utilities;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Scim.Controllers;
@@ -12,11 +11,5 @@ public class InfoController : Controller
     public DateTime GetAlive()
     {
         return DateTime.UtcNow;
-    }
-
-    [HttpGet("~/version")]
-    public JsonResult GetVersion()
-    {
-        return Json(AssemblyHelpers.GetVersion());
     }
 }

--- a/bitwarden_license/src/Scim/Startup.cs
+++ b/bitwarden_license/src/Scim/Startup.cs
@@ -132,6 +132,10 @@ public class Startup
         app.UseFeatureFlagChecks();
 
         // Add MVC to the request pipeline.
-        app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapDefaultControllerRoute();
+            endpoints.MapVersionEndpoint();
+        });
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41451
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Removes uses of `AssemblyHelpers.GetVersion()` from @bitwarden/team-admin-console-dev code in favor of `IBitwardenEnvironment` and `MapVersionEndpoint()`. 

AssemblyHelpers exists in Core and returns the version for the Core assembly itself. We can move the the MapVersionEndpoint() provided in the Bitwarden.Server.Sdk.WebEssentials package which will return in the same format but will instead return the version of the services assembly. While this is technically different since all packages without overrides get the version from the Directory.Build.props it is effectively the same.

This removes one reason a service might have to depend on Core. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
