### PR TITLE
[PM-40209] Add PAM access claim and ManageAccessRules permission

### DIFF
--- a/src/Api/AdminConsole/Models/Response/BaseProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/BaseProfileOrganizationResponseModel.cs
@@ -131,6 +131,7 @@ public abstract class BaseProfileOrganizationResponseModel : ResponseModel
     public string? KeyConnectorUrl { get; set; }
     public MemberDecryptionType? SsoMemberDecryptionType { get; set; }
     public bool AccessSecretsManager { get; set; }
+    public bool AccessPam { get; set; }
     public Guid? UserId { get; set; }
     public OrganizationUserStatusType Status { get; set; }
     public OrganizationUserType Type { get; set; }

--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
@@ -28,6 +28,7 @@ public class OrganizationUserResponseModel : ResponseModel
         Status = organizationUser.Status;
         ExternalId = organizationUser.ExternalId;
         AccessSecretsManager = organizationUser.AccessSecretsManager;
+        AccessPam = organizationUser.AccessPam;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
         ResetPasswordEnrolled = OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey);
     }
@@ -47,6 +48,7 @@ public class OrganizationUserResponseModel : ResponseModel
         Status = organizationUser.Status;
         ExternalId = organizationUser.ExternalId;
         AccessSecretsManager = organizationUser.AccessSecretsManager;
+        AccessPam = organizationUser.AccessPam;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
         ResetPasswordEnrolled = OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey);
         UsesKeyConnector = organizationUser.UsesKeyConnector;
@@ -59,6 +61,7 @@ public class OrganizationUserResponseModel : ResponseModel
     public OrganizationUserStatusType Status { get; set; }
     public string ExternalId { get; set; }
     public bool AccessSecretsManager { get; set; }
+    public bool AccessPam { get; set; }
     public Permissions Permissions { get; set; }
     public bool ResetPasswordEnrolled { get; set; }
     public bool UsesKeyConnector { get; set; }

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -31,6 +31,7 @@ public class ProfileOrganizationResponseModel : BaseProfileOrganizationResponseM
             SponsoredPlans.Get(PlanSponsorshipType.FamiliesForEnterprise)
             .UsersCanSponsor(organizationDetails);
         AccessSecretsManager = organizationDetails.AccessSecretsManager;
+        AccessPam = organizationDetails.AccessPam;
     }
 
     public Guid OrganizationUserId { get; set; }

--- a/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModel.cs
@@ -20,5 +20,6 @@ public class ProfileProviderOrganizationResponseModel : BaseProfileOrganizationR
         ProviderType = organizationDetails.ProviderType;
         Permissions = new Permissions();
         AccessSecretsManager = false; // Provider users cannot access Secrets Manager
+        AccessPam = false; // Provider users cannot access Privileged Access Manager
     }
 }

--- a/src/Api/AdminConsole/Public/Models/PermissionsModel.cs
+++ b/src/Api/AdminConsole/Public/Models/PermissionsModel.cs
@@ -31,6 +31,7 @@ public class PermissionsModel
         ManageUsers = data.ManageUsers;
         ManageResetPassword = data.ManageResetPassword;
         ManageScim = data.ManageScim;
+        ManageAccessRules = data.ManageAccessRules;
     }
 
     public bool AccessEventLogs { get; set; }
@@ -45,6 +46,7 @@ public class PermissionsModel
     public bool ManageUsers { get; set; }
     public bool ManageResetPassword { get; set; }
     public bool ManageScim { get; set; }
+    public bool ManageAccessRules { get; set; }
 
     public Permissions ToData()
     {
@@ -61,7 +63,8 @@ public class PermissionsModel
             ManageSso = ManageSso,
             ManageUsers = ManageUsers,
             ManageResetPassword = ManageResetPassword,
-            ManageScim = ManageScim
+            ManageScim = ManageScim,
+            ManageAccessRules = ManageAccessRules
         };
     }
 }

