### PR TITLE
[PM-41451] Migrate Billing files off of `AssemblyHelpers.GetVersion()`

### DIFF
--- a/src/Billing/Controllers/InfoController.cs
+++ b/src/Billing/Controllers/InfoController.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Utilities;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Billing.Controllers;
 
@@ -10,11 +9,5 @@ public class InfoController : Controller
     public DateTime GetAlive()
     {
         return DateTime.UtcNow;
-    }
-
-    [HttpGet("~/version")]
-    public JsonResult GetVersion()
-    {
-        return Json(AssemblyHelpers.GetVersion());
     }
 }

--- a/src/Billing/Startup.cs
+++ b/src/Billing/Startup.cs
@@ -142,6 +142,10 @@ public class Startup
         app.UseRouting();
         app.UseAuthentication();
         app.UseAuthorization();
-        app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapDefaultControllerRoute();
+            endpoints.MapVersionEndpoint();
+        });
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41451
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Removes uses of `AssemblyHelpers.GetVersion()` from @bitwarden/team-billing-dev code in favor of `IBitwardenEnvironment` and
`MapVersionEndpoint()`. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
