### PR TITLE
[BRE-2157] ci(build): Centralize Docker image tag sanitization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ permissions:
 env:
   _AZ_REGISTRY: "bitwardenprod.azurecr.io"
   _GHCR_REGISTRY: "ghcr.io/bitwarden"
-  _GITHUB_PR_REPO_NAME: ${{ github.event.pull_request.head.repo.full_name }}
 
 jobs:
   lint:
@@ -199,24 +198,15 @@ jobs:
       ########## Generate image tag and build Docker image ##########
       - name: Generate Docker image tag
         id: tag
+        uses: bitwarden/gh-actions/sanitize-image-tag@main
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fork_repo: ${{ github.event.pull_request.head.repo.fork == true && github.event.pull_request.head.repo.full_name || '' }}
+
+      - name: Report Docker image tag
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" || "${GITHUB_EVENT_NAME}" == "pull_request_target" ]]; then
-            IMAGE_TAG=$(echo "${GITHUB_HEAD_REF}" | sed "s/[^a-zA-Z0-9]/-/g") # Sanitize branch name to alphanumeric only
-          else
-            IMAGE_TAG=$(echo "${GITHUB_REF:11}" | sed "s#/#-#g")
-          fi
-
-          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
-            SANITIZED_REPO_NAME=$(echo "$_GITHUB_PR_REPO_NAME" | sed "s/[^a-zA-Z0-9]/-/g") # Sanitize repo name to alphanumeric only
-            IMAGE_TAG=$SANITIZED_REPO_NAME-$IMAGE_TAG # Add repo name to the tag
-          fi
-
-          if [[ "$IMAGE_TAG" == "main" ]]; then
-            IMAGE_TAG=dev
-          fi
-
-          IMAGE_TAG=${IMAGE_TAG:0:128} # Limit image tags to 128 chars
-          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
           echo "### :mega: Docker Image Tag: $IMAGE_TAG" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up project name
@@ -231,7 +221,7 @@ jobs:
       - name: Generate image tags(s)
         id: image-tags
         env:
-          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
           PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
           SHA: ${{ github.sha }}
         run: |
@@ -289,7 +279,7 @@ jobs:
       - name: Generate image manifest fragment
         env:
           PROJECT_NAME: ${{ steps.setup.outputs.project_name }}
-          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
           DIGEST: ${{ steps.build-artifacts.outputs.digest }}
           TAGS: ${{ steps.image-tags.outputs.tags }}
         run: |


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2157](https://bitwarden.atlassian.net/browse/BRE-2157)

Example of the resulting deploy failure: [devops run 30939160891](https://github.com/bitwarden/devops/actions/runs/30939160891/job/92097267990) — `ERROR: the specified tag does not exist`.

## 📔 Objective

The tag a build publishes and the tag a deploy requests are derived by two separate implementations.

`build-docker` computed its tag locally, collapsing every non-alphanumeric character to a dash on `pull_request` events.`devops/deploy-k8s.yml` derives the same tag independently and preserves dots. Branch `billing/pm-36225/upgrade-stripe-sdk-to-51.1.0` was published as `...-51-1-0` but requested as `...-51.1.0`, so the ACR digest lookup failed and the deploy aborted. Every branch containing a dot fails this way.

Fixed here rather than in devops because `sanitize-image-tag` preserves dots, so deploy already agrees with it. This workflow was the outlier, and only partly so: the `bitwarden-lite` jobs below already call the action. Patching a regex on either side would restore agreement today while leaving two implementations to drift again.
* Use `sanitize-image-tag` for the `build-docker` tag, and read its `tag` output in place of the removed `image_tag`
* Move the step summary echo into its own step
* Drop `_GITHUB_PR_REPO_NAME`, whose only consumer was the removed fork-repo sed; the action takes `fork_repo` directly

Tags for `main`, `rc` and `hotfix-rc` are unchanged. Branches with a dot or underscore, and fork PRs, now resolve to a different tag and need a rebuild before they can be deployed.

[BRE-2157]: https://bitwarden.atlassian.net/browse/BRE-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