--- a/src/Core/AdminConsole/Context/CurrentContextOrganization.cs
+++ b/src/Core/AdminConsole/Context/CurrentContextOrganization.cs
@@ -19,10 +19,12 @@ public class CurrentContextOrganization
         Type = orgUser.Type;
         Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(orgUser.Permissions);
         AccessSecretsManager = orgUser.AccessSecretsManager && orgUser.UseSecretsManager && orgUser.Enabled;
+        AccessPam = orgUser.AccessPam && orgUser.UsePam && orgUser.Enabled;
     }
 
     public Guid Id { get; set; }
     public OrganizationUserType Type { get; set; }
     public Permissions Permissions { get; set; } = new();
     public bool AccessSecretsManager { get; set; }
+    public bool AccessPam { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/Permissions.cs
+++ b/src/Core/AdminConsole/Models/Data/Permissions.cs
@@ -17,6 +17,7 @@ public class Permissions
     public bool ManageUsers { get; set; }
     public bool ManageResetPassword { get; set; }
     public bool ManageScim { get; set; }
+    public bool ManageAccessRules { get; set; }
 
     [JsonIgnore]
     public List<(bool Permission, string ClaimName)> ClaimsMap => new()
@@ -33,5 +34,6 @@ public class Permissions
         (ManageUsers, Claims.CustomPermissions.ManageUsers),
         (ManageResetPassword, Claims.CustomPermissions.ManageResetPassword),
         (ManageScim, Claims.CustomPermissions.ManageScim),
+        (ManageAccessRules, Claims.CustomPermissions.ManageAccessRules),
     };
 }

--- a/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
+++ b/src/Core/AdminConsole/Services/Implementations/OrganizationService.cs
@@ -1057,6 +1057,11 @@ public class OrganizationService : IOrganizationService
             return false;
         }
 
+        if (permissions.ManageAccessRules && !org.Permissions.ManageAccessRules)
+        {
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/Core/Auth/Identity/Claims.cs
+++ b/src/Core/Auth/Identity/Claims.cs
@@ -18,6 +18,7 @@ public static class Claims
     public const string ProviderServiceUser = "providerserviceuser";
 
     public const string SecretsManagerAccess = "accesssecretsmanager";
+    public const string PamAccess = "accesspam";
 
     // Service Account
     public const string Organization = "organization";
@@ -40,6 +41,7 @@ public static class Claims
         public const string ManageUsers = "manageusers";
         public const string ManageResetPassword = "manageresetpassword";
         public const string ManageScim = "managescim";
+        public const string ManageAccessRules = "manageaccessrules";
     }
 
     /// <summary>

--- a/src/Core/Utilities/CoreHelpers.cs
+++ b/src/Core/Utilities/CoreHelpers.cs
@@ -758,6 +758,12 @@ public static class CoreHelpers
                         claims.Add(new KeyValuePair<string, string>(Claims.SecretsManagerAccess, org.Id.ToString()));
                     }
                 }
+
+                // Privileged Access Manager
+                foreach (var org in group.Where(o => o.AccessPam))
+                {
+                    claims.Add(new KeyValuePair<string, string>(Claims.PamAccess, org.Id.ToString()));
+                }
             }
         }
 

--- a/src/Identity/IdentityServer/ApiResources.cs
+++ b/src/Identity/IdentityServer/ApiResources.cs
@@ -25,7 +25,8 @@ public class ApiResources
                 Claims.OrganizationCustom,
                 Claims.ProviderAdmin,
                 Claims.ProviderServiceUser,
