### PR TITLE
Add GlobalSettingsBridge library

### DIFF
--- a/bitwarden-server.slnx
+++ b/bitwarden-server.slnx
@@ -22,6 +22,7 @@
     <Project Path="src/Libraries/Data/Data.csproj" />
     <Project Path="src/Libraries/ExceptionHandling/ExceptionHandling.csproj" />
     <Project Path="src/Libraries/OrganizationAuthorization/OrganizationAuthorization.csproj" />
+    <Project Path="src/Libraries/GlobalSettingsBridge/GlobalSettingsBridge.csproj" />
     <Project Path="src/Libraries/SerilogFileLogging/SerilogFileLogging.csproj" />
     <Project Path="src/Libraries/SsrfProtection/SsrfProtection.csproj" />
     <Project Path="src/Events/Events.csproj" />
@@ -67,6 +68,7 @@
     <Project Path="test/Libraries/Data.Test/Data.Test.csproj" />
     <Project Path="test/Libraries/ExceptionHandling.Test/ExceptionHandling.Test.csproj" />
     <Project Path="test/Libraries/OrganizationAuthorization.Test/OrganizationAuthorization.Test.csproj" />
+    <Project Path="test/Libraries/GlobalSettingsBridge.Test/GlobalSettingsBridge.Test.csproj" />
     <Project Path="test/Libraries/SerilogFileLogging.Test/SerilogFileLogging.Test.csproj" />
     <Project Path="test/Libraries/SsrfProtection.Test/SsrfProtection.Test.csproj" />
     <Project Path="test/Events.IntegrationTest/Events.IntegrationTest.csproj" />

--- a/src/Libraries/GlobalSettingsBridge/ConfigureCorsOptions.cs
+++ b/src/Libraries/GlobalSettingsBridge/ConfigureCorsOptions.cs
@@ -1,0 +1,35 @@
+﻿using Bitwarden.Server.Sdk.Environment;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Bit.GlobalSettingsBridge;
+
+internal sealed class ConfigureCorsOptions : IConfigureOptions<CorsOptions>
+{
+    private readonly IBitwardenEnvironment _environment;
+    private readonly IConfiguration _config;
+
+    public ConfigureCorsOptions(IBitwardenEnvironment environment, IConfiguration config)
+    {
+        _environment = environment;
+        _config = config;
+    }
+
+    public void Configure(CorsOptions options)
+    {
+        var vaultUri = _config["globalSettings:baseServiceUri:vault"];
+        var selfHosted = _environment.SelfHosted;
+
+        options.AddDefaultPolicy(policy =>
+            policy
+                .SetIsOriginAllowed(origin =>
+                    origin == vaultUri ||
+                    origin == "file://" ||
+                    origin == "bw-desktop-file://bundle" ||
+                    (!selfHosted && origin == "https://bitwarden.com"))
+                .AllowAnyMethod()
+                .AllowAnyHeader()
+                .AllowCredentials());
+    }
+}

--- a/src/Libraries/GlobalSettingsBridge/ConfigureForwardedHeadersOptions.cs
+++ b/src/Libraries/GlobalSettingsBridge/ConfigureForwardedHeadersOptions.cs
@@ -1,0 +1,71 @@
+﻿using System.Net;
+using Bitwarden.Server.Sdk.Environment;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Bit.GlobalSettingsBridge;
+
+internal sealed class ConfigureForwardedHeadersOptions : IConfigureOptions<ForwardedHeadersOptions>
+{
+    private readonly IBitwardenEnvironment _environment;
+    private readonly IConfiguration _config;
+
+    public ConfigureForwardedHeadersOptions(IBitwardenEnvironment environment, IConfiguration config)
+    {
+        _environment = environment;
+        _config = config;
+    }
+
+    public void Configure(ForwardedHeadersOptions options)
+    {
+        options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+        if (_environment.SelfHostFlavor != "lite")
+        {
+            // Trust the X-Forwarded-Host header of the nginx docker container
+            try
+            {
+                var nginxIp = Dns.GetHostEntry("nginx")?.AddressList.FirstOrDefault();
+                if (nginxIp != null)
+                {
+                    options.KnownProxies.Add(nginxIp);
+                }
+            }
+            catch
+            {
+                // Ignore DNS errors
+            }
+        }
+
+        var knownProxies = _config["globalSettings:knownProxies"];
+        if (!string.IsNullOrWhiteSpace(knownProxies))
+        {
+            foreach (var proxy in knownProxies.Split(','))
+            {
+                if (IPAddress.TryParse(proxy.Trim(), out var ip))
+                {
+                    options.KnownProxies.Add(ip);
+                }
+            }
+        }
+
+        var knownNetworks = _config["globalSettings:knownNetworks"];
+        if (!string.IsNullOrWhiteSpace(knownNetworks))
+        {
+            foreach (var network in knownNetworks.Split(','))
+            {
+                if (System.Net.IPNetwork.TryParse(network.Trim(), out var ipn))
+                {
+                    options.KnownIPNetworks.Add(ipn);
+                }
+            }
+        }
+
+        if (options.KnownProxies.Count > 1 || options.KnownIPNetworks.Count > 1)
+        {
+            options.ForwardLimit = null;
+        }
+    }
+}

