### PR TITLE
[PM-41451] Migrate Auth files off of `AssemblyHelpers.GetVersion()`

### DIFF
--- a/bitwarden_license/src/Sso/Controllers/InfoController.cs
+++ b/bitwarden_license/src/Sso/Controllers/InfoController.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Utilities;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Sso.Controllers;
 
@@ -10,11 +9,5 @@ public class InfoController : Controller
     public DateTime GetAlive()
     {
         return DateTime.UtcNow;
-    }
-
-    [HttpGet("~/version")]
-    public JsonResult GetVersion()
-    {
-        return Json(AssemblyHelpers.GetVersion());
     }
 }

--- a/bitwarden_license/src/Sso/Startup.cs
+++ b/bitwarden_license/src/Sso/Startup.cs
@@ -150,7 +150,11 @@ public class Startup
         // Gates endpoints carrying IFeatureMetadata; required in any app that
         // routes requests through endpoints tagged with [RequireFeature].
         app.UseFeatureFlagChecks();
-        app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapDefaultControllerRoute();
+            endpoints.MapVersionEndpoint();
+        });
 
         // Log startup
         logger.LogInformation(Constants.BypassFiltersEventId, "{Project} started.", globalSettings.ProjectName);

--- a/src/Identity/Controllers/InfoController.cs
+++ b/src/Identity/Controllers/InfoController.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Utilities;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Identity.Controllers;
 
@@ -16,11 +15,5 @@ public class InfoController : Controller
     public DateTime GetNow()
     {
         return GetAlive();
-    }
-
-    [HttpGet("~/version")]
-    public JsonResult GetVersion()
-    {
-        return Json(AssemblyHelpers.GetVersion());
     }
 }

--- a/src/Identity/Startup.cs
+++ b/src/Identity/Startup.cs
@@ -235,7 +235,11 @@ public class Startup
         app.UseFeatureFlagChecks();
 
         // Add Mvc stuff
-        app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapDefaultControllerRoute();
+            endpoints.MapVersionEndpoint();
+        });
 
         // Log startup
         logger.LogInformation(Constants.BypassFiltersEventId, "{Project} started.", globalSettings.ProjectName);


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41451
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Removes uses of `AssemblyHelpers.GetVersion()` from @bitwarden/team-auth-dev code in favor of `IBitwardenEnvironment` and `MapVersionEndpoint()`. 

AssemblyHelpers exists in Core and returns the version for the Core assembly itself. We can move the the MapVersionEndpoint() provided in the Bitwarden.Server.Sdk.WebEssentials package which will return in the same format but will instead return the version of the services assembly. While this is technically different since all packages without overrides get the version from the Directory.Build.props it is effectively the same.

This removes one reason a service might have to depend on Core. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
