### PR TITLE
[PM-22405] - Remove invalid users from invites

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
@@ -38,8 +38,8 @@ public class SendOrganizationInvitesCommand(
     }
 
     /// <summary>
-    /// Returns the invitable org users, resolving a missing email in memory from the linked user (via UserId) and
-    /// logging then excluding any that still lack one. SSO JIT provisioning can leave such invalid invited rows.
+    /// Returns the invitable org users, resolving a missing email from the linked user (via UserId), and
+    /// logging then excluding any that still lack one.
     /// </summary>
     private async Task<List<OrganizationUser>> ValidateInvitedUsersAsync(OrganizationUser[] requestedOrgUsers)
     {

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
@@ -26,7 +26,7 @@ public class SendOrganizationInvitesCommand(
 {
     public async Task SendInvitesAsync(SendInvitesRequest request)
     {
-        var orgUsers = await ValidateAndRepairInvitedUsersAsync(request.Users);
+        var orgUsers = await ValidateInvitedUsersAsync(request.Users);
         if (orgUsers.Count == 0)
         {
             return;
@@ -38,16 +38,10 @@ public class SendOrganizationInvitesCommand(
     }
 
     /// <summary>
-    /// Validates the list of invited organization users. If the user does not have an email address (invalid state), this
-    /// attempts to retrieve the email from an existing User record based on the UserId if it exists. If no userId is
-    /// populated, the invalid organization user is logged.
+    /// Returns the invitable org users, resolving a missing email in memory from the linked user (via UserId) and
+    /// logging then excluding any that still lack one. SSO JIT provisioning can leave such invalid invited rows.
     /// </summary>
-    /// <remarks>
-    /// SSO JIT provisioning can leave an invalid invited row (Email null, UserId populated). If any invalid invited organization
-    /// users are encountered, the record will be corrected. The email will be set using the existing tie to the user
-    /// (via UserId), and the UserId will be set to null. This will put the organization user into the normal invite flow.
-    /// </remarks>
-    private async Task<List<OrganizationUser>> ValidateAndRepairInvitedUsersAsync(OrganizationUser[] requestedOrgUsers)
+    private async Task<List<OrganizationUser>> ValidateInvitedUsersAsync(OrganizationUser[] requestedOrgUsers)
     {
         var missingEmailUserIds = requestedOrgUsers
             .Where(ou => string.IsNullOrWhiteSpace(ou.Email) && ou.UserId.HasValue)
@@ -59,64 +53,43 @@ public class SendOrganizationInvitesCommand(
             : (await userRepository.GetManyAsync(missingEmailUserIds)).ToDictionary(user => user.Id);
 
         var invitable = new List<OrganizationUser>();
-        var repaired = new List<OrganizationUser>();
 
         foreach (var orgUser in requestedOrgUsers)
         {
-            if (ResolveEmail(orgUser, linkedUsersById) is not { } resolved)
+            if (!TryResolveEmail(orgUser, linkedUsersById))
             {
                 logger.LogUserInviteStateDiagnostics(orgUser);
                 continue;
             }
 
-            invitable.Add(resolved.OrganizationUser);
-            if (resolved.ToUpdate)
-            {
-                repaired.Add(resolved.OrganizationUser);
-            }
-        }
-
-        if (repaired.Count != 0)
-        {
-            await organizationUserRepository.ReplaceManyAsync(repaired);
+            invitable.Add(orgUser);
         }
 
         return invitable;
     }
 
-    /// <summary>
-    /// Resolves an organization user's email, repairing it from its linked user when possible.
-    /// </summary>
-    /// <returns>
-    /// An <see cref="OrganizationUserToSendInvite"/> with <c>ToUpdate</c> set when the email was repaired
-    /// (Email set, UserId cleared), or null when the org user has no usable email.
-    /// </returns>
-    private static OrganizationUserToSendInvite? ResolveEmail(OrganizationUser orgUser, Dictionary<Guid, User> linkedUsersById)
+    private static bool TryResolveEmail(OrganizationUser orgUser, Dictionary<Guid, User> linkedUsersById)
     {
         if (!string.IsNullOrWhiteSpace(orgUser.Email))
         {
-            return new OrganizationUserToSendInvite(orgUser, ToUpdate: false);
+            return true;
         }
 
         if (orgUser.UserId.HasValue && linkedUsersById.TryGetValue(orgUser.UserId.Value, out var linkedUser) &&
             !string.IsNullOrWhiteSpace(linkedUser.Email))
         {
             orgUser.Email = linkedUser.Email;
-            return new OrganizationUserToSendInvite(orgUser, ToUpdate: true);
+            return true;
         }
 
-        return null;
+        return false;
     }
-
-    private readonly record struct OrganizationUserToSendInvite(OrganizationUser OrganizationUser, bool ToUpdate);
 
     private async Task<OrganizationInvitesInfo> BuildOrganizationInvitesInfoAsync(List<OrganizationUser> orgUsers, Organization organization, bool initOrganization, string? inviterEmail)
     {
         // Email links must include information about the org and user for us to make routing decisions client side
         // Given an org user, determine if existing BW user exists
-        var existingUsers = await userRepository.GetManyByEmailsAsync([
-            .. orgUsers.Where(ou => !string.IsNullOrWhiteSpace(ou.Email)).Select(ou => ou.Email!)
-        ]);
+        var existingUsers = await userRepository.GetManyByEmailsAsync([.. orgUsers.Select(ou => ou.Email!)]);
 
         // hash existing users emails list for O(1) lookups
         var existingUserEmailsHashSet = new HashSet<string>(existingUsers.Select(u => u.Email),

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
@@ -46,10 +46,10 @@ public class SendOrganizationInvitesCommand(
     /// Self-heals invited org users missing their email, then returns the users and emails that can be invited.
     /// </summary>
     /// <remarks>
-    /// SSO JIT provisioning can leave a corrupt invited row (Email null, UserId populated). The email must be
-    /// persisted, not just patched in memory, because the invite token is re-validated against the stored email at
-    /// accept time. When the row has a UserId we recover the email from that user, null the UserId to restore the
-    /// canonical invited shape, and persist the repair. Rows that cannot be repaired are logged and dropped.
+    /// SSO JIT provisioning can leave a corrupt invited row (Email null, UserId populated). If any invalid invited organization
+    /// users ane encountered, the record will be "healed". This is done by setting the Email on the OrgUser record so that
+    /// the token can validate when being sent back. UserId is retained and the orgUser is still technically invalid. However,
+    /// this will work for the SSO login flow.
     /// </remarks>
     private async Task<(List<OrganizationUser> OrgUsers, List<string> Emails)> RepairAndFilterUsersWithoutEmailAsync(
         OrganizationUser[] requestedOrgUsers)

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
@@ -5,6 +5,7 @@ using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
+using Bit.Core.AdminConsole.Utilities.DebuggingInstruments;
 using Bit.Core.Auth.Models.Business;
 using Bit.Core.Auth.Models.Business.Tokenables;
 using Bit.Core.Auth.Repositories;
@@ -13,6 +14,7 @@ using Bit.Core.Models.Mail;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Tokens;
+using Microsoft.Extensions.Logging;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers;
 
@@ -22,40 +24,77 @@ public class SendOrganizationInvitesCommand(
     IPolicyQuery policyQuery,
     IOrgUserInviteTokenableFactory orgUserInviteTokenableFactory,
     IDataProtectorTokenFactory<OrgUserInviteTokenable> dataProtectorTokenFactory,
-    IMailService mailService) : ISendOrganizationInvitesCommand
+    IMailService mailService,
+    ILogger<SendOrganizationInvitesCommand> logger) : ISendOrganizationInvitesCommand
 {
     public async Task SendInvitesAsync(SendInvitesRequest request)
     {
+        var (orgUsers, orgUserEmails) = ExcludeUsersWithoutEmail(request.Users);
+        if (orgUsers.Count == 0)
+        {
+            return;
+        }
+
         var inviterEmail = await GetInviterEmailAsync(request.InvitingUserId);
         var orgInvitesInfo = await BuildOrganizationInvitesInfoAsync(
-            request.Users, request.Organization, request.InitOrganization, inviterEmail);
+            orgUsers, orgUserEmails, request.Organization, request.InitOrganization, inviterEmail);
         await mailService.SendUpdatedOrganizationInviteEmailsAsync(orgInvitesInfo);
     }
 
-    private async Task<OrganizationInvitesInfo> BuildOrganizationInvitesInfoAsync(IEnumerable<OrganizationUser> orgUsers,
-        Organization organization, bool initOrganization = false, string inviterEmail = null)
+    /// <summary>
+    /// Removes Organizations Users that do not have an Email address.
+    /// </summary>
+    /// <remarks>
+    /// An invited org user is expected to have an email address, but SSO JIT provisioning can leave it
+    /// null. We attempt to get the existing users, a NULL value throws an error when mapping to the Emails parameter.
+    ///
+    /// Attempting to use the existing User record by populated UserId would also result in a failure because when
+    /// validating the token, we would fail to look up the organization user with the Email from the User record.
+    /// Instead, we are opting to dropping the users from the invites to be sent, and we'll log the invalid state for
+    /// a more complete bug fix.
+    /// </remarks>
+    private (List<OrganizationUser> OrgUsers, List<string> Emails) ExcludeUsersWithoutEmail(
+        OrganizationUser[] requestedOrgUsers)
     {
-        // Materialize the sequence into a list to avoid multiple enumeration warnings
-        var orgUsersList = orgUsers.ToList();
+        var (orgUsers, emails) = requestedOrgUsers.Aggregate(
+            (OrgUsers: new List<OrganizationUser>(), Emails: new List<string>()),
+            (aggregate, orgUser) =>
+            {
+                if (string.IsNullOrWhiteSpace(orgUser.Email))
+                {
+                    logger.LogUserInviteStateDiagnostics(orgUser);
+                    return aggregate;
+                }
 
+                aggregate.OrgUsers.Add(orgUser);
+                aggregate.Emails.Add(orgUser.Email);
+                return aggregate;
+            });
+
+        return (orgUsers, emails);
+    }
+
+    private async Task<OrganizationInvitesInfo> BuildOrganizationInvitesInfoAsync(List<OrganizationUser> orgUsers,
+        List<string> orgUserEmails, Organization organization, bool initOrganization, string inviterEmail)
+    {
         // Email links must include information about the org and user for us to make routing decisions client side
         // Given an org user, determine if existing BW user exists
-        var orgUserEmails = orgUsersList.Select(ou => ou.Email).ToList();
         var existingUsers = await userRepository.GetManyByEmailsAsync(orgUserEmails);
 
         // hash existing users emails list for O(1) lookups
-        var existingUserEmailsHashSet = new HashSet<string>(existingUsers.Select(u => u.Email));
+        var existingUserEmailsHashSet = new HashSet<string>(existingUsers.Select(u => u.Email),
+            StringComparer.OrdinalIgnoreCase);
 
-        // Create a dictionary of org user guids and bools for whether or not they have an existing BW user
-        var orgUserHasExistingUserDict = orgUsersList.ToDictionary(
+        // Create a dictionary of org user guids and bools for whether they have an existing BW user
+        var orgUserHasExistingUserDict = orgUsers.ToDictionary(
             ou => ou.Id,
             ou => existingUserEmailsHashSet.Contains(ou.Email)
         );
 
-        // Determine if org has SSO enabled and if user is required to login with SSO
+        // Determine if org has SSO enabled and if user is required to log in with SSO
         // Note: we only want to call the DB after checking if the org can use SSO per plan and if they have any policies enabled.
         var orgSsoEnabled = organization.UseSso && (await ssoConfigurationRepository.GetByOrganizationIdAsync(organization.Id))?.Enabled == true;
-        // Even though the require SSO policy can be turned on regardless of SSO being enabled, for this logic, we only
+        // Even though the Require SSO policy can be turned on regardless of SSO being enabled, for this logic, we only
         // need to check the policy if the org has SSO enabled.
         var orgSsoLoginRequiredPolicyEnabled = orgSsoEnabled &&
                                                organization.UsePolicies &&
@@ -70,7 +109,8 @@ public class SendOrganizationInvitesCommand(
             return (orgUser, new ExpiringToken(protectedToken, orgUserInviteTokenable.ExpirationDate));
         }
 
-        var orgUsersWithExpTokens = orgUsers.Select(MakeOrgUserExpiringTokenPair);
+        // Materialized so that consumers enumerating more than once do not mint a new token each time
+        var orgUsersWithExpTokens = orgUsers.Select(MakeOrgUserExpiringTokenPair).ToList();
 
         return new OrganizationInvitesInfo(
             organization,

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
@@ -1,7 +1,4 @@
-﻿// FIXME: Update this file to be null safe and then delete the line below
-#nullable disable
-
-using Bit.Core.AdminConsole.Entities;
+﻿using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers.Models;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
@@ -20,7 +17,6 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUse
 
 public class SendOrganizationInvitesCommand(
     IUserRepository userRepository,
-    IOrganizationUserRepository organizationUserRepository,
     ISsoConfigRepository ssoConfigurationRepository,
     IPolicyQuery policyQuery,
     IOrgUserInviteTokenableFactory orgUserInviteTokenableFactory,
@@ -30,66 +26,54 @@ public class SendOrganizationInvitesCommand(
 {
     public async Task SendInvitesAsync(SendInvitesRequest request)
     {
-        var (orgUsers, orgUserEmails) = await RepairAndFilterUsersWithoutEmailAsync(request.Users);
+        var orgUsers = await ValidateAndRepairInvitedUsersAsync(request.Users);
         if (orgUsers.Count == 0)
         {
             return;
         }
 
         var inviterEmail = await GetInviterEmailAsync(request.InvitingUserId);
-        var orgInvitesInfo = await BuildOrganizationInvitesInfoAsync(
-            orgUsers, orgUserEmails, request.Organization, request.InitOrganization, inviterEmail);
+        var orgInvitesInfo = await BuildOrganizationInvitesInfoAsync(orgUsers, request.Organization, request.InitOrganization, inviterEmail);
         await mailService.SendUpdatedOrganizationInviteEmailsAsync(orgInvitesInfo);
     }
 
     /// <summary>
-    /// Self-heals invited org users missing their email, then returns the users and emails that can be invited.
+    /// Validates the list of invited organization users. If the user does not have an email address (invalid state), this
+    /// attempts to retrieve the email from an existing User record based on the UserId if it exists. If no userId is
+    /// populated, the invalid organization user is logged.
     /// </summary>
     /// <remarks>
-    /// SSO JIT provisioning can leave a corrupt invited row (Email null, UserId populated). If any invalid invited organization
-    /// users ane encountered, the record will be "healed". This is done by setting the Email on the OrgUser record so that
-    /// the token can validate when being sent back. UserId is retained and the orgUser is still technically invalid. However,
-    /// this will work for the SSO login flow.
+    /// SSO JIT provisioning can leave an invalid invited row (Email null, UserId populated). If any invalid invited organization
+    /// users are encountered, the record will be corrected. The email will be set using the existing tie to the user
+    /// (via UserId), and the UserId will be set to null. This will put the organization user into the normal invite flow.
     /// </remarks>
-    private async Task<(List<OrganizationUser> OrgUsers, List<string> Emails)> RepairAndFilterUsersWithoutEmailAsync(
-        OrganizationUser[] requestedOrgUsers)
+    private async Task<List<OrganizationUser>> ValidateAndRepairInvitedUsersAsync(OrganizationUser[] requestedOrgUsers)
     {
-        var missingEmail = requestedOrgUsers.Where(ou => string.IsNullOrWhiteSpace(ou.Email)).ToList();
+        var missingEmailUserIds = requestedOrgUsers
+            .Where(ou => string.IsNullOrWhiteSpace(ou.Email) && ou.UserId.HasValue)
+            .Select(ou => ou.UserId!.Value)
+            .ToList();
 
-        if (missingEmail.Count == 0)
-        {
-            return (requestedOrgUsers.ToList(), requestedOrgUsers.Select(ou => ou.Email).ToList());
-        }
+        var linkedUsersById = missingEmailUserIds.Count == 0
+            ? new Dictionary<Guid, User>()
+            : (await userRepository.GetManyAsync(missingEmailUserIds)).ToDictionary(user => user.Id);
 
-        var linkedUsersById = (await userRepository.GetManyAsync(
-                missingEmail.Where(ou => ou.UserId.HasValue).Select(ou => ou.UserId.Value)))
-            .ToDictionary(user => user.Id);
-
+        var invitable = new List<OrganizationUser>();
         var repaired = new List<OrganizationUser>();
-        var orgUsers = new List<OrganizationUser>();
-        var emails = new List<string>();
 
         foreach (var orgUser in requestedOrgUsers)
         {
-            if (!string.IsNullOrWhiteSpace(orgUser.Email))
+            if (ResolveEmail(orgUser, linkedUsersById) is not { } resolved)
             {
-                orgUsers.Add(orgUser);
-                emails.Add(orgUser.Email);
+                logger.LogUserInviteStateDiagnostics(orgUser);
                 continue;
             }
 
-            if (orgUser.UserId.HasValue &&
-                linkedUsersById.TryGetValue(orgUser.UserId.Value, out var linkedUser) &&
-                !string.IsNullOrWhiteSpace(linkedUser.Email))
+            invitable.Add(resolved.OrganizationUser);
+            if (resolved.ToUpdate)
             {
-                orgUser.Email = linkedUser.Email;
-                repaired.Add(orgUser);
-                orgUsers.Add(orgUser);
-                emails.Add(orgUser.Email);
-                continue;
+                repaired.Add(resolved.OrganizationUser);
             }
-
-            logger.LogUserInviteStateDiagnostics(orgUser);
         }
 
         if (repaired.Count != 0)
@@ -97,15 +81,42 @@ public class SendOrganizationInvitesCommand(
             await organizationUserRepository.ReplaceManyAsync(repaired);
         }
 
-        return (orgUsers, emails);
+        return invitable;
     }
 
-    private async Task<OrganizationInvitesInfo> BuildOrganizationInvitesInfoAsync(List<OrganizationUser> orgUsers,
-        List<string> orgUserEmails, Organization organization, bool initOrganization, string inviterEmail)
+    /// <summary>
+    /// Resolves an organization user's email, repairing it from its linked user when possible.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="OrganizationUserToSendInvite"/> with <c>ToUpdate</c> set when the email was repaired
+    /// (Email set, UserId cleared), or null when the org user has no usable email.
+    /// </returns>
+    private static OrganizationUserToSendInvite? ResolveEmail(OrganizationUser orgUser, Dictionary<Guid, User> linkedUsersById)
+    {
+        if (!string.IsNullOrWhiteSpace(orgUser.Email))
+        {
+            return new OrganizationUserToSendInvite(orgUser, ToUpdate: false);
+        }
+
+        if (orgUser.UserId.HasValue && linkedUsersById.TryGetValue(orgUser.UserId.Value, out var linkedUser) &&
+            !string.IsNullOrWhiteSpace(linkedUser.Email))
+        {
+            orgUser.Email = linkedUser.Email;
+            return new OrganizationUserToSendInvite(orgUser, ToUpdate: true);
+        }
+
+        return null;
+    }
+
+    private readonly record struct OrganizationUserToSendInvite(OrganizationUser OrganizationUser, bool ToUpdate);
+
+    private async Task<OrganizationInvitesInfo> BuildOrganizationInvitesInfoAsync(List<OrganizationUser> orgUsers, Organization organization, bool initOrganization, string? inviterEmail)
     {
         // Email links must include information about the org and user for us to make routing decisions client side
         // Given an org user, determine if existing BW user exists
-        var existingUsers = await userRepository.GetManyByEmailsAsync(orgUserEmails);
+        var existingUsers = await userRepository.GetManyByEmailsAsync([
+            .. orgUsers.Where(ou => !string.IsNullOrWhiteSpace(ou.Email)).Select(ou => ou.Email!)
+        ]);
 
         // hash existing users emails list for O(1) lookups
         var existingUserEmailsHashSet = new HashSet<string>(existingUsers.Select(u => u.Email),
@@ -114,7 +125,7 @@ public class SendOrganizationInvitesCommand(
         // Create a dictionary of org user guids and bools for whether they have an existing BW user
         var orgUserHasExistingUserDict = orgUsers.ToDictionary(
             ou => ou.Id,
-            ou => existingUserEmailsHashSet.Contains(ou.Email)
+            ou => existingUserEmailsHashSet.Contains(ou.Email!)
         );
 
         // Determine if org has SSO enabled and if user is required to log in with SSO
@@ -149,7 +160,7 @@ public class SendOrganizationInvitesCommand(
         );
     }
 
-    private async Task<string> GetInviterEmailAsync(Guid? invitingUserId)
+    private async Task<string?> GetInviterEmailAsync(Guid? invitingUserId)
     {
         if (!invitingUserId.HasValue || invitingUserId.Value == Guid.Empty)
         {

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommand.cs
@@ -20,6 +20,7 @@ namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUse
 
 public class SendOrganizationInvitesCommand(
     IUserRepository userRepository,
+    IOrganizationUserRepository organizationUserRepository,
     ISsoConfigRepository ssoConfigurationRepository,
     IPolicyQuery policyQuery,
     IOrgUserInviteTokenableFactory orgUserInviteTokenableFactory,
@@ -29,7 +30,7 @@ public class SendOrganizationInvitesCommand(
 {
     public async Task SendInvitesAsync(SendInvitesRequest request)
     {
-        var (orgUsers, orgUserEmails) = ExcludeUsersWithoutEmail(request.Users);
+        var (orgUsers, orgUserEmails) = await RepairAndFilterUsersWithoutEmailAsync(request.Users);
         if (orgUsers.Count == 0)
         {
             return;
@@ -42,34 +43,59 @@ public class SendOrganizationInvitesCommand(
     }
 
     /// <summary>
-    /// Removes Organizations Users that do not have an Email address.
+    /// Self-heals invited org users missing their email, then returns the users and emails that can be invited.
     /// </summary>
     /// <remarks>
-    /// An invited org user is expected to have an email address, but SSO JIT provisioning can leave it
-    /// null. We attempt to get the existing users, a NULL value throws an error when mapping to the Emails parameter.
-    ///
-    /// Attempting to use the existing User record by populated UserId would also result in a failure because when
-    /// validating the token, we would fail to look up the organization user with the Email from the User record.
-    /// Instead, we are opting to dropping the users from the invites to be sent, and we'll log the invalid state for
-    /// a more complete bug fix.
+    /// SSO JIT provisioning can leave a corrupt invited row (Email null, UserId populated). The email must be
+    /// persisted, not just patched in memory, because the invite token is re-validated against the stored email at
+    /// accept time. When the row has a UserId we recover the email from that user, null the UserId to restore the
+    /// canonical invited shape, and persist the repair. Rows that cannot be repaired are logged and dropped.
     /// </remarks>
-    private (List<OrganizationUser> OrgUsers, List<string> Emails) ExcludeUsersWithoutEmail(
+    private async Task<(List<OrganizationUser> OrgUsers, List<string> Emails)> RepairAndFilterUsersWithoutEmailAsync(
         OrganizationUser[] requestedOrgUsers)
     {
-        var (orgUsers, emails) = requestedOrgUsers.Aggregate(
-            (OrgUsers: new List<OrganizationUser>(), Emails: new List<string>()),
-            (aggregate, orgUser) =>
-            {
-                if (string.IsNullOrWhiteSpace(orgUser.Email))
-                {
-                    logger.LogUserInviteStateDiagnostics(orgUser);
-                    return aggregate;
-                }
+        var missingEmail = requestedOrgUsers.Where(ou => string.IsNullOrWhiteSpace(ou.Email)).ToList();
 
-                aggregate.OrgUsers.Add(orgUser);
-                aggregate.Emails.Add(orgUser.Email);
-                return aggregate;
-            });
+        if (missingEmail.Count == 0)
+        {
+            return (requestedOrgUsers.ToList(), requestedOrgUsers.Select(ou => ou.Email).ToList());
+        }
+
+        var linkedUsersById = (await userRepository.GetManyAsync(
+                missingEmail.Where(ou => ou.UserId.HasValue).Select(ou => ou.UserId.Value)))
+            .ToDictionary(user => user.Id);
+
+        var repaired = new List<OrganizationUser>();
+        var orgUsers = new List<OrganizationUser>();
+        var emails = new List<string>();
+
+        foreach (var orgUser in requestedOrgUsers)
+        {
+            if (!string.IsNullOrWhiteSpace(orgUser.Email))
+            {
+                orgUsers.Add(orgUser);
+                emails.Add(orgUser.Email);
+                continue;
+            }
+
+            if (orgUser.UserId.HasValue &&
+                linkedUsersById.TryGetValue(orgUser.UserId.Value, out var linkedUser) &&
+                !string.IsNullOrWhiteSpace(linkedUser.Email))
+            {
+                orgUser.Email = linkedUser.Email;
+                repaired.Add(orgUser);
+                orgUsers.Add(orgUser);
+                emails.Add(orgUser.Email);
+                continue;
+            }
+
+            logger.LogUserInviteStateDiagnostics(orgUser);
+        }
+
+        if (repaired.Count != 0)
+        {
+            await organizationUserRepository.ReplaceManyAsync(repaired);
+        }
 
         return (orgUsers, emails);
     }

--- a/src/Core/AdminConsole/Utilities/DebuggingInstruments/UserInviteDebuggingLogger.cs
+++ b/src/Core/AdminConsole/Utilities/DebuggingInstruments/UserInviteDebuggingLogger.cs
@@ -17,7 +17,7 @@ public static class UserInviteDebuggingLogger
         LogUserInviteStateDiagnostics(logger, [orgUser]);
     }
 
-    public static void LogUserInviteStateDiagnostics(this ILogger logger, IEnumerable<OrganizationUser> allOrgUsers)
+    public static void LogUserInviteStateDiagnostics(this ILogger logger, ICollection<OrganizationUser> allOrgUsers)
     {
         try
         {
@@ -29,7 +29,7 @@ public static class UserInviteDebuggingLogger
                 logger.LogWarning("Warning invalid invited state. {logData}", logData);
             }
 
-            var invalidConfirmedOrAcceptedState = allOrgUsers.Any(user => (user.Status == OrganizationUserStatusType.Confirmed || user.Status == OrganizationUserStatusType.Accepted) && !user.Email.IsNullOrWhiteSpace());
+            var invalidConfirmedOrAcceptedState = allOrgUsers.Any(user => user.Status is OrganizationUserStatusType.Confirmed or OrganizationUserStatusType.Accepted && !user.Email.IsNullOrWhiteSpace());
 
             if (invalidConfirmedOrAcceptedState)
             {
@@ -39,7 +39,6 @@ public static class UserInviteDebuggingLogger
         }
         catch (Exception exception)
         {
-
             // Ensure that this debugging instrument does not interfere with the current flow.
             logger.LogWarning(exception, "Unexpected exception from UserInviteDebuggingLogger");
         }

--- a/src/Core/AdminConsole/Utilities/DebuggingInstruments/UserInviteDebuggingLogger.cs
+++ b/src/Core/AdminConsole/Utilities/DebuggingInstruments/UserInviteDebuggingLogger.cs
@@ -17,24 +17,26 @@ public static class UserInviteDebuggingLogger
         LogUserInviteStateDiagnostics(logger, [orgUser]);
     }
 
-    public static void LogUserInviteStateDiagnostics(this ILogger logger, ICollection<OrganizationUser> allOrgUsers)
+    public static void LogUserInviteStateDiagnostics(this ILogger logger, IEnumerable<OrganizationUser> allOrgUsers)
     {
         try
         {
-            var invalidInviteState = allOrgUsers.Any(user => user.Status == OrganizationUserStatusType.Invited && user.Email.IsNullOrWhiteSpace());
+            var orgUserList = allOrgUsers.ToList();
+
+            var invalidInviteState = orgUserList.Any(user => user.Status == OrganizationUserStatusType.Invited && user.Email.IsNullOrWhiteSpace());
 
             if (invalidInviteState)
             {
-                var logData = MapObjectDataToLog(allOrgUsers);
+                var logData = MapObjectDataToLog(orgUserList);
                 logger.LogWarning("Warning invalid invited state. {logData}", logData);
             }
 
-            var invalidConfirmedOrAcceptedState = allOrgUsers.Any(user => user.Status is OrganizationUserStatusType.Confirmed or OrganizationUserStatusType.Accepted && !user.Email.IsNullOrWhiteSpace());
+            var invalidConfirmedOrAcceptedState = orgUserList.Any(user => user.Status is OrganizationUserStatusType.Confirmed or OrganizationUserStatusType.Accepted && !user.Email.IsNullOrWhiteSpace());
 
             if (invalidConfirmedOrAcceptedState)
             {
-                var logData = MapObjectDataToLog(allOrgUsers);
-                logger.LogWarning("Warning invalid confirmed or accepted state. {logData}", logData);
+                var logData = MapObjectDataToLog(orgUserList);
+                logger.LogWarning("Warning invalid confirmed or accepted state. {LogData}", logData);
             }
         }
         catch (Exception exception)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
@@ -294,7 +294,7 @@ public class SendOrganizationInvitesCommandTests
     [BitAutoData((string)null)]
     [BitAutoData("")]
     [BitAutoData("   ")]
-    public async Task SendInvitesAsync_WhenAnOrgUserHasNoEmail_StillSendsTheOtherInvites(
+    public async Task SendInvitesAsync_WhenAnOrgUserHasNoEmailButALinkedUser_RepairsAndSendsBothInvites(
         string blankEmail,
         Organization organization,
         OrganizationUser invite,
@@ -304,19 +304,31 @@ public class SendOrganizationInvitesCommandTests
     {
         SetupSutProviderWithNoExistingUsers(sutProvider);
 
-        // Arrange - a linked UserId does not make the org user invitable, the invite token is validated
-        // against the stored email at accept time
+        // Arrange - corrupt invited row (no email, linked to a user) is healed from the linked user
         inviteWithoutEmail.Email = blankEmail;
         inviteWithoutEmail.UserId = linkedUser.Id;
+
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([linkedUser]);
 
         // Act
         await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
 
-        // Assert
+        // Assert - repaired row persisted with the recovered email
+        await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1)
+            .ReplaceManyAsync(Arg.Is<IEnumerable<OrganizationUser>>(users =>
+                users.Count() == 1 &&
+                users.Single().Id == inviteWithoutEmail.Id &&
+                users.Single().Email == linkedUser.Email));
+
+        // Assert - both invites are sent, and the repaired user carries the recovered email
         await sutProvider.GetDependency<IMailService>().Received(1)
             .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
-                info.OrgUserTokenPairs.Count() == 1 &&
-                info.OrgUserTokenPairs.Single().OrgUser.Id == invite.Id));
+                info.OrgUserTokenPairs.Count() == 2 &&
+                info.OrgUserTokenPairs.Any(p => p.OrgUser.Id == invite.Id) &&
+                info.OrgUserTokenPairs.Any(p =>
+                    p.OrgUser.Id == inviteWithoutEmail.Id && p.OrgUser.Email == linkedUser.Email)));
     }
 
     [Theory, BitAutoData]
@@ -416,6 +428,167 @@ public class SendOrganizationInvitesCommandTests
                 info.OrgUserHasExistingUserDict[invite.Id]));
     }
 
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_MixedBatch_RepairsInOneRoundTripAndDropsUnrepairable(
+        Organization organization,
+        OrganizationUser canonicalInvite,
+        OrganizationUser repairableInvite,
+        OrganizationUser unrepairableInvite,
+        User linkedUser,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange - one healthy invite, one that can be self-healed from its linked user, and one that cannot
+        repairableInvite.Email = null;
+        repairableInvite.UserId = linkedUser.Id;
+
+        unrepairableInvite.Email = null;
+        unrepairableInvite.UserId = null;
+        unrepairableInvite.Status = OrganizationUserStatusType.Invited;
+
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([linkedUser]);
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(
+            new SendInvitesRequest([canonicalInvite, repairableInvite, unrepairableInvite], organization));
+
+        // Assert - only the repaired row is persisted, in a single call
+        await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1)
+            .ReplaceManyAsync(Arg.Is<IEnumerable<OrganizationUser>>(users =>
+                users.Count() == 1 && users.Single().Id == repairableInvite.Id));
+
+        // Assert - the unrepairable row is logged
+        sutProvider.GetDependency<ILogger<SendOrganizationInvitesCommand>>().Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => state.ToString().Contains(unrepairableInvite.Id.ToString())),
+            null,
+            Arg.Any<Func<object, Exception, string>>());
+
+        // Assert - the healthy and repaired invites are sent, the unrepairable one is not
+        await sutProvider.GetDependency<IMailService>().Received(1)
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
+                info.OrgUserTokenPairs.Count() == 2 &&
+                info.OrgUserTokenPairs.Any(p => p.OrgUser.Id == canonicalInvite.Id) &&
+                info.OrgUserTokenPairs.Any(p => p.OrgUser.Id == repairableInvite.Id) &&
+                info.OrgUserTokenPairs.All(p => p.OrgUser.Id != unrepairableInvite.Id)));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_OrgUserWithNoEmailAndNoUserId_DropsWithoutPersisting(
+        Organization organization,
+        OrganizationUser invite,
+        OrganizationUser inviteWithoutEmail,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange - no email and no linked user means the row cannot be repaired
+        inviteWithoutEmail.Email = null;
+        inviteWithoutEmail.UserId = null;
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
+
+        // Assert
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceive()
+            .ReplaceManyAsync(Arg.Any<IEnumerable<OrganizationUser>>());
+
+        await sutProvider.GetDependency<IMailService>().Received(1)
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
+                info.OrgUserTokenPairs.Count() == 1 &&
+                info.OrgUserTokenPairs.Single().OrgUser.Id == invite.Id));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_OrgUserWithNoEmailAndDanglingUserId_DropsWithoutPersisting(
+        Organization organization,
+        OrganizationUser invite,
+        OrganizationUser inviteWithoutEmail,
+        Guid danglingUserId,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange - the linked user no longer exists, so GetManyAsync returns nothing for it
+        inviteWithoutEmail.Email = null;
+        inviteWithoutEmail.UserId = danglingUserId;
+
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([]);
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
+
+        // Assert
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceive()
+            .ReplaceManyAsync(Arg.Any<IEnumerable<OrganizationUser>>());
+
+        await sutProvider.GetDependency<IMailService>().Received(1)
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
+                info.OrgUserTokenPairs.Count() == 1 &&
+                info.OrgUserTokenPairs.Single().OrgUser.Id == invite.Id));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_LinkedUserHasBlankEmail_DropsWithoutPersisting(
+        Organization organization,
+        OrganizationUser invite,
+        OrganizationUser inviteWithoutEmail,
+        User linkedUser,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange - the linked user resolves, but has no email to recover, so the row cannot be repaired
+        inviteWithoutEmail.Email = null;
+        inviteWithoutEmail.UserId = linkedUser.Id;
+        linkedUser.Email = "";
+
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([linkedUser]);
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
+
+        // Assert
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceive()
+            .ReplaceManyAsync(Arg.Any<IEnumerable<OrganizationUser>>());
+
+        await sutProvider.GetDependency<IMailService>().Received(1)
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
+                info.OrgUserTokenPairs.Count() == 1 &&
+                info.OrgUserTokenPairs.Single().OrgUser.Id == invite.Id));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_AllOrgUsersHaveEmail_SkipsRepairEntirely(
+        Organization organization,
+        OrganizationUser firstInvite,
+        OrganizationUser secondInvite,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([firstInvite, secondInvite], organization));
+
+        // Assert - the repair fast path takes no extra dependencies
+        await sutProvider.GetDependency<IUserRepository>().DidNotReceive()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>());
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceive()
+            .ReplaceManyAsync(Arg.Any<IEnumerable<OrganizationUser>>());
+
+        await sutProvider.GetDependency<IMailService>().Received(1)
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
+                info.OrgUserTokenPairs.Count() == 2));
+    }
+
     private void SetupSutProvider(SutProvider<SendOrganizationInvitesCommand> sutProvider)
     {
         sutProvider.SetDependency(_orgUserInviteTokenDataFactory, "orgUserInviteTokenDataFactory");
@@ -428,6 +601,10 @@ public class SendOrganizationInvitesCommandTests
 
         sutProvider.GetDependency<IUserRepository>()
             .GetManyByEmailsAsync(Arg.Any<IEnumerable<string>>())
+            .Returns([]);
+
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
             .Returns([]);
 
         sutProvider.GetDependency<IOrgUserInviteTokenableFactory>()

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
@@ -9,6 +9,7 @@ using Bit.Core.Auth.Models.Business.Tokenables;
 using Bit.Core.Auth.Repositories;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Models.Mail;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
@@ -371,6 +372,8 @@ public class SendOrganizationInvitesCommandTests
 
         // Arrange
         inviteWithoutEmail.Email = null;
+        inviteWithoutEmail.Status = OrganizationUserStatusType.Invited;
+        inviteWithoutEmail.OrganizationId = organization.Id;
 
         // Act
         await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
@@ -432,7 +432,7 @@ public class SendOrganizationInvitesCommandTests
     {
         SetupSutProviderWithNoExistingUsers(sutProvider);
 
-        // Arrange - one healthy invite, one whose email resolves from its linked user, and one that cannot
+        // Arrange
         resolvableInvite.Email = null;
         resolvableInvite.UserId = linkedUser.Id;
 
@@ -456,7 +456,7 @@ public class SendOrganizationInvitesCommandTests
             null,
             Arg.Any<Func<object, Exception, string>>());
 
-        // Assert - the healthy and resolved invites are sent, the unresolvable one is not
+        // Assert - correct invites are sent
         await sutProvider.GetDependency<IMailService>().Received(1)
             .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
                 info.OrgUserTokenPairs.Count() == 2 &&

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
@@ -18,6 +18,7 @@ using Bit.Core.Tokens;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Bit.Test.Common.Fakes;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
 using Xunit;
@@ -264,9 +265,173 @@ public class SendOrganizationInvitesCommandTests
                 info.InviterEmail == null));
     }
 
+    [Theory]
+    [BitAutoData((string)null)]
+    [BitAutoData("")]
+    [BitAutoData("   ")]
+    public async Task SendInvitesAsync_WhenAnOrgUserHasNoEmail_DoesNotLookThatEmailUp(
+        string blankEmail,
+        Organization organization,
+        OrganizationUser invite,
+        OrganizationUser inviteWithoutEmail,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange - an invited org user with no email, as left behind by SSO just-in-time provisioning
+        inviteWithoutEmail.Email = blankEmail;
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
+
+        // Assert - a blank email in this lookup fails the whole send against SQL Server
+        await sutProvider.GetDependency<IUserRepository>().DidNotReceive()
+            .GetManyByEmailsAsync(Arg.Is<IEnumerable<string>>(emails => emails.Any(string.IsNullOrWhiteSpace)));
+    }
+
+    [Theory]
+    [BitAutoData((string)null)]
+    [BitAutoData("")]
+    [BitAutoData("   ")]
+    public async Task SendInvitesAsync_WhenAnOrgUserHasNoEmail_StillSendsTheOtherInvites(
+        string blankEmail,
+        Organization organization,
+        OrganizationUser invite,
+        OrganizationUser inviteWithoutEmail,
+        User linkedUser,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange - a linked UserId does not make the org user invitable, the invite token is validated
+        // against the stored email at accept time
+        inviteWithoutEmail.Email = blankEmail;
+        inviteWithoutEmail.UserId = linkedUser.Id;
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
+
+        // Assert
+        await sutProvider.GetDependency<IMailService>().Received(1)
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
+                info.OrgUserTokenPairs.Count() == 1 &&
+                info.OrgUserTokenPairs.Single().OrgUser.Id == invite.Id));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_WhenAnOrgUserHasNoEmail_MailInfoIsInternallyConsistent(
+        Organization organization,
+        OrganizationUser invite,
+        OrganizationUser inviteWithoutEmail,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange
+        inviteWithoutEmail.Email = null;
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
+
+        // Assert - every mailed org user needs a recipient and an entry in the existing user dictionary
+        await sutProvider.GetDependency<IMailService>().Received(1)
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
+                info.OrgUserTokenPairs.All(pair =>
+                    !string.IsNullOrWhiteSpace(pair.OrgUser.Email) &&
+                    info.OrgUserHasExistingUserDict.ContainsKey(pair.OrgUser.Id))));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_WhenNoOrgUserHasAnEmail_SendsNothing(
+        Organization organization,
+        OrganizationUser inviteWithoutEmail,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange
+        inviteWithoutEmail.Email = null;
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([inviteWithoutEmail], organization));
+
+        // Assert
+        await sutProvider.GetDependency<IMailService>().DidNotReceive()
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Any<OrganizationInvitesInfo>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_WhenAnOrgUserHasNoEmail_WarnsWithTheSkippedOrgUserId(
+        Organization organization,
+        OrganizationUser invite,
+        OrganizationUser inviteWithoutEmail,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange
+        inviteWithoutEmail.Email = null;
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
+
+        // Assert - the log is the only signal an operator gets, and it must not carry an email address
+        sutProvider.GetDependency<ILogger<SendOrganizationInvitesCommand>>().Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state =>
+                state.ToString().Contains(inviteWithoutEmail.Id.ToString()) &&
+                state.ToString().Contains(organization.Id.ToString()) &&
+                !state.ToString().Contains(invite.Email)),
+            null,
+            Arg.Any<Func<object, Exception, string>>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendInvitesAsync_WhenAccountEmailDiffersInCase_TreatsUserAsExisting(
+        Organization organization,
+        OrganizationUser invite,
+        User existingUser,
+        SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProviderWithNoExistingUsers(sutProvider);
+
+        // Arrange - email lookups are case insensitive everywhere else in the invite flow
+        invite.Email = "member@example.com";
+        existingUser.Email = "Member@Example.com";
+
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyByEmailsAsync(Arg.Any<IEnumerable<string>>())
+            .Returns([existingUser]);
+
+        // Act
+        await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite], organization));
+
+        // Assert
+        await sutProvider.GetDependency<IMailService>().Received(1)
+            .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
+                info.OrgUserHasExistingUserDict[invite.Id]));
+    }
+
     private void SetupSutProvider(SutProvider<SendOrganizationInvitesCommand> sutProvider)
     {
         sutProvider.SetDependency(_orgUserInviteTokenDataFactory, "orgUserInviteTokenDataFactory");
         sutProvider.Create();
+    }
+
+    private void SetupSutProviderWithNoExistingUsers(SutProvider<SendOrganizationInvitesCommand> sutProvider)
+    {
+        SetupSutProvider(sutProvider);
+
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyByEmailsAsync(Arg.Any<IEnumerable<string>>())
+            .Returns([]);
+
+        sutProvider.GetDependency<IOrgUserInviteTokenableFactory>()
+            .CreateToken(Arg.Any<OrganizationUser>())
+            .Returns(info => new OrgUserInviteTokenable(info.Arg<OrganizationUser>())
+            {
+                ExpirationDate = DateTime.UtcNow.Add(TimeSpan.FromDays(5))
+            });
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
@@ -320,7 +320,8 @@ public class SendOrganizationInvitesCommandTests
             .ReplaceManyAsync(Arg.Is<IEnumerable<OrganizationUser>>(users =>
                 users.Count() == 1 &&
                 users.Single().Id == inviteWithoutEmail.Id &&
-                users.Single().Email == linkedUser.Email));
+                users.Single().Email == linkedUser.Email &&
+                users.Single().UserId == null));
 
         // Assert - both invites are sent, and the repaired user carries the recovered email
         await sutProvider.GetDependency<IMailService>().Received(1)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/SendOrganizationInvitesCommandTests.cs
