### PR TITLE
PM-41426: PM and SM select for sales-assisted trials

### DIFF
--- a/src/Admin/Auth/Controllers/SalesAssistedTrialController.cs
+++ b/src/Admin/Auth/Controllers/SalesAssistedTrialController.cs
@@ -31,11 +31,11 @@ public class SalesAssistedTrialController(
         // Defaults reflect the most common sales-assisted trial shape. They are applied only
         // here, on the initial GET — never as property initializers on the model itself — so a
         // POST redisplay always reflects exactly what the user submitted, never a reasserted
-        // default (see Products, which has no hidden-input fallback for an all-unchecked submit).
+        // default.
         return View(new SalesAssistedTrialInviteModel
         {
             ProductTier = ProductTierType.Enterprise,
-            Products = new List<ProductType> { ProductType.PasswordManager },
+            Product = ProductType.PasswordManager,
             TrialLength = 30
         });
     }
@@ -54,12 +54,18 @@ public class SalesAssistedTrialController(
 
         try
         {
+            // Client /trial-initiation prioritizes a single product via parseInt
+            // and Secrets Manager trial initiation also provides Password Manager trial
+            // initiation at the selected product tier. PM-41426
+            // Self-service trial command has an IEnumerable shape for Product_s_, however
+            // to ensure proper parsing and enrollment, sales-assisted will enforce a
+            // single product selection policy.
             await sendCommand.HandleAsync(
                 model.Email,
                 model.Name,
                 senderEmail,
                 model.ProductTier,
-                model.Products,
+                new[] { model.Product },
                 model.TrialLength);
         }
         catch (BadRequestException ex)

--- a/src/Admin/Auth/Controllers/SalesAssistedTrialController.cs
+++ b/src/Admin/Auth/Controllers/SalesAssistedTrialController.cs
@@ -57,7 +57,7 @@ public class SalesAssistedTrialController(
             // Client /trial-initiation prioritizes a single product via parseInt
             // and Secrets Manager trial initiation also provides Password Manager trial
             // initiation at the selected product tier. PM-41426
-            // Self-service trial command has an IEnumerable shape for Product_s_, however
+            // Self-service trial command has an IEnumerable shape for Product(s), however
             // to ensure proper parsing and enrollment, sales-assisted will enforce a
             // single product selection policy.
             await sendCommand.HandleAsync(

--- a/src/Admin/Auth/Models/SalesAssistedTrial/SalesAssistedTrialInviteModel.cs
+++ b/src/Admin/Auth/Models/SalesAssistedTrial/SalesAssistedTrialInviteModel.cs
@@ -16,8 +16,7 @@ public class SalesAssistedTrialInviteModel : IValidatableObject
     public ProductTierType ProductTier { get; set; }
 
     [Required]
-    [MinLength(1)]
-    public IEnumerable<ProductType> Products { get; set; } = null!;
+    public ProductType Product { get; set; }
 
     [Display(Name = "Trial Length (Days)")]
     [Required]
@@ -31,6 +30,16 @@ public class SalesAssistedTrialInviteModel : IValidatableObject
             yield return new ValidationResult(
                 "Teams Starter is no longer available for new trials.",
                 [nameof(ProductTier)]);
+        }
+
+        if (ProductTier == ProductTierType.Families && Product == ProductType.SecretsManager)
+        {
+            // Current constraint of Families plan, hard-coded validation here for
+            // fail-fast feedback to tool users.
+            // PM-41426
+            yield return new ValidationResult(
+                "Secrets Manager is not available for the Families plan.",
+                [nameof(Product)]);
         }
     }
 }

--- a/src/Admin/Auth/Views/SalesAssistedTrial/Index.cshtml
+++ b/src/Admin/Auth/Views/SalesAssistedTrial/Index.cshtml
@@ -55,14 +55,14 @@
         </div>
 
         <div class="mb-3">
-            <label class="form-label">Products</label>
-            <span asp-validation-for="Products" class="text-danger"></span>
+            <label class="form-label">Product</label>
+            <span asp-validation-for="Product" class="text-danger"></span>
             @foreach (var product in Enum.GetValues<ProductType>())
             {
                 <div class="form-check">
-                    <input type="checkbox" name="Products" value="@product" id="product-@product" class="form-check-input"
-                           checked="@(Model.Products != null && Model.Products.Contains(product))" />
-                    <label for="product-@product" class="form-check-label">@product</label>
+                    <input type="radio" name="Product" value="@product" id="product-@product" class="form-check-input"
+                           checked="@(Model.Product == product)" />
+                    <label for="product-@product" class="form-check-label">@(product.GetDisplayAttribute()?.GetName() ?? product.ToString())</label>
                 </div>
             }
         </div>

--- a/test/Admin.Test/Auth/Controllers/SalesAssistedTrialControllerTests.cs
+++ b/test/Admin.Test/Auth/Controllers/SalesAssistedTrialControllerTests.cs
@@ -26,7 +26,7 @@ public class SalesAssistedTrialControllerTests
         Email = "prospect@example.com",
         Name = "Prospect Company",
         ProductTier = ProductTierType.Enterprise,