--- a/src/Libraries/GlobalSettingsBridge/ConfigureSelfHostDetails.cs
+++ b/src/Libraries/GlobalSettingsBridge/ConfigureSelfHostDetails.cs
@@ -1,0 +1,24 @@
+﻿using Bitwarden.Server.Sdk.Environment.Setup;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Bit.GlobalSettingsBridge;
+
+internal sealed class ConfigureSelfHostDetails : IConfigureOptions<SelfHostDetails>
+{
+    private readonly IConfiguration _config;
+
+    public ConfigureSelfHostDetails(IConfiguration config) => _config = config;
+
+    public void Configure(SelfHostDetails details)
+    {
+        if (!_config.GetValue<bool>("globalSettings:selfHosted"))
+        {
+            details.MakeCloud();
+            return;
+        }
+
+        var flavor = _config.GetValue<bool>("globalSettings:liteDeployment") ? "lite" : "unknown";
+        details.MakeSelfHost(flavor);
+    }
+}

--- a/src/Libraries/GlobalSettingsBridge/GlobalSettingsBridge.csproj
+++ b/src/Libraries/GlobalSettingsBridge/GlobalSettingsBridge.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Bitwarden.Server.Sdk" />
+
+  <PropertyGroup>
+    <!-- Only the Environment package is needed; disable Features which defaults to on. -->
+    <BitIncludeFeatures>false</BitIncludeFeatures>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/src/Libraries/GlobalSettingsBridge/GlobalSettingsBridgeServiceCollectionExtensions.cs
+++ b/src/Libraries/GlobalSettingsBridge/GlobalSettingsBridgeServiceCollectionExtensions.cs
@@ -1,0 +1,58 @@
+﻿using Bit.GlobalSettingsBridge;
+using Bitwarden.Server.Sdk.Environment.Setup;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class GlobalSettingsBridgeServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers options configurators that read from the <c>globalSettings</c> configuration
+    /// section and populate <see cref="CorsOptions"/>, <see cref="ForwardedHeadersOptions"/>,
+    /// and <see cref="SelfHostDetails"/>, replacing direct <c>GlobalSettings</c> dependencies
+    /// in middleware setup.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This method is intended for services that already depend on GlobalSettings-style
+    /// configuration and are migrating to the options pattern.</b> New services should configure
+    /// <see cref="SelfHostDetails"/>, <see cref="CorsOptions"/>, and
+    /// <see cref="ForwardedHeadersOptions"/> directly rather than going through this bridge.
+    /// </para>
+    /// <para>
+    /// After calling this method, configure CORS middleware with the parameterless overload
+    /// so it picks up the default policy populated here:
+    /// <code>app.UseCors();</code>
+    /// instead of the inline-lambda form currently used at each call site.
+    /// </para>
+    /// <para>
+    /// Forwarded-headers options are always configured by this method; the caller is still
+    /// responsible for guarding the middleware behind a self-hosted check:
+    /// <code>
+    /// if (environment.SelfHosted)
+    /// {
+    ///     app.UseForwardedHeaders();
+    /// }
+    /// </code>
+    /// </para>
+    /// <para>
+    /// This method depends on <see cref="IBitwardenEnvironment"/> being resolvable from the
+    /// container. Call <c>AddBitwardenEnvironment()</c> (or <c>UseBitwardenSdk()</c>) before
+    /// or after this method — registration order does not matter because both are resolved
+    /// lazily when options are first accessed.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddGlobalSettingsBridge(this IServiceCollection services)
+    {
+        services.TryAddEnumerable([
+            ServiceDescriptor.Singleton<IConfigureOptions<SelfHostDetails>, ConfigureSelfHostDetails>(),
+            ServiceDescriptor.Singleton<IConfigureOptions<CorsOptions>, ConfigureCorsOptions>(),
+            ServiceDescriptor.Singleton<IConfigureOptions<ForwardedHeadersOptions>, ConfigureForwardedHeadersOptions>(),
+        ]);
+
+        return services;
+    }
+}

