### PR TITLE
[PM-41451] Migrate Dirt files off of `AssemblyHelpers.GetVersion()`

### DIFF
--- a/src/Events/Controllers/InfoController.cs
+++ b/src/Events/Controllers/InfoController.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Core.Utilities;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Events.Controllers;
 
@@ -10,11 +9,5 @@ public class InfoController : Controller
     public DateTime GetAlive()
     {
         return DateTime.UtcNow;
-    }
-
-    [HttpGet("~/version")]
-    public JsonResult GetVersion()
-    {
-        return Json(AssemblyHelpers.GetVersion());
     }
 }

--- a/src/Events/Startup.cs
+++ b/src/Events/Startup.cs
@@ -119,6 +119,10 @@ public class Startup
         app.UseFeatureFlagChecks();
 
         // Add MVC to the request pipeline.
-        app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapDefaultControllerRoute();
+            endpoints.MapVersionEndpoint();
+        });
     }
 }

--- a/src/EventsProcessor/Program.cs
+++ b/src/EventsProcessor/Program.cs
@@ -8,6 +8,7 @@ public class Program
     {
         Host
             .CreateDefaultBuilder(args)
+            .UseBitwardenSdk()
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseStartup<Startup>();

--- a/src/EventsProcessor/Startup.cs
+++ b/src/EventsProcessor/Startup.cs
@@ -48,9 +48,7 @@ public class Startup
                 async context => await context.Response.WriteAsJsonAsync(System.DateTime.UtcNow));
             endpoints.MapGet("/now",
                 async context => await context.Response.WriteAsJsonAsync(System.DateTime.UtcNow));
-            endpoints.MapGet("/version",
-                async context => await context.Response.WriteAsJsonAsync(AssemblyHelpers.GetVersion()));
-
+            endpoints.MapVersionEndpoint();
         });
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41451
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Removes uses of `AssemblyHelpers.GetVersion()` from @bitwarden/team-data-insights-and-reporting-dev code in favor of `IBitwardenEnvironment` and
`MapVersionEndpoint()`. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