@@ -294,7 +294,7 @@ public class SendOrganizationInvitesCommandTests
     [BitAutoData((string)null)]
     [BitAutoData("")]
     [BitAutoData("   ")]
-    public async Task SendInvitesAsync_WhenAnOrgUserHasNoEmailButALinkedUser_RepairsAndSendsBothInvites(
+    public async Task SendInvitesAsync_WhenAnOrgUserHasNoEmailButALinkedUser_ResolvesAndSendsBothInvites(
         string blankEmail,
         Organization organization,
         OrganizationUser invite,
@@ -304,7 +304,7 @@ public class SendOrganizationInvitesCommandTests
     {
         SetupSutProviderWithNoExistingUsers(sutProvider);
 
-        // Arrange - corrupt invited row (no email, linked to a user) is healed from the linked user
+        // Arrange - corrupt invited row (no email, linked to a user) has its email resolved from the linked user
         inviteWithoutEmail.Email = blankEmail;
         inviteWithoutEmail.UserId = linkedUser.Id;
 
@@ -315,15 +315,7 @@ public class SendOrganizationInvitesCommandTests
         // Act
         await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
 
-        // Assert - repaired row persisted with the recovered email
-        await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1)
-            .ReplaceManyAsync(Arg.Is<IEnumerable<OrganizationUser>>(users =>
-                users.Count() == 1 &&
-                users.Single().Id == inviteWithoutEmail.Id &&
-                users.Single().Email == linkedUser.Email &&
-                users.Single().UserId == null));
-
-        // Assert - both invites are sent, and the repaired user carries the recovered email
+        // Assert - both invites are sent, and the resolved user carries the recovered email
         await sutProvider.GetDependency<IMailService>().Received(1)
             .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
                 info.OrgUserTokenPairs.Count() == 2 &&
@@ -430,23 +422,23 @@ public class SendOrganizationInvitesCommandTests
     }
 
     [Theory, BitAutoData]
-    public async Task SendInvitesAsync_MixedBatch_RepairsInOneRoundTripAndDropsUnrepairable(
+    public async Task SendInvitesAsync_MixedBatch_ResolvesAndDropsUnresolvable(
         Organization organization,
         OrganizationUser canonicalInvite,
-        OrganizationUser repairableInvite,
-        OrganizationUser unrepairableInvite,
+        OrganizationUser resolvableInvite,
+        OrganizationUser unresolvableInvite,
         User linkedUser,
         SutProvider<SendOrganizationInvitesCommand> sutProvider)
     {
         SetupSutProviderWithNoExistingUsers(sutProvider);
 
-        // Arrange - one healthy invite, one that can be self-healed from its linked user, and one that cannot
-        repairableInvite.Email = null;
-        repairableInvite.UserId = linkedUser.Id;
+        // Arrange - one healthy invite, one whose email resolves from its linked user, and one that cannot
+        resolvableInvite.Email = null;
+        resolvableInvite.UserId = linkedUser.Id;
 
-        unrepairableInvite.Email = null;
-        unrepairableInvite.UserId = null;
-        unrepairableInvite.Status = OrganizationUserStatusType.Invited;
+        unresolvableInvite.Email = null;
+        unresolvableInvite.UserId = null;
+        unresolvableInvite.Status = OrganizationUserStatusType.Invited;
 
         sutProvider.GetDependency<IUserRepository>()
             .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
@@ -454,32 +446,27 @@ public class SendOrganizationInvitesCommandTests
 
         // Act
         await sutProvider.Sut.SendInvitesAsync(
-            new SendInvitesRequest([canonicalInvite, repairableInvite, unrepairableInvite], organization));
+            new SendInvitesRequest([canonicalInvite, resolvableInvite, unresolvableInvite], organization));
 
-        // Assert - only the repaired row is persisted, in a single call
-        await sutProvider.GetDependency<IOrganizationUserRepository>().Received(1)
-            .ReplaceManyAsync(Arg.Is<IEnumerable<OrganizationUser>>(users =>
-                users.Count() == 1 && users.Single().Id == repairableInvite.Id));
-
-        // Assert - the unrepairable row is logged
+        // Assert - the unresolvable row is logged
         sutProvider.GetDependency<ILogger<SendOrganizationInvitesCommand>>().Received(1).Log(
             LogLevel.Warning,
             Arg.Any<EventId>(),
-            Arg.Is<object>(state => state.ToString().Contains(unrepairableInvite.Id.ToString())),
+            Arg.Is<object>(state => state.ToString().Contains(unresolvableInvite.Id.ToString())),
             null,
             Arg.Any<Func<object, Exception, string>>());
 
-        // Assert - the healthy and repaired invites are sent, the unrepairable one is not
+        // Assert - the healthy and resolved invites are sent, the unresolvable one is not
         await sutProvider.GetDependency<IMailService>().Received(1)
             .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
                 info.OrgUserTokenPairs.Count() == 2 &&
                 info.OrgUserTokenPairs.Any(p => p.OrgUser.Id == canonicalInvite.Id) &&
-                info.OrgUserTokenPairs.Any(p => p.OrgUser.Id == repairableInvite.Id) &&
-                info.OrgUserTokenPairs.All(p => p.OrgUser.Id != unrepairableInvite.Id)));
+                info.OrgUserTokenPairs.Any(p => p.OrgUser.Id == resolvableInvite.Id) &&
+                info.OrgUserTokenPairs.All(p => p.OrgUser.Id != unresolvableInvite.Id)));
     }
 
     [Theory, BitAutoData]