-                Claims.SecretsManagerAccess
+                Claims.SecretsManagerAccess,
+                Claims.PamAccess
             }),
             new(ApiScopes.ApiSendAccess, [
                 JwtClaimTypes.Subject,

--- a/src/Libraries/OrganizationAuthorization/Organizations/OrganizationClaimsExtensions.cs
+++ b/src/Libraries/OrganizationAuthorization/Organizations/OrganizationClaimsExtensions.cs
@@ -33,6 +33,7 @@ public static class OrganizationClaimsExtensions
             Id = organizationId,
             Type = role.Value,
             AccessSecretsManager = hasClaim(Claims.SecretsManagerAccess),
+            AccessPam = hasClaim(Claims.PamAccess),
             Permissions = role == OrganizationUserType.Custom
                 ? GetPermissionsFromClaims(hasClaim)
                 : new Permissions()
@@ -113,5 +114,6 @@ public static class OrganizationClaimsExtensions
         ManageUsers = hasClaim(Claims.CustomPermissions.ManageUsers),
         ManageResetPassword = hasClaim(Claims.CustomPermissions.ManageResetPassword),
         ManageScim = hasClaim(Claims.CustomPermissions.ManageScim),
+        ManageAccessRules = hasClaim(Claims.CustomPermissions.ManageAccessRules),
     };
 }

--- a/test/Api.Test/AdminConsole/Models/Response/OrganizationUserResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Response/OrganizationUserResponseModelTests.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Api.AdminConsole.Models.Response.Organizations;
+using Bit.Core.Entities;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
 using Bit.Test.Common.AutoFixture.Attributes;
@@ -8,6 +9,32 @@ namespace Bit.Api.Test.AdminConsole.Models.Response;
 
 public class OrganizationUserResponseModelTests
 {
+    [Theory, BitAutoData]
+    public void Constructor_OrganizationUser_PopulatesAccessFlags(OrganizationUser orgUser)
+    {
+        orgUser.Permissions = null;
+        orgUser.AccessSecretsManager = true;
+        orgUser.AccessPam = true;
+
+        var result = new OrganizationUserResponseModel(orgUser);
+
+        Assert.True(result.AccessSecretsManager);
+        Assert.True(result.AccessPam);
+    }
+
+    [Theory, BitAutoData]
+    public void Constructor_OrganizationUserUserDetails_PopulatesAccessFlags(OrganizationUserUserDetails orgUser)
+    {
+        orgUser.Permissions = null;
+        orgUser.AccessSecretsManager = true;
+        orgUser.AccessPam = true;
+
+        var result = new OrganizationUserResponseModel(orgUser);
+
+        Assert.True(result.AccessSecretsManager);
+        Assert.True(result.AccessPam);
+    }
+
     [Theory, BitAutoData]
     public void OrganizationUserDetailsResponseModel_Constructor_PopulatesCreationDate(
         OrganizationUserUserDetails orgUser)

--- a/test/Api.Test/AdminConsole/Models/Response/ProfileOrganizationResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Response/ProfileOrganizationResponseModelTests.cs
@@ -53,6 +53,7 @@ public class ProfileOrganizationResponseModelTests
             UseOrganizationDomains = organization.UseOrganizationDomains,
             UseAdminSponsoredFamilies = organization.UseAdminSponsoredFamilies,
             UseAutomaticUserConfirmation = organization.UseAutomaticUserConfirmation,
+            UsePam = organization.UsePam,
             SelfHost = organization.SelfHost,
             Seats = organization.Seats,
             MaxCollections = organization.MaxCollections,
@@ -84,6 +85,7 @@ public class ProfileOrganizationResponseModelTests
             Status = OrganizationUserStatusType.Confirmed,
             Type = OrganizationUserType.Owner,
             AccessSecretsManager = true,
+            AccessPam = true,
             SmSeats = 5,
             SmServiceAccounts = 10
         };
@@ -142,6 +144,8 @@ public class ProfileOrganizationResponseModelTests
         Assert.NotNull(result.Permissions);
         Assert.True(result.ResetPasswordEnrolled);
         Assert.Equal(organizationDetails.AccessSecretsManager, result.AccessSecretsManager);