--- a/src/Libraries/GlobalSettingsBridge/packages.lock.json
+++ b/src/Libraries/GlobalSettingsBridge/packages.lock.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "Bitwarden.Server.Sdk.Environment": {
+        "type": "Direct",
+        "requested": "[0.1.0, )",
+        "resolved": "0.1.0",
+        "contentHash": "yLK3ik/+zQ4w41iDObvv4vq2QwWPaVMuyKFpzlgsukClOOuZUxJAivwnnZZDMXbp2wipWgaW4yeEY+yLdLVaVQ=="
+      }
+    }
+  }
+}

--- a/test/Libraries/GlobalSettingsBridge.Test/ConfigureCorsOptionsTests.cs
+++ b/test/Libraries/GlobalSettingsBridge.Test/ConfigureCorsOptionsTests.cs
@@ -1,0 +1,69 @@
+﻿using Bitwarden.Server.Sdk.Environment;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Bit.GlobalSettingsBridge.Test;
+
+public class ConfigureCorsOptionsTests
+{
+    [Theory]
+    [InlineData("https://vault.example.com", true)]   // configured vault URI
+    [InlineData("file://", true)]                     // Safari extension origin
+    [InlineData("bw-desktop-file://bundle", true)]    // Desktop application protocol
+    [InlineData("https://bitwarden.com", true)]       // Product website (cloud only)
+    [InlineData("https://evil.example.com", false)]   // Unknown origin
+    public void Configure_CloudInstance_AllowsExpectedOrigins(string origin, bool expected)
+    {
+        var policy = BuildDefaultPolicy(selfHosted: false, vaultUri: "https://vault.example.com");
+
+        Assert.Equal(expected, policy.IsOriginAllowed(origin));
+    }
+
+    [Theory]
+    [InlineData("https://vault.example.com", true)]   // configured vault URI
+    [InlineData("file://", true)]                     // Safari extension origin
+    [InlineData("bw-desktop-file://bundle", true)]    // Desktop application protocol
+    [InlineData("https://bitwarden.com", false)]      // Product website blocked for self-host
+    [InlineData("https://evil.example.com", false)]   // Unknown origin
+    public void Configure_SelfHostedInstance_AllowsExpectedOrigins(string origin, bool expected)
+    {
+        var policy = BuildDefaultPolicy(selfHosted: true, vaultUri: "https://vault.example.com");
+
+        Assert.Equal(expected, policy.IsOriginAllowed(origin));
+    }
+
+    [Fact]
+    public void Configure_DefaultPolicy_AllowsAnyMethodHeaderAndCredentials()
+    {
+        var policy = BuildDefaultPolicy(selfHosted: false, vaultUri: "https://vault.example.com");
+
+        Assert.True(policy.AllowAnyMethod);
+        Assert.True(policy.AllowAnyHeader);
+        Assert.True(policy.SupportsCredentials);
+    }
+
+    private static CorsPolicy BuildDefaultPolicy(bool selfHosted, string vaultUri)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["globalSettings:baseServiceUri:vault"] = vaultUri,
+            })
+            .Build();
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddSingleton<IBitwardenEnvironment>(new TestBitwardenEnvironment
+        {
+            SelfHosted = selfHosted,
+            SelfHostFlavor = selfHosted ? "unknown" : null,
+        });
+        services.AddGlobalSettingsBridge();
+        var corsOptions = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<CorsOptions>>().Value;
+        return corsOptions.GetPolicy(corsOptions.DefaultPolicyName)!;
+    }
+}

