### PR TITLE
[PM-41438] - Add new errors for taken emails

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/Errors.cs
@@ -28,7 +28,7 @@ public record NewEmailDomainNotClaimedError()
 public record EmailAlreadyInUseError()
     : EmailValidationError("Email already in use.", "email_already_in_use");
 public record EmailAlreadyInUseByAnotherMemberError()
-    : EmailValidationError("Email already in use by another organization member", "email_taken_by_organization_member");
+    : EmailValidationError("Email already in use by another organization member.", "email_taken_by_organization_member");
 public record EmailTakenOutsideOrganizationError()
     : EmailValidationError("Email is already in use outside organization.", "email_taken_outside_organization");
 public record EmailClaimedByAnotherOrganizationError()

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/Errors.cs
@@ -27,8 +27,12 @@ public record NewEmailDomainNotClaimedError()
     : EmailValidationError("The new email address must be on a domain claimed by the organization.", "new_email_domain_not_claimed");
 public record EmailAlreadyInUseError()
     : EmailValidationError("Email already in use.", "email_already_in_use");
+public record EmailAlreadyInUseByAnotherMemberError()
+    : EmailValidationError("Email already in use by another organization member", "email_taken_by_organization_member");
+public record EmailTakenOutsideOrganizationError()
+    : EmailValidationError("Email is already in use outside organization.", "email_taken_outside_organization");
 public record EmailClaimedByAnotherOrganizationError()