+        Assert.Equal(organization.UsePam, result.UsePam);
+        Assert.Equal(organizationDetails.AccessPam, result.AccessPam);
         Assert.Equal(organizationDetails.FamilySponsorshipFriendlyName, result.FamilySponsorshipFriendlyName);
         Assert.Equal(organizationDetails.FamilySponsorshipLastSyncDate, result.FamilySponsorshipLastSyncDate);
         Assert.Equal(organizationDetails.FamilySponsorshipToDelete, result.FamilySponsorshipToDelete);

--- a/test/Api.Test/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Response/ProfileProviderOrganizationResponseModelTests.cs
@@ -127,5 +127,6 @@ public class ProfileProviderOrganizationResponseModelTests
         Assert.False(result.Permissions.ManageUsers);
         Assert.False(result.ResetPasswordEnrolled);
         Assert.False(result.AccessSecretsManager);
+        Assert.False(result.AccessPam);
     }
 }

--- a/test/Api.Test/AdminConsole/Public/Models/PermissionsModelTests.cs
+++ b/test/Api.Test/AdminConsole/Public/Models/PermissionsModelTests.cs
@@ -1,0 +1,34 @@
+﻿using Bit.Api.AdminConsole.Public.Models;
+using Bit.Core.Models.Data;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Public.Models;
+
+public class PermissionsModelTests
+{
+    /// <summary>
+    /// <see cref="PermissionsModel"/> is a hand-rolled mirror of <see cref="Permissions"/>, and
+    /// <see cref="PermissionsModel.ToData"/> rebuilds the whole object. A permission missing from the mirror is
+    /// therefore silently cleared whenever a member is updated through the public API, so every permission must
+    /// survive a round trip.
+    /// </summary>
+    [Fact]
+    public void ToData_RoundTripsEveryPermission()
+    {
+        var permissionProperties = typeof(Permissions)
+            .GetProperties()
+            .Where(p => p.PropertyType == typeof(bool));
+
+        foreach (var permission in permissionProperties)
+        {
+            var data = new Permissions();
+            permission.SetValue(data, true);
+
+            var roundTripped = new PermissionsModel(data).ToData();
+
+            Assert.True((bool)permission.GetValue(roundTripped)!,
+                $"{permission.Name} was lost when round-tripping through {nameof(PermissionsModel)}. " +
+                $"Add it to the constructor, its own property, and {nameof(PermissionsModel.ToData)}.");
+        }
+    }
+}

--- a/test/Core.Test/AdminConsole/Context/CurrentContextOrganizationTests.cs
+++ b/test/Core.Test/AdminConsole/Context/CurrentContextOrganizationTests.cs
@@ -1,0 +1,51 @@
+﻿using Bit.Core.Context;
+using Bit.Core.Models.Data.Organizations.OrganizationUsers;
+using Xunit;
+
+namespace Bit.Core.Test.AdminConsole.Context;
+
+public class CurrentContextOrganizationTests
+{
+    [Theory]
+    // Access is only granted when the member holds it, the organization has the feature, and the organization is enabled.
+    [InlineData(true, true, true, true)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, true, false, false)]
+    public void Constructor_AccessSecretsManager_RequiresMemberAccessAndEnabledOrganization(
+        bool accessSecretsManager, bool useSecretsManager, bool enabled, bool expected)
+    {
+        var orgUser = new OrganizationUserOrganizationDetails
+        {
+            OrganizationId = Guid.NewGuid(),
+            Enabled = enabled,
+            AccessSecretsManager = accessSecretsManager,
+            UseSecretsManager = useSecretsManager
+        };
+
+        var sut = new CurrentContextOrganization(orgUser);
+
+        Assert.Equal(expected, sut.AccessSecretsManager);
+    }
+
+    [Theory]
+    [InlineData(true, true, true, true)]
+    [InlineData(false, true, true, false)]
+    [InlineData(true, false, true, false)]
+    [InlineData(true, true, false, false)]
+    public void Constructor_AccessPam_RequiresMemberAccessAndEnabledOrganization(
+        bool accessPam, bool usePam, bool enabled, bool expected)
+    {
+        var orgUser = new OrganizationUserOrganizationDetails
+        {
+            OrganizationId = Guid.NewGuid(),
+            Enabled = enabled,
+            AccessPam = accessPam,
+            UsePam = usePam
+        };
+
+        var sut = new CurrentContextOrganization(orgUser);
+
+        Assert.Equal(expected, sut.AccessPam);
+    }
+}