--- a/test/Libraries/GlobalSettingsBridge.Test/ConfigureForwardedHeadersOptionsTests.cs
+++ b/test/Libraries/GlobalSettingsBridge.Test/ConfigureForwardedHeadersOptionsTests.cs
@@ -1,0 +1,141 @@
+﻿using System.Net;
+using Bitwarden.Server.Sdk.Environment;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+using IPNetwork = System.Net.IPNetwork;
+
+namespace Bit.GlobalSettingsBridge.Test;
+
+public class ConfigureForwardedHeadersOptionsTests
+{
+    [Fact]
+    public void Configure_AlwaysSets_XForwardedForAndProtoHeaders()
+    {
+        var options = Build([]);
+
+        Assert.Equal(ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto, options.ForwardedHeaders);
+    }
+
+    [Fact]
+    public void Configure_ParsesKnownProxiesFromConfig()
+    {
+        var options = Build(new()
+        {
+            ["globalSettings:knownProxies"] = "10.0.0.1,192.168.1.1",
+        });
+
+        Assert.Contains(IPAddress.Parse("10.0.0.1"), options.KnownProxies);
+        Assert.Contains(IPAddress.Parse("192.168.1.1"), options.KnownProxies);
+    }
+
+    [Fact]
+    public void Configure_ParsesKnownNetworksFromConfig()
+    {
+        var options = Build(new()
+        {
+            ["globalSettings:knownNetworks"] = "10.0.0.0/8,192.168.0.0/16",
+        });
+
+        Assert.Contains(IPNetwork.Parse("10.0.0.0/8"), options.KnownIPNetworks);
+        Assert.Contains(IPNetwork.Parse("192.168.0.0/16"), options.KnownIPNetworks);
+    }
+
+    [Fact]
+    public void Configure_NullsForwardLimit_WhenMultipleKnownProxies()
+    {
+        var options = Build(new()
+        {
+            ["globalSettings:knownProxies"] = "10.0.0.1,10.0.0.2",
+        });
+
+        Assert.Null(options.ForwardLimit);
+    }
+
+    [Fact]
+    public void Configure_NullsForwardLimit_WhenMultipleKnownNetworks()
+    {
+        var options = Build(new()
+        {
+            ["globalSettings:knownNetworks"] = "10.0.0.0/8,192.168.0.0/16",
+        });
+
+        Assert.Null(options.ForwardLimit);
+    }
+
+    [Fact]
+    public void Configure_IgnoresInvalidProxyAddresses()
+    {
+        var options = Build(new()
+        {
+            ["globalSettings:knownProxies"] = "not-an-ip,10.0.0.1",
+        });
+
+        Assert.Contains(IPAddress.Parse("10.0.0.1"), options.KnownProxies);
+        Assert.DoesNotContain(options.KnownProxies, ip => ip.ToString() == "not-an-ip");
+    }
+
+    [Fact]
+    public void Configure_IgnoresInvalidNetworkAddresses()
+    {
+        var options = Build(new()
+        {
+            ["globalSettings:knownNetworks"] = "not-a-network,10.0.0.0/8",
+        });
+
+        Assert.Contains(IPNetwork.Parse("10.0.0.0/8"), options.KnownIPNetworks);
+        Assert.DoesNotContain(options.KnownIPNetworks, n => n.ToString() == "not-a-network");
+    }
+
+    [Fact]
+    public void Configure_TrimsWhitespaceFromProxiesAndNetworks()
+    {
+        var options = Build(new()
+        {
+            ["globalSettings:knownProxies"] = " 10.0.0.1 , 192.168.1.1 ",
+            ["globalSettings:knownNetworks"] = " 10.0.0.0/8 , 192.168.0.0/16 ",
+        });
+
+        Assert.Contains(IPAddress.Parse("10.0.0.1"), options.KnownProxies);
+        Assert.Contains(IPAddress.Parse("192.168.1.1"), options.KnownProxies);
+        Assert.Contains(IPNetwork.Parse("10.0.0.0/8"), options.KnownIPNetworks);
+        Assert.Contains(IPNetwork.Parse("192.168.0.0/16"), options.KnownIPNetworks);
+    }
+
+    [Fact]
+    public void Configure_NonLiteFlavor_StillAppliesConfigProxies()
+    {
+        // Non-lite flavor attempts a nginx DNS lookup (which fails in test environments)
+        // and falls through silently. Config-specified proxies must still be applied.
+        var options = BuildWithFlavor("unknown", new()
+        {
+            ["globalSettings:knownProxies"] = "10.0.0.1",
+        });
+
+        Assert.Contains(IPAddress.Parse("10.0.0.1"), options.KnownProxies);
+    }
+
+    // Builds options with a "lite" flavor so the nginx DNS attempt is skipped, keeping
+    // tests deterministic regardless of whether an nginx container is reachable.
+    private static ForwardedHeadersOptions Build(Dictionary<string, string?> configValues)
+        => BuildWithFlavor("lite", configValues);
+
+    private static ForwardedHeadersOptions BuildWithFlavor(string flavor, Dictionary<string, string?> configValues)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(configValues).Build();
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddSingleton<IBitwardenEnvironment>(new TestBitwardenEnvironment
+        {
+            SelfHosted = true,
+            SelfHostFlavor = flavor,
+        });
+        services.AddGlobalSettingsBridge();
+        return services.BuildServiceProvider()
+            .GetRequiredService<IOptions<ForwardedHeadersOptions>>().Value;
+    }
+}

