### PR TITLE
QA-2270: add OrganizationGroupScene to the seeder

### DIFF
--- a/util/Seeder/Scenes/OrganizationGroupScene.cs
+++ b/util/Seeder/Scenes/OrganizationGroupScene.cs
@@ -7,10 +7,6 @@ using Bit.Seeder.Services;
 
 namespace Bit.Seeder.Scenes;
 
-/// <summary>
-/// Creates an organization group, optionally adds organization users as members, and optionally grants the
-/// group access to existing collections with per-assignment permissions.
-/// </summary>
 public class OrganizationGroupScene(
     IOrganizationRepository organizationRepository,
     IGroupRepository groupRepository,
@@ -22,16 +18,10 @@ public class OrganizationGroupScene(
         public required Guid OrganizationId { get; set; }
         [Required]
         public required string Name { get; set; }
-        /// <summary>
-        /// <c>OrganizationUser.Id</c> values (not <c>User.Id</c>) to add to the group as members after creation.
-        /// </summary>
         public IEnumerable<Guid>? OrganizationUserIds { get; set; }
         public IEnumerable<AccessSelectionRequest>? Collections { get; set; }
     }
 
-    /// <summary>
-    /// A collection access grant for the new group. <see cref="Id"/> is the <c>Collection.Id</c> the group is granted access to.
-    /// </summary>
     public class AccessSelectionRequest
     {
         [Required]

--- a/util/Seeder/Scenes/OrganizationGroupScene.cs
+++ b/util/Seeder/Scenes/OrganizationGroupScene.cs
@@ -1,0 +1,87 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Models.Data;
+using Bit.Core.Repositories;
+using Bit.Seeder.Factories;
+using Bit.Seeder.Services;
+
+namespace Bit.Seeder.Scenes;
+
+/// <summary>
+/// Creates an organization group, optionally adds organization users as members, and optionally grants the
+/// group access to existing collections with per-assignment permissions.
+/// </summary>
+public class OrganizationGroupScene(
+    IOrganizationRepository organizationRepository,
+    IGroupRepository groupRepository,
+    IManglerService manglerService) : IScene<OrganizationGroupScene.Request, OrganizationGroupScene.Result>
+{
+    public class Request
+    {
+        [Required]
+        public required Guid OrganizationId { get; set; }
+        [Required]
+        public required string Name { get; set; }
+        /// <summary>
+        /// <c>OrganizationUser.Id</c> values (not <c>User.Id</c>) to add to the group as members after creation.
+        /// </summary>
+        public IEnumerable<Guid>? OrganizationUserIds { get; set; }
+        public IEnumerable<AccessSelectionRequest>? Collections { get; set; }
+    }
+
+    /// <summary>
+    /// A collection access grant for the new group. <see cref="Id"/> is the <c>Collection.Id</c> the group is granted access to.
+    /// </summary>
+    public class AccessSelectionRequest
+    {
+        [Required]
+        public required Guid Id { get; set; }
+        [Required]
+        public bool ReadOnly { get; set; }
+        [Required]
+        public bool HidePasswords { get; set; }
+        [Required]
+        public bool Manage { get; set; }
+    }
+
+    public class Result
+    {
+        public required Guid GroupId { get; init; }
+    }
+
+    public async Task<SceneResult<Result>> SeedAsync(Request request)
+    {
+        var organization = await organizationRepository.GetByIdAsync(request.OrganizationId);
+        if (organization == null)
+        {
+            throw new InvalidOperationException($"Organization {request.OrganizationId} not found.");
+        }
+
+        var group = GroupSeeder.Create(organization.Id, request.Name);
+
+        var collections = MapAccessSelections(request.Collections);
+
+        await groupRepository.CreateAsync(group, collections ?? []);
+
+        if (request.OrganizationUserIds?.Any() == true)
+        {
+            await groupRepository.AddGroupUsersByIdAsync(group.Id, request.OrganizationUserIds, DateTime.UtcNow);
+        }
+
+        return new SceneResult<Result>(
+            result: new Result
+            {
+                GroupId = group.Id
+            },
+            mangleMap: manglerService.GetMangleMap());
+    }
+
+    private static IEnumerable<CollectionAccessSelection>? MapAccessSelections(IEnumerable<AccessSelectionRequest>? selections)
+        => selections?.Select(s => new CollectionAccessSelection
+        {
+            Id = s.Id,
+            ReadOnly = s.ReadOnly,
+            HidePasswords = s.HidePasswords,
+            Manage = s.Manage
+        });
+}


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/QA-2270

## 📔 Objective
The SeederApi can create organizations, members, and collections, but has no way to create a group. This blocks per-test seeding for any test that needs a group. This adds `OrganizationGroupScene`, mirroring the existing `OrganizationCollectionScene`: it creates a group, optionally adds members, and optionally grants the group access to existing collections. The underlying pieces already existed (`GroupSeeder.Create`, `IGroupRepository.CreateAsync`, `AddGroupUsersByIdAsync`); this exposes them as a scene, which the reflection-based scene registration picks up automatically by class name.

Verified by clean build (0 warnings, warnings-as-errors on), `dotnet format --verify-no-changes`, and the code-review agent pass. No scene has a dedicated test harness in this repo (18 of 19 sibling scenes are untested), so no unit test was added, consistent with existing precedent.