### PR TITLE
Ensure appsettings.{env}.json can be found

### DIFF
--- a/util/SeederUtility/Configuration/GlobalSettingsFactory.cs
+++ b/util/SeederUtility/Configuration/GlobalSettingsFactory.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Core.Settings;
+﻿using System.Reflection;
+using Bit.Core.Settings;
 using Microsoft.Extensions.Configuration;
 
 namespace Bit.SeederUtility.Configuration;
@@ -14,10 +15,15 @@ public static class GlobalSettingsFactory
 
     private static GlobalSettings LoadGlobalSettings()
     {
+        var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+                        ?? Directory.GetCurrentDirectory();
+
         var configBuilder = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
+            .SetBasePath(directory)
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true, reloadOnChange: true)
+            .AddJsonFile(
+                $"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json",
+                optional: true, reloadOnChange: true)
             .AddUserSecrets("bitwarden-seeder-utility")
             .AddEnvironmentVariables();
 

--- a/util/SeederUtility/SeederUtility.csproj
+++ b/util/SeederUtility/SeederUtility.csproj
@@ -19,4 +19,13 @@
     <PackageReference Include="Spectre.Console" Version="[0.55.2]" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Currently, the ./Seed.json does not find the appsettings files due to the apps configuration base directory is set to `./dev`. The appsettings files are also not copied to the output directory.

This PR makes sure that the files are copied to the output directory, and that the base directory for configuration is set to the binary's output directory.

## 🎟️ Tracking

No JIRA issue for this.

## 📔 Objective

Make the seeder usable for me again.

## 📸 Screenshots

N/A