--- a/test/Libraries/GlobalSettingsBridge.Test/ConfigureSelfHostDetailsTests.cs
+++ b/test/Libraries/GlobalSettingsBridge.Test/ConfigureSelfHostDetailsTests.cs
@@ -1,0 +1,55 @@
+﻿using Bitwarden.Server.Sdk.Environment.Setup;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Bit.GlobalSettingsBridge.Test;
+
+public class ConfigureSelfHostDetailsTests
+{
+    [Fact]
+    public void Configure_WhenCloud_SetsNotSelfHosted()
+    {
+        var details = Build(new() { ["globalSettings:selfHosted"] = "false" });
+
+        Assert.False(details.SelfHosted);
+        Assert.Null(details.SelfHostFlavor);
+    }
+
+    [Fact]
+    public void Configure_WhenSelfHostedAndLite_SetsLiteFlavor()
+    {
+        var details = Build(new()
+        {
+            ["globalSettings:selfHosted"] = "true",
+            ["globalSettings:liteDeployment"] = "true",
+        });
+
+        Assert.True(details.SelfHosted);
+        Assert.Equal("lite", details.SelfHostFlavor);
+    }
+
+    [Fact]
+    public void Configure_WhenSelfHostedAndNotLite_SetsUnknownFlavor()
+    {
+        var details = Build(new()
+        {
+            ["globalSettings:selfHosted"] = "true",
+            ["globalSettings:liteDeployment"] = "false",
+        });
+
+        Assert.True(details.SelfHosted);
+        Assert.Equal("unknown", details.SelfHostFlavor);
+    }
+
+    private static SelfHostDetails Build(Dictionary<string, string?> configValues)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(configValues).Build();
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddGlobalSettingsBridge();
+        return services.BuildServiceProvider().GetRequiredService<IOptions<SelfHostDetails>>().Value;
+    }
+}

--- a/test/Libraries/GlobalSettingsBridge.Test/GlobalSettingsBridge.Test.csproj
+++ b/test/Libraries/GlobalSettingsBridge.Test/GlobalSettingsBridge.Test.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="$(CoverletCollectorVersion)">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Libraries\GlobalSettingsBridge\GlobalSettingsBridge.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Libraries/GlobalSettingsBridge.Test/TestBitwardenEnvironment.cs
+++ b/test/Libraries/GlobalSettingsBridge.Test/TestBitwardenEnvironment.cs
@@ -1,0 +1,11 @@
+﻿using Bitwarden.Server.Sdk.Environment;
+
+namespace Bit.GlobalSettingsBridge.Test;
+
+internal sealed class TestBitwardenEnvironment : IBitwardenEnvironment
+{
+    public string Version => "";
+    public string? GitHash => null;
+    public required bool SelfHosted { get; init; }
+    public required string? SelfHostFlavor { get; init; }
+}