--- a/test/Core.Test/AdminConsole/Helpers/PermissionsHelpersTests.cs
+++ b/test/Core.Test/AdminConsole/Helpers/PermissionsHelpersTests.cs
@@ -32,7 +32,8 @@ public class PermissionsHelpersTests
             ManageSso: true,
             ManageUsers: true,
             ManageResetPassword: true,
-            ManageScim: false
+            ManageScim: false,
+            ManageAccessRules: true
         });
     }
 }

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -1041,6 +1041,45 @@ public class OrganizationServiceTests
          InviteeUserType = OrganizationUserType.Custom,
          InvitorUserType = OrganizationUserType.Custom
      ), BitAutoData]
+    public async Task ValidateOrganizationUserUpdatePermissions_WithManageAccessRules_WhenSavingUserHasManageAccessRules_Passes(
+        CurrentContextOrganization organization,
+        OrganizationUserInvite organizationUserInvite,
+        SutProvider<OrganizationService> sutProvider)
+    {
+        organization.Permissions = new Permissions { ManageAccessRules = true };
+        var invitePermissions = new Permissions { ManageAccessRules = true };
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+        sutProvider.GetDependency<ICurrentContext>().ManageUsers(organization.Id).Returns(true);
+
+        await sutProvider.Sut.ValidateOrganizationUserUpdatePermissions(organization.Id, organizationUserInvite.Type.Value, null, invitePermissions);
+    }
+
+    [Theory]
+    [OrganizationInviteCustomize(
+         InviteeUserType = OrganizationUserType.Custom,
+         InvitorUserType = OrganizationUserType.Custom
+     ), BitAutoData]
+    public async Task ValidateOrganizationUserUpdatePermissions_WithManageAccessRules_WhenSavingUserLacksManageAccessRules_Throws(
+        CurrentContextOrganization organization,
+        OrganizationUserInvite organizationUserInvite,
+        SutProvider<OrganizationService> sutProvider)
+    {
+        organization.Permissions = new Permissions { ManageAccessRules = false };
+        var invitePermissions = new Permissions { ManageAccessRules = true };
+        sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
+        sutProvider.GetDependency<ICurrentContext>().ManageUsers(organization.Id).Returns(true);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.ValidateOrganizationUserUpdatePermissions(organization.Id, organizationUserInvite.Type.Value, null, invitePermissions));
+
+        Assert.Contains("custom users can only grant the same custom permissions that they have.", exception.Message.ToLowerInvariant());
+    }
+
+    [Theory]
+    [OrganizationInviteCustomize(
+         InviteeUserType = OrganizationUserType.Custom,
+         InvitorUserType = OrganizationUserType.Custom
+     ), BitAutoData]
     public async Task ValidateOrganizationUserUpdatePermissions_WithCustomAddingUser_WithoutPermissions_Throws(
         Guid organizationId,
         OrganizationUserInvite organizationUserInvite,

--- a/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
+++ b/test/Core.Test/AdminConsole/Services/OrganizationServiceTests.cs
@@ -1036,14 +1036,9 @@ public class OrganizationServiceTests
         Assert.Contains("custom users can not manage admins or owners.", exception.Message.ToLowerInvariant());
     }
 
