### PR TITLE
[PM-41468] Fix thread-unsafe StringBuilder in Setup Helpers.Exec

### DIFF
--- a/util/Setup/Helpers.cs
+++ b/util/Setup/Helpers.cs
@@ -125,17 +125,28 @@ public static class Helpers
         var process = new Process { StartInfo = startInfo };
 
         var result = new StringBuilder();
+        // OutputDataReceived and ErrorDataReceived are raised on separate threads, so appends to the
+        // shared StringBuilder must be synchronized. Without this lock, simultaneous stdout/stderr
+        // output corrupts the builder's internal buffer and throws
+        // "System.ArgumentException: Destination is too short", crashing the setup process.
+        var resultLock = new object();
 
         process.OutputDataReceived += (_, e) =>
         {
             if (!returnStdout || e.Data == null) return;
-            result.AppendLine(e.Data);
+            lock (resultLock)
+            {
+                result.AppendLine(e.Data);
+            }
         };
 
         process.ErrorDataReceived += (_, e) =>
         {
             if (!returnStderr || e.Data == null) return;
-            result.AppendLine(e.Data);
+            lock (resultLock)
+            {
+                result.AppendLine(e.Data);
+            }
         };
 
         process.Start();


### PR DESCRIPTION
## 🎟️ Tracking

Fixes https://github.com/bitwarden/server/issues/8059
https://bitwarden.atlassian.net/browse/PM-40973
https://bitwarden.atlassian.net/browse/PM-41468

## 📔 Objective

`Helpers.Exec` (`util/Setup/Helpers.cs`) captures a child process's stdout and stderr into a single `StringBuilder`, appending from both the `OutputDataReceived` and `ErrorDataReceived` event handlers:

```csharp
var result = new StringBuilder();

process.OutputDataReceived += (_, e) => { ...; result.AppendLine(e.Data); };
process.ErrorDataReceived  += (_, e) => { ...; result.AppendLine(e.Data); };
```

.NET raises these two events on **separate threads**, and `StringBuilder` is **not thread-safe**. When the child process writes to stdout and stderr at nearly the same moment, the two handler threads call `AppendLine` concurrently and corrupt the builder's internal buffer. This surfaces as an unhandled exception that terminates the setup process:

```
Unhandled exception. System.ArgumentException: Destination is too short. (Parameter 'destination')
   at System.Text.StringBuilder.AppendWithExpansion(Char& value, Int32 valueCount)
   at System.Text.StringBuilder.Append(String value)
   at System.Text.StringBuilder.AppendLine(String value)
   at Bit.Setup.Helpers.<>c__DisplayClass4_0.<Exec>b__0(Object _, DataReceivedEventArgs e) in /source/util/Setup/Helpers.cs:line 132
   ...
```

Observed in the wild during a routine `./bitwarden.sh update` on a self-hosted install (process exited 139). Because it is a race, it is intermittent — it reproduces only when stdout/stderr output interleaves at the wrong moment — which is why the same update succeeds on retry.

**Fix:** guard both appends with a shared lock so the two reader threads can't mutate the `StringBuilder` simultaneously. The change is behaviour-preserving in the normal (non-interleaving) case and does not alter the method's return value.

## 📸 Screenshots

<!-- N/A — no UI changes. -->

---

### Note on tests

This is a concurrency race with no deterministic unit test: reproducing it requires a child process that emits heavily interleaved stdout+stderr and relies on thread-scheduling timing, so any test would be probabilistic/flaky. The fix is small and correct by inspection (serializing access to a non-thread-safe `StringBuilder`). Happy to add a stress-style test that runs such a subprocess in a loop if the team would like one.