-    : EmailValidationError("This email address is claimed by an organization using Bitwarden.", "email_claimed_by_another_organization");
+    : EmailValidationError("This email domain is claimed by an organization using Bitwarden.", "email_claimed_by_another_organization");
 public record EmailChangeFailedError(string Message)
     : EmailValidationError(Message, "email_change_failed");
 

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserValidator.cs
@@ -20,7 +20,9 @@ public class UpdateOrganizationUserValidator(
     IOrganizationUserValidationService organizationUserValidationService,
     ICollectionRepository collectionRepository,
     IGetOrganizationUsersClaimedStatusQuery getOrganizationUsersClaimedStatusQuery,
-    IOrganizationDomainRepository organizationDomainRepository)
+    IOrganizationDomainRepository organizationDomainRepository,
+    IUserRepository userRepository,
+    IOrganizationUserRepository organizationUserRepository)
     : IUpdateOrganizationUserValidator
 {
     public async Task<ValidationResult<UpdateOrganizationUserRequest>> ValidateAsync(
@@ -127,8 +129,7 @@ public class UpdateOrganizationUserValidator(
             return new MemberHasMasterPasswordError();
         }
 
-        var claimedStatus = await getOrganizationUsersClaimedStatusQuery
-            .GetUsersOrganizationClaimedStatusAsync(request.Organization.Id, [organizationUser.Id]);
+        var claimedStatus = await getOrganizationUsersClaimedStatusQuery.GetUsersOrganizationClaimedStatusAsync(request.Organization.Id, [organizationUser.Id]);
         if (!(claimedStatus.TryGetValue(organizationUser.Id, out var isClaimed) && isClaimed))
         {
             return isEmailChanging ? new MemberNotClaimedError() : new NameChangeMemberNotClaimedError();
@@ -143,9 +144,31 @@ public class UpdateOrganizationUserValidator(
             {
                 return new NewEmailDomainNotClaimedError();
             }
+
+            return await ValidateNewEmailNotTakenAsync(request);
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Rejects a new email already owned by another account: <see cref="EmailAlreadyInUseByAnotherMemberError"/>
+    /// when that account is a member of this organization, otherwise <see cref="EmailTakenOutsideOrganizationError"/>.
+    /// </summary>
+    private async Task<Error?> ValidateNewEmailNotTakenAsync(UpdateOrganizationUserRequest request)
+    {
+        var existingUser = await userRepository.GetByEmailAsync(request.NewEmail!);
+        if (existingUser is null || existingUser.Id == request.UserToUpdate!.Id)
+        {
+            return null;
+        }
+
+        var membership = await organizationUserRepository
+            .GetByOrganizationAsync(request.Organization.Id, existingUser.Id);
+
+        return membership is not null
+            ? new EmailAlreadyInUseByAnotherMemberError()
+            : new EmailTakenOutsideOrganizationError();
     }
 
     /// <summary>

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
@@ -461,7 +461,7 @@ public class OrganizationUserControllerPutTests : IClassFixture<ApiApplicationFa
         var response = await _client.PutAsJsonAsync(
             $"organizations/{_organization.Id}/users/{member.Id}", UpdateRequest(email: takenEmail));
 
-        await AssertValidationProblemAsync(response, new EmailAlreadyInUseError());
+        await AssertValidationProblemAsync(response, new EmailAlreadyInUseByAnotherMemberError());
     }
 
     private static HttpStatusCode ExpectedSuccess(bool flagOn) =>

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
@@ -464,6 +464,24 @@ public class OrganizationUserControllerPutTests : IClassFixture<ApiApplicationFa
         await AssertValidationProblemAsync(response, new EmailAlreadyInUseByAnotherMemberError());
     }
 
+    [Fact]
+    public async Task Put_WhenChangingEmailToAddressTakenOutsideOrganization_ReturnsTakenOutsideOrganizationProblemDetails()
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.ChangeMemberEmailNoMp).Returns(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+        var (member, domain) = await CreateClaimedMemberWithoutMasterPasswordAsync();
+
+        // Same-domain address owned by an account that is not a member of the organization, so
+        // domain validation passes and the uniqueness check identifies it as taken outside the org.
+        var takenEmail = $"outsider-{Guid.NewGuid()}@{domain}";
+        await _factory.LoginWithNewAccount(takenEmail);
+
+        var response = await _client.PutAsJsonAsync(
+            $"organizations/{_organization.Id}/users/{member.Id}", UpdateRequest(email: takenEmail));
+
+        await AssertValidationProblemAsync(response, new EmailTakenOutsideOrganizationError());
+    }
+
     private static HttpStatusCode ExpectedSuccess(bool flagOn) =>
         flagOn ? HttpStatusCode.NoContent : HttpStatusCode.OK;
 

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserValidatorTests.cs
@@ -393,6 +393,91 @@ public class UpdateOrganizationUserValidatorTests
 
     [Theory]
     [BitAutoData]
+    public async Task ValidateAsync_WhenNewEmailTakenByAnotherOrganizationMember_ReturnsEmailAlreadyInUseByAnotherMember(
+        SutProvider<UpdateOrganizationUserValidator> sutProvider,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser)
+    {
+        orgUser.UserId = Guid.NewGuid();
+        var userToUpdate = new User { Id = orgUser.UserId!.Value, Email = "member@claimed.example.com" };
+        var request = CreateRequest(sutProvider, orgUser, OrganizationUserType.User,
+            newEmail: "new@claimed.example.com", userToUpdate: userToUpdate);
+
+        sutProvider.GetDependency<IGetOrganizationUsersClaimedStatusQuery>()
+            .GetUsersOrganizationClaimedStatusAsync(orgUser.OrganizationId, Arg.Any<IEnumerable<Guid>>())
+            .Returns(new Dictionary<Guid, bool> { [orgUser.Id] = true });
+        sutProvider.GetDependency<IOrganizationDomainRepository>()
+            .GetVerifiedDomainsByOrganizationIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(new List<OrganizationDomain> { new() { DomainName = "claimed.example.com" } });
+
+        var emailOwner = new User { Id = Guid.NewGuid(), Email = "new@claimed.example.com" };
+        sutProvider.GetDependency<IUserRepository>()
+            .GetByEmailAsync("new@claimed.example.com")
+            .Returns(emailOwner);
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(Arg.Any<Guid>(), emailOwner.Id)
+            .Returns(new OrganizationUser());
+
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<EmailAlreadyInUseByAnotherMemberError>(result.AsError);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_WhenNewEmailTakenOutsideOrganization_ReturnsEmailTakenOutsideOrganization(
+        SutProvider<UpdateOrganizationUserValidator> sutProvider,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser)
+    {
+        orgUser.UserId = Guid.NewGuid();
+        var userToUpdate = new User { Id = orgUser.UserId!.Value, Email = "member@claimed.example.com" };
+        var request = CreateRequest(sutProvider, orgUser, OrganizationUserType.User,
+            newEmail: "new@claimed.example.com", userToUpdate: userToUpdate);
+
+        sutProvider.GetDependency<IGetOrganizationUsersClaimedStatusQuery>()
+            .GetUsersOrganizationClaimedStatusAsync(orgUser.OrganizationId, Arg.Any<IEnumerable<Guid>>())
+            .Returns(new Dictionary<Guid, bool> { [orgUser.Id] = true });
+        sutProvider.GetDependency<IOrganizationDomainRepository>()
+            .GetVerifiedDomainsByOrganizationIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(new List<OrganizationDomain> { new() { DomainName = "claimed.example.com" } });
+
+        var emailOwner = new User { Id = Guid.NewGuid(), Email = "new@claimed.example.com" };
+        sutProvider.GetDependency<IUserRepository>()
+            .GetByEmailAsync("new@claimed.example.com")
+            .Returns(emailOwner);
+
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<EmailTakenOutsideOrganizationError>(result.AsError);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_WhenNewEmailNotTaken_ReturnsValidAndSkipsMembershipLookup(
+        SutProvider<UpdateOrganizationUserValidator> sutProvider,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser)
+    {
+        orgUser.UserId = Guid.NewGuid();
+        var userToUpdate = new User { Id = orgUser.UserId!.Value, Email = "member@claimed.example.com" };
+        var request = CreateRequest(sutProvider, orgUser, OrganizationUserType.User,
+            newEmail: "new@claimed.example.com", userToUpdate: userToUpdate);
+
+        sutProvider.GetDependency<IGetOrganizationUsersClaimedStatusQuery>()
+            .GetUsersOrganizationClaimedStatusAsync(orgUser.OrganizationId, Arg.Any<IEnumerable<Guid>>())
+            .Returns(new Dictionary<Guid, bool> { [orgUser.Id] = true });
+        sutProvider.GetDependency<IOrganizationDomainRepository>()
+            .GetVerifiedDomainsByOrganizationIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(new List<OrganizationDomain> { new() { DomainName = "claimed.example.com" } });
+        // GetByEmailAsync returns null (default) — the new email is free.
+
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task ValidateAsync_WhenChangingNameForClaimedMember_ReturnsValid(
         SutProvider<UpdateOrganizationUserValidator> sutProvider,
         [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser)


### PR DESCRIPTION
## 🎟️ Tracking
[PM-41438](https://bitwarden.atlassian.net/browse/PM-41438)

## 📔 Objective
When attempting to change the email address, if the email is taken by another user we want to be able to inform the current admin if the user is an org member or not. This adds an email uniqueness check outside in the validator so we can determine if the email is taken before attempting to do any changes.

New errors are :

Message: Email already in use by another organization member.
Type string: email_taken_by_organization_member

Message: Email is already in use outside organization.
Type: email_taken_outside_organization

[Clients PR](https://github.com/bitwarden/clients/pull/22220)

[PM-41438]: https://bitwarden.atlassian.net/browse/PM-41438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