-    [Theory]
-    [OrganizationInviteCustomize(
-         InviteeUserType = OrganizationUserType.Custom,
-         InvitorUserType = OrganizationUserType.Custom
-     ), BitAutoData]
+    [Theory, BitAutoData]
     public async Task ValidateOrganizationUserUpdatePermissions_WithManageAccessRules_WhenSavingUserHasManageAccessRules_Passes(
         CurrentContextOrganization organization,
-        OrganizationUserInvite organizationUserInvite,
         SutProvider<OrganizationService> sutProvider)
     {
         organization.Permissions = new Permissions { ManageAccessRules = true };
@@ -1051,17 +1046,12 @@ public class OrganizationServiceTests
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(organization.Id).Returns(organization);
         sutProvider.GetDependency<ICurrentContext>().ManageUsers(organization.Id).Returns(true);
 
-        await sutProvider.Sut.ValidateOrganizationUserUpdatePermissions(organization.Id, organizationUserInvite.Type.Value, null, invitePermissions);
+        await sutProvider.Sut.ValidateOrganizationUserUpdatePermissions(organization.Id, OrganizationUserType.Custom, null, invitePermissions);
     }
 
-    [Theory]
-    [OrganizationInviteCustomize(
-         InviteeUserType = OrganizationUserType.Custom,
-         InvitorUserType = OrganizationUserType.Custom
-     ), BitAutoData]
+    [Theory, BitAutoData]
     public async Task ValidateOrganizationUserUpdatePermissions_WithManageAccessRules_WhenSavingUserLacksManageAccessRules_Throws(
         CurrentContextOrganization organization,
-        OrganizationUserInvite organizationUserInvite,
         SutProvider<OrganizationService> sutProvider)
     {
         organization.Permissions = new Permissions { ManageAccessRules = false };
@@ -1070,7 +1060,7 @@ public class OrganizationServiceTests
         sutProvider.GetDependency<ICurrentContext>().ManageUsers(organization.Id).Returns(true);
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.ValidateOrganizationUserUpdatePermissions(organization.Id, organizationUserInvite.Type.Value, null, invitePermissions));
+            () => sutProvider.Sut.ValidateOrganizationUserUpdatePermissions(organization.Id, OrganizationUserType.Custom, null, invitePermissions));
 
         Assert.Contains("custom users can only grant the same custom permissions that they have.", exception.Message.ToLowerInvariant());
     }

--- a/test/Core.Test/Models/PermissionsTests.cs
+++ b/test/Core.Test/Models/PermissionsTests.cs
@@ -20,7 +20,8 @@ public class PermissionsTests
         "\"manageSso\": false,",
         "\"manageUsers\": false,",
         "\"manageResetPassword\": false,",
-        "\"manageScim\": false",
+        "\"manageScim\": false,",
+        "\"manageAccessRules\": false",
         "}");
 
     [Fact]
@@ -40,6 +41,7 @@ public class PermissionsTests
             ManageUsers = false,
             ManageResetPassword = false,
             ManageScim = false,
+            ManageAccessRules = false,
         };
 
         // minify expected json

--- a/test/Core.Test/Utilities/CoreHelpersTests.cs
+++ b/test/Core.Test/Utilities/CoreHelpersTests.cs
@@ -326,6 +326,34 @@ public class CoreHelpersTests
     }
 
     [Theory, BitAutoData, UserCustomize]