-    public async Task SendInvitesAsync_OrgUserWithNoEmailAndNoUserId_DropsWithoutPersisting(
+    public async Task SendInvitesAsync_OrgUserWithNoEmailAndNoUserId_Drops(
         Organization organization,
         OrganizationUser invite,
         OrganizationUser inviteWithoutEmail,
@@ -487,7 +474,7 @@ public class SendOrganizationInvitesCommandTests
     {
         SetupSutProviderWithNoExistingUsers(sutProvider);
 
-        // Arrange - no email and no linked user means the row cannot be repaired
+        // Arrange - no email and no linked user means the row cannot be resolved
         inviteWithoutEmail.Email = null;
         inviteWithoutEmail.UserId = null;
 
@@ -495,9 +482,6 @@ public class SendOrganizationInvitesCommandTests
         await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
 
         // Assert
-        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceive()
-            .ReplaceManyAsync(Arg.Any<IEnumerable<OrganizationUser>>());
-
         await sutProvider.GetDependency<IMailService>().Received(1)
             .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
                 info.OrgUserTokenPairs.Count() == 1 &&
@@ -505,7 +489,7 @@ public class SendOrganizationInvitesCommandTests
     }
 
     [Theory, BitAutoData]
-    public async Task SendInvitesAsync_OrgUserWithNoEmailAndDanglingUserId_DropsWithoutPersisting(
+    public async Task SendInvitesAsync_OrgUserWithNoEmailAndDanglingUserId_Drops(
         Organization organization,
         OrganizationUser invite,
         OrganizationUser inviteWithoutEmail,
@@ -526,9 +510,6 @@ public class SendOrganizationInvitesCommandTests
         await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
 
         // Assert
-        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceive()
-            .ReplaceManyAsync(Arg.Any<IEnumerable<OrganizationUser>>());
-
         await sutProvider.GetDependency<IMailService>().Received(1)
             .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
                 info.OrgUserTokenPairs.Count() == 1 &&
@@ -536,7 +517,7 @@ public class SendOrganizationInvitesCommandTests
     }
 
     [Theory, BitAutoData]
-    public async Task SendInvitesAsync_LinkedUserHasBlankEmail_DropsWithoutPersisting(
+    public async Task SendInvitesAsync_LinkedUserHasBlankEmail_Drops(
         Organization organization,
         OrganizationUser invite,
         OrganizationUser inviteWithoutEmail,
@@ -545,7 +526,7 @@ public class SendOrganizationInvitesCommandTests
     {
         SetupSutProviderWithNoExistingUsers(sutProvider);
 
-        // Arrange - the linked user resolves, but has no email to recover, so the row cannot be repaired
+        // Arrange - the linked user resolves, but has no email to recover, so the row cannot be resolved
         inviteWithoutEmail.Email = null;
         inviteWithoutEmail.UserId = linkedUser.Id;
         linkedUser.Email = "";
@@ -558,9 +539,6 @@ public class SendOrganizationInvitesCommandTests
         await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([invite, inviteWithoutEmail], organization));
 
         // Assert
-        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceive()
-            .ReplaceManyAsync(Arg.Any<IEnumerable<OrganizationUser>>());
-
         await sutProvider.GetDependency<IMailService>().Received(1)
             .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>
                 info.OrgUserTokenPairs.Count() == 1 &&
@@ -568,7 +546,7 @@ public class SendOrganizationInvitesCommandTests
     }
 
     [Theory, BitAutoData]
-    public async Task SendInvitesAsync_AllOrgUsersHaveEmail_SkipsRepairEntirely(
+    public async Task SendInvitesAsync_AllOrgUsersHaveEmail_SkipsEmailResolutionEntirely(
         Organization organization,
         OrganizationUser firstInvite,
         OrganizationUser secondInvite,
@@ -579,11 +557,9 @@ public class SendOrganizationInvitesCommandTests
         // Act
         await sutProvider.Sut.SendInvitesAsync(new SendInvitesRequest([firstInvite, secondInvite], organization));
 
-        // Assert - the repair fast path takes no extra dependencies
+        // Assert - the fast path takes no extra dependencies
         await sutProvider.GetDependency<IUserRepository>().DidNotReceive()
             .GetManyAsync(Arg.Any<IEnumerable<Guid>>());
-        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceive()
-            .ReplaceManyAsync(Arg.Any<IEnumerable<OrganizationUser>>());
 
         await sutProvider.GetDependency<IMailService>().Received(1)
             .SendUpdatedOrganizationInviteEmailsAsync(Arg.Is<OrganizationInvitesInfo>(info =>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-22405](https://bitwarden.atlassian.net/browse/PM-22405)

## 📔 Objective
As a user goes to bulk resend invites, it attempts to match the Organization Users against the existing users. With those SSO JIT OrgUsers, the null email will cause the database call to fail because it can't map the NULL value to an Email. 

In order to unblock re-invite, we are going to retrieve the email for the invalid invited org users via the User record. This will allow us to send out the email to everyone selected. If for some reason there is still a user who does not have an email on Org User or User record, then we'll log them and exclude them from the email list.

[PM-22405]: https://bitwarden.atlassian.net/browse/PM-22405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