--- a/test/Libraries/GlobalSettingsBridge.Test/packages.lock.json
+++ b/test/Libraries/GlobalSettingsBridge.Test/packages.lock.json
@@ -1,0 +1,185 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.0.1, )",
+        "resolved": "18.0.1",
+        "contentHash": "WNpu6vI2rA0pXY4r7NKxCN16XRWl5uHu6qjuyVLoDo6oYEggIQefrMjkRuibQHm/NslIUNCcKftvoWAN80MSAg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.0.1",
+          "Microsoft.TestPlatform.TestHost": "18.0.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.6.6, )",
+        "resolved": "2.6.6",
+        "contentHash": "MAbOOMtZIKyn2lrAmMlvhX0BhDOX/smyrTB+8WTXnSKkrmTGBS2fm8g1PZtHBPj91Dc5DJA7fY+/81TJ/yUFZw==",
+        "dependencies": {
+          "xunit.analyzers": "1.10.0",
+          "xunit.assert": "2.6.6",
+          "xunit.core": "[2.6.6]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.5.6, )",
+        "resolved": "2.5.6",
+        "contentHash": "CW6uhMXNaQQNMSG1IWhHkBT+V5eqHqn7MP0zfNMhU9wS/sgKX7FGL3rzoaUgt26wkY3bpf7pDVw3IjXhwfiP4w=="
+      },
+      "Bitwarden.Server.Sdk.Environment": {
+        "type": "Transitive",
+        "resolved": "0.1.0",
+        "contentHash": "yLK3ik/+zQ4w41iDObvv4vq2QwWPaVMuyKFpzlgsukClOOuZUxJAivwnnZZDMXbp2wipWgaW4yeEY+yLdLVaVQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "O+utSr97NAJowIQT/OVp3Lh9QgW/wALVTP4RG1m2AfFP4IyJmJz0ZBmFJUsRQiAPgq6IRC0t8AAzsiPIsaUDEA=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "qT/mwMcLF9BieRkzOBPL2qCopl8hQu6A1P7JWAoj/FMu5i9vds/7cjbJ/LLtaiwWevWLAeD5v5wjQJ/l6jvhWQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.0.1",
+        "contentHash": "uDJKAEjFTaa2wHdWlfo6ektyoh+WD4/Eesrwb4FpBFKsLGehhACVnwwTI4qD3FrIlIEPlxdXg3SyrYRIcO+RRQ==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.10.0",
+        "contentHash": "Lw8CiDy5NaAWcO6keqD7iZHYUTIuCOcoFrUHw5Sv84ITZ9gFeDybdkVdH0Y2maSlP9fUjtENyiykT44zwFQIHA=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.6.6",
+        "contentHash": "74Cm9lAZOk5TKCz2MvCBCByKsS23yryOKDIMxH3XRDHXmfGM02jKZWzRA7g4mGB41GnBnv/pcWP3vUYkrCtEcg=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.6.6",
+        "contentHash": "tqi7RfaNBqM7t8zx6QHryuBPzmotsZXKGaWnopQG2Ez5UV7JoWuyoNdT6gLpDIcKdGYey6YTXJdSr9IXDMKwjg==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.6.6]",
+          "xunit.extensibility.execution": "[2.6.6]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.6.6",
+        "contentHash": "ty6VKByzbx4Toj4/VGJLEnlmOawqZiMv0in/tLju+ftA+lbWuAWDERM+E52Jfhj4ZYHrAYVa14KHK5T+dq0XxA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.6.6",
+        "contentHash": "UDjIVGj2TepVKN3n32/qXIdb3U6STwTb9L6YEwoQO2A8OxiJS5QAVv2l1aT6tDwwv/9WBmm8Khh/LyHALipcng==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.6.6]"
+        }
+      },
+      "globalsettingsbridge": {
+        "type": "Project",
+        "dependencies": {
+          "Bitwarden.Server.Sdk.Environment": "[0.1.0, )"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34549

## 📔 Objective

Introduces a new `GlobalSettingsBridge` library (`src/Libraries/GlobalSettingsBridge/`) that bridges `globalSettings`-style `IConfiguration` keys into the ASP.NET Core options pattern via `IConfigureOptions<T>`.

Calling `services.AddGlobalSettingsBridge()` registers three configurators:

- **`ConfigureSelfHostDetails`** — reads `globalSettings:selfHosted` / `globalSettings:liteDeployment` and populates `SelfHostDetails` (the SDK's environment type).
- **`ConfigureCorsOptions`** — reads `globalSettings:baseServiceUri:vault` and uses `IBitwardenEnvironment.SelfHosted` to configure the default CORS policy, replacing direct `GlobalSettings` usage in middleware setup.
- **`ConfigureForwardedHeadersOptions`** — reads `globalSettings:knownProxies` / `globalSettings:knownNetworks`, handles the nginx DNS lookup for non-lite self-hosted deployments, and sets `ForwardLimit = null` when multiple proxies/networks are configured.

The library has no dependency on `Bit.Core` or `GlobalSettings` directly — it reads all config via `IConfiguration`. It uses `Bitwarden.Server.Sdk` (with `BitIncludeFeatures=false`) to pick up the `Bitwarden.Server.Sdk.Environment` package.

**This method is intended for services migrating away from direct GlobalSettings dependencies.** New services should configure `CorsOptions`, `ForwardedHeadersOptions`, and `SelfHostDetails` directly.

## 📸 Screenshots

N/A — no UI changes.