+    public void BuildIdentityClaims_SecretsManagerAccess_OnlyForOrganizationsWithAccess(User user,
+        CurrentContextOrganization orgWithAccess, CurrentContextOrganization orgWithoutAccess)
+    {
+        orgWithAccess.AccessSecretsManager = true;
+        orgWithoutAccess.AccessSecretsManager = false;
+
+        var actual = CoreHelpers.BuildIdentityClaims(user, [orgWithAccess, orgWithoutAccess],
+            Array.Empty<CurrentContextProvider>(), false);
+
+        Assert.Contains(new KeyValuePair<string, string>("accesssecretsmanager", orgWithAccess.Id.ToString()), actual);
+        Assert.DoesNotContain(new KeyValuePair<string, string>("accesssecretsmanager", orgWithoutAccess.Id.ToString()), actual);
+    }
+
+    [Theory, BitAutoData, UserCustomize]
+    public void BuildIdentityClaims_PamAccess_OnlyForOrganizationsWithAccess(User user,
+        CurrentContextOrganization orgWithAccess, CurrentContextOrganization orgWithoutAccess)
+    {
+        orgWithAccess.AccessPam = true;
+        orgWithoutAccess.AccessPam = false;
+
+        var actual = CoreHelpers.BuildIdentityClaims(user, [orgWithAccess, orgWithoutAccess],
+            Array.Empty<CurrentContextProvider>(), false);
+
+        Assert.Contains(new KeyValuePair<string, string>("accesspam", orgWithAccess.Id.ToString()), actual);
+        Assert.DoesNotContain(new KeyValuePair<string, string>("accesspam", orgWithoutAccess.Id.ToString()), actual);
+    }
+
+    [Theory, BitAutoData, UserCustomize]
     public void BuildIdentityClaims_ProviderClaims_Success(User user)
     {
         var fixture = new Fixture().WithAutoNSubstitutions();

--- a/test/Identity.IntegrationTest/openid-configuration.json
+++ b/test/Identity.IntegrationTest/openid-configuration.json
@@ -31,6 +31,7 @@
     "providerprovideradmin",
     "providerserviceuser",
     "accesssecretsmanager",
+    "accesspam",
     "sub",
     "send_id",
     "organization"

--- a/test/Libraries/OrganizationAuthorization.Test/Organizations/OrganizationClaimsExtensionsTests.cs
+++ b/test/Libraries/OrganizationAuthorization.Test/Organizations/OrganizationClaimsExtensionsTests.cs
@@ -38,7 +38,8 @@ public class OrganizationClaimsExtensionsTests
                 {
                     Id = Guid.NewGuid(),
                     Type = role,
-                    AccessSecretsManager = true
+                    AccessSecretsManager = true,
+                    AccessPam = true
                 }
             ];
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40209

## 📔 Objective

The identity/authorization spine for PAM, mirroring the Secrets Manager shape throughout: an `accesspam` claim beside `accesssecretsmanager`, and the one PAM custom permission, `ManageAccessRules`. Holding `AccessPam` **is** the access grant — there is no separate "can access PAM items" permission; `ManageAccessRules` only gates Access Rule authorship.

Consumption is left to the `IOrganizationRequirement` pattern (ADR-0022) in PM-40211, so this only touches claim emission and the claims-parsing path the requirement handler reads.

Worth flagging for review:

- **`CurrentContext` is untouched** — no `AccessPam(orgId)`/`ManageAccessRules(orgId)` helpers, no changes to its hand-rolled claims parsers. That's the legacy path requirements replace.
- **`PamAccess` is deliberately not in `UserIdentityClaimTypes`.** It's an authorization claim, so it must be rebuilt from the database on every issuance rather than carried across a refresh.
- **Two additions beyond the ticket's scope.** `ApiResources` declares `Claims.PamAccess` where `SecretsManagerAccess` already sits (not load-bearing, but keeps the declared resource claims honest). The public API's hand-rolled `PermissionsModel` gains `ManageAccessRules`, because `ToData()` rebuilds the whole object and would otherwise silently clear it on `PUT /public/members/{id}`; `ToData_RoundTripsEveryPermission` guards that mirror against future drift.
- **Known gap:** `OrganizationService.ValidateCustomPermissionsGrant` enumerates permissions against `ICurrentContext`, so it doesn't cover `ManageAccessRules` — a Custom member with `ManageUsers` could grant it without holding it. The newer `OrganizationUserValidationService` uses `ClaimsMap` and is covered. Closing the legacy path needs the `CurrentContext` helpers this story excludes.

Depends on PM-40208 (the `OrganizationUser.AccessPam` column), already merged.
