### PR TITLE
[BRE-2162] ci(build): Trigger downstream build on release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -653,7 +653,6 @@ jobs:
     name: Trigger downstream build
     if: github.event_name == 'push' && contains(fromJSON('["refs/heads/main", "refs/heads/rc", "refs/heads/hotfix-rc"]'), github.ref)
     runs-on: ubuntu-24.04
-    needs: lint
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,7 @@ jobs:
         with:
           username: bitwarden
           password: ${{ steps.get-kv-secrets.outputs.DOCKERHUB-OAT }}
-      
+
       - name: Build Docker image
         id: build-artifacts
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -648,3 +648,20 @@ jobs:
           azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
           task: deploy-server-dev
           description: "Triggered by server build on main"
+
+  trigger-downstream-build:
+    name: Trigger downstream build
+    if: github.event_name == 'push' && contains(fromJSON('["refs/heads/main", "refs/heads/rc", "refs/heads/hotfix-rc"]'), github.ref)
+    runs-on: ubuntu-24.04
+    needs: lint
+    permissions:
+      id-token: write
+    steps:
+      - name: Trigger downstream build
+        uses: bitwarden/gh-actions/trigger-actions@main
+        with:
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          task: build-downstream-artifacts
+          monitor-deployment: false


### PR DESCRIPTION


## 🎟️ Tracking

[BRE-2162](https://bitwarden.atlassian.net/browse/BRE-2162)

## 📔 Objective

Add a `trigger-downstream-build` job so downstream artifact builds start automatically after a push to a release branch.

* Run only on `push` to `main`, `rc`, or `hotfix-rc`
* Fire and forget with `monitor-deployment: false`
* Strip trailing whitespace in the `build-docker` job


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[BRE-2162]: https://bitwarden.atlassian.net/browse/BRE-2162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