-        Products = new[] { ProductType.PasswordManager },
+        Product = ProductType.PasswordManager,
         TrialLength = 14
     };
 
@@ -52,7 +52,7 @@ public class SalesAssistedTrialControllerTests
         var viewResult = Assert.IsType<ViewResult>(result);
         var model = Assert.IsType<SalesAssistedTrialInviteModel>(viewResult.Model);
         Assert.Equal(ProductTierType.Enterprise, model.ProductTier);
-        Assert.Equal(new[] { ProductType.PasswordManager }, model.Products);
+        Assert.Equal(ProductType.PasswordManager, model.Product);
         Assert.Equal(30, model.TrialLength);
     }
 
@@ -76,7 +76,7 @@ public class SalesAssistedTrialControllerTests
                 model.Name,
                 SenderEmail,
                 model.ProductTier,
-                model.Products,
+                Arg.Is<IEnumerable<ProductType>>(products => products.SequenceEqual(new[] { model.Product })),
                 model.TrialLength);
     }
 
@@ -106,7 +106,7 @@ public class SalesAssistedTrialControllerTests
         SutProvider<SalesAssistedTrialController> sutProvider)
     {
         var model = BuildValidModel();
-        model.Products = new[] { ProductType.SecretsManager };
+        model.Product = ProductType.SecretsManager;
         SetUpAuthenticatedSender(sutProvider);
         sutProvider.Sut.ModelState.AddModelError(nameof(model.Email), "The Email field is required.");
 
@@ -116,7 +116,7 @@ public class SalesAssistedTrialControllerTests
         // Ensure when a model is returned to the view for validation errors (POST round-trip)
         // that user's choices are persisted; the defaults do not change their prior selections.
         var redisplayedModel = Assert.IsType<SalesAssistedTrialInviteModel>(viewResult.Model);
-        Assert.Equal(model.Products, redisplayedModel.Products);
+        Assert.Equal(model.Product, redisplayedModel.Product);
 
         await sutProvider.GetDependency<ISendSalesAssistedTrialInvitationCommand>()
             .DidNotReceiveWithAnyArgs()

--- a/test/Admin.Test/Auth/Models/SalesAssistedTrial/SalesAssistedTrialInviteModelTests.cs
+++ b/test/Admin.Test/Auth/Models/SalesAssistedTrial/SalesAssistedTrialInviteModelTests.cs
@@ -11,7 +11,7 @@ public class SalesAssistedTrialInviteModelTests
         Email = "prospect@example.com",
         Name = "Prospect Company",
         ProductTier = ProductTierType.Enterprise,
-        Products = new[] { ProductType.PasswordManager },
+        Product = ProductType.PasswordManager,
         TrialLength = 30,
     };
 
@@ -37,6 +37,35 @@ public class SalesAssistedTrialInviteModelTests
     {
         var model = BuildValidModel();
         model.ProductTier = productTier;
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Empty(results);
+    }
+
+    // Current constraint of Families plan, appears as validation in the model for
+    // fail-fast feedback to tool users.
+    // PM-41426
+    [Fact]
+    public void Validate_WhenProductTierIsFamiliesAndProductIsSecretsManager_ReturnsError()
+    {
+        var model = BuildValidModel();
+        model.ProductTier = ProductTierType.Families;
+        model.Product = ProductType.SecretsManager;
+
+        var results = model.Validate(new ValidationContext(model)).ToList();
+
+        Assert.Single(results);
+        Assert.Contains("Families", results[0].ErrorMessage);
+        Assert.Contains(nameof(model.Product), results[0].MemberNames);
+    }
+
+    [Fact]
+    public void Validate_WhenProductTierIsFreeAndProductIsSecretsManager_NoError()
+    {
+        var model = BuildValidModel();
+        model.ProductTier = ProductTierType.Free;
+        model.Product = ProductType.SecretsManager;
 
         var results = model.Validate(new ValidationContext(model)).ToList();
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41426](https://bitwarden.atlassian.net/browse/PM-41426)

## 📔 Objective

Solve an issue where the client `/trial-initiation` stepper could drop Secrets Manager enrollment for a trial when Password Manager was also selected (multi-product choice). Admin tool is now restricted to a single product choice; the stepper enrolls trials in Password Manager when Secrets Manager is selected. See ticket [PM-41426](https://bitwarden.atlassian.net/browse/PM-41426) for more details.

## 📸 Screenshots

Multiple screenshots expressing all paths available on ticket [PM-41426](https://bitwarden.atlassian.net/browse/PM-41426).


[PM-41426]: https://bitwarden.atlassian.net/browse/PM-41426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-41426]: https://bitwarden.atlassian.net/browse/PM-41426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-41426]: https://bitwarden.atlassian.net/browse/PM-41426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