### PR TITLE
[PM-40210] Add single + bulk PAM enable flows for AccessPam

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -444,6 +444,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
                 model.Type.Value,
                 model.Permissions,
                 model.AccessSecretsManager,
+                model.AccessPam,
                 collectionAccessToSave,
                 groupsToSave,
                 model.Email,
@@ -794,6 +795,38 @@ public class OrganizationUsersController : BaseAdminConsoleController
         foreach (var orgUser in orgUsers)
         {
             orgUser.AccessSecretsManager = true;
+        }
+
+        await _organizationUserRepository.ReplaceManyAsync(orgUsers);
+    }
+
+    /// <summary>
+    /// Grants PAM access to the specified members. A plain field write: PAM has no seats, so there is no
+    /// autoscale or billing step. Members who already have access are skipped.
+    /// </summary>
+    [HttpPut("enable-pam")]
+    [Authorize<ManageUsersRequirement>]
+    public async Task BulkEnablePamAsync(Guid orgId,
+        [FromBody] OrganizationUserBulkRequestModel model)
+    {
+        var orgUsers = (await _organizationUserRepository.GetManyAsync(model.Ids))
+            .Where(ou => ou.OrganizationId == orgId && !ou.AccessPam).ToList();
+        if (orgUsers.Count == 0)
+        {
+            throw new BadRequestException("Users invalid.");
+        }
+
+        // Granting access on an organization without PAM would be inert: claim emission ANDs AccessPam with the
+        // organization's UsePam.
+        var organization = await _organizationRepository.GetByIdAsync(orgId);
+        if (organization is not { UsePam: true })
+        {
+            throw new BadRequestException("To grant PAM access the organization must have PAM enabled.");
+        }
+
+        foreach (var orgUser in orgUsers)
+        {
+            orgUser.AccessPam = true;
         }
 
         await _organizationUserRepository.ReplaceManyAsync(orgUsers);

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -813,7 +813,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
             .Where(ou => ou.OrganizationId == orgId && !ou.AccessPam).ToList();
         if (orgUsers.Count == 0)
         {
-            throw new BadRequestException("Users invalid.");
+            throw new BadRequestException(new UsersInvalid().Message);
         }
 
         // Granting access on an organization without PAM would be inert: claim emission ANDs AccessPam with the
@@ -821,7 +821,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
         var organization = await _organizationRepository.GetByIdAsync(orgId);
         if (organization is not { UsePam: true })
         {
-            throw new BadRequestException("To grant PAM access the organization must have PAM enabled.");
+            throw new BadRequestException(new V2_UpdateUserCommand.PamNotEnabled().Message);
         }
 
         foreach (var orgUser in orgUsers)

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -98,6 +98,7 @@ public class OrganizationUserUpdateRequestModel
     [EnumDataType(typeof(OrganizationUserType))]
     public OrganizationUserType? Type { get; set; }
     public bool AccessSecretsManager { get; set; }
+    public bool AccessPam { get; set; }
     public Permissions Permissions { get; set; }
     public IEnumerable<SelectionReadOnlyRequestModel> Collections { get; set; }
     public IEnumerable<Guid> Groups { get; set; }
@@ -118,6 +119,7 @@ public class OrganizationUserUpdateRequestModel
         existingUser.Type = Type.Value;
         existingUser.Permissions = CoreHelpers.ClassToJsonData(Permissions);
         existingUser.AccessSecretsManager = AccessSecretsManager;
+        existingUser.AccessPam = AccessPam;
         return existingUser;
     }
 }

--- a/src/Core/AdminConsole/Entities/OrganizationUser.cs
+++ b/src/Core/AdminConsole/Entities/OrganizationUser.cs
@@ -160,6 +160,7 @@ public class OrganizationUser : ITableObject<Guid>, IExternal, IOrganizationUser
     public OrganizationUser UpdateOrganizationUser(OrganizationUserType organizationUserType,
         Permissions? permissions,
         bool accessSecretsManager,
+        bool accessPam,
         TimeProvider timeProvider)
     {
         if (permissions is not null)
@@ -168,6 +169,7 @@ public class OrganizationUser : ITableObject<Guid>, IExternal, IOrganizationUser
         }
         Type = organizationUserType;
         AccessSecretsManager = accessSecretsManager;
+        AccessPam = accessPam;
         RevisionDate = timeProvider.GetUtcNow().UtcDateTime;
         return this;
     }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
@@ -14,6 +14,7 @@ using Bit.Core.OrganizationFeatures.OrganizationSubscriptions.Interface;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Bit.Core.Settings;
+using V2_UpdateUserCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.UpdateUser.v2;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers;
 
@@ -138,7 +139,7 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
         // Only the grant is gated — revoking access stays possible on an organization whose entitlement has lapsed.
         if (!originalOrganizationUser.AccessPam && organizationUser.AccessPam && !organization.UsePam)
         {
-            throw new BadRequestException("To grant PAM access the organization must have PAM enabled.");
+            throw new BadRequestException(new V2_UpdateUserCommand.PamNotEnabled().Message);
         }
 
         // Only autoscale (if required) after all validation has passed so that we know it's a valid request before

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommand.cs
@@ -133,6 +133,14 @@ public class UpdateOrganizationUserCommand : IUpdateOrganizationUserCommand
             }
         }
 
+        // Granting PAM access to a member of an organization without PAM would be inert: claim emission ANDs
+        // AccessPam with the organization's UsePam. Reject so the admin gets an actionable error instead.
+        // Only the grant is gated — revoking access stays possible on an organization whose entitlement has lapsed.
+        if (!originalOrganizationUser.AccessPam && organizationUser.AccessPam && !organization.UsePam)
+        {
+            throw new BadRequestException("To grant PAM access the organization must have PAM enabled.");
+        }
+
         // Only autoscale (if required) after all validation has passed so that we know it's a valid request before
         // updating Stripe
         if (!originalOrganizationUser.AccessSecretsManager && organizationUser.AccessSecretsManager)

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/Errors.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/Errors.cs
@@ -12,6 +12,7 @@ public record ManageMutuallyExclusive() : BadRequestError("The Manage property i
 public record CustomPermissionsNotEnabled() : BadRequestError("To enable custom permissions the organization must be on an Enterprise plan.");
 public record CannotAssignDefaultCollection() : BadRequestError("Default collections cannot be assigned to a member.");
 public record CannotAutoscaleSecretsManagerSeatsOnSelfHost() : BadRequestError("Cannot autoscale on a self-hosted instance.");
+public record PamNotEnabled() : BadRequestError("To grant PAM access the organization must have PAM enabled.");
 public record CouldNotIncreaseSeatsOfSecretManager(string Message) : BadRequestError(Message);
 
 public abstract record EmailValidationError(string Message, string Type) : BadRequestError(Message), IValidationError

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommand.cs
@@ -54,6 +54,7 @@ public class UpdateOrganizationUserCommand(
         var organizationUser = request.OrganizationUserToUpdate.UpdateOrganizationUser(request.NewType,
             request.NewPermissions,
             request.NewAccessSecretsManager,
+            request.NewAccessPam,
             timeProvider);
 
         if (request.IsEnablingSecretsManager())

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserRequest.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserRequest.cs
@@ -23,6 +23,7 @@ public record UpdateOrganizationUserRequest(
     OrganizationUserType NewType,
     Permissions? NewPermissions,
     bool NewAccessSecretsManager,
+    bool NewAccessPam,
     List<CollectionAccessSelection>? CollectionsToSave,
     IEnumerable<Guid>? NewGroups,
     string? NewEmail,
@@ -36,6 +37,12 @@ public record UpdateOrganizationUserRequest(
         && NewType is not (OrganizationUserType.Admin or OrganizationUserType.Owner);
 
     public bool IsEnablingSecretsManager() => !_existingAccessSecretsManager && NewAccessSecretsManager;
+
+    /// <summary>
+    /// Only a false → true transition is a grant. Revoking access stays possible on an organization whose PAM
+    /// entitlement has lapsed, so <see cref="Organization.UsePam"/> is not checked when disabling.
+    /// </summary>
+    public bool IsEnablingPam() => !_existingAccessPam && NewAccessPam;
 
     public bool IsEmailChanged() =>
         !string.IsNullOrWhiteSpace(NewEmail)
@@ -54,4 +61,5 @@ public record UpdateOrganizationUserRequest(
 
     private readonly OrganizationUserType _existingOrganizationUserType = OrganizationUserToUpdate.Type;
     private readonly bool _existingAccessSecretsManager = OrganizationUserToUpdate.AccessSecretsManager;
+    private readonly bool _existingAccessPam = OrganizationUserToUpdate.AccessPam;
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserValidator.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserValidator.cs
@@ -81,6 +81,13 @@ public class UpdateOrganizationUserValidator(
             return Invalid(request, new CustomPermissionsNotEnabled());
         }
 
+        // Granting PAM access to a member of an organization without PAM would be inert: claim emission ANDs
+        // AccessPam with the organization's UsePam. Reject so the admin gets an actionable error instead.
+        if (request.IsEnablingPam() && !request.Organization.UsePam)
+        {
+            return Invalid(request, new PamNotEnabled());
+        }
+
         if (request.NewType != OrganizationUserType.Owner &&
             !await hasConfirmedOwnersExceptQuery.HasConfirmedOwnersExceptAsync(organizationUser.OrganizationId,
                 [organizationUser.Id]))

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
@@ -312,6 +312,87 @@ public class OrganizationUserControllerPutTests : IClassFixture<ApiApplicationFa
         await AssertDoesNotHaveCollectionAsync(member, defaultCollection.Id);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Put_GrantingPam_PersistsAccessPam(bool flagOn)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.ChangeMemberEmailNoMp).Returns(flagOn);
+        await SetUsePamAsync(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var (_, member) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory, _organization.Id,
+            OrganizationUserType.User);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/{member.Id}",
+            UpdateRequest(accessPam: true));
+
+        Assert.Equal(ExpectedSuccess(flagOn), response.StatusCode);
+        await AssertAccessPamAsync(member, true);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Put_GrantingPamWithoutOrganizationPam_ReturnsBadRequest(bool flagOn)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.ChangeMemberEmailNoMp).Returns(flagOn);
+        await SetUsePamAsync(false);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var (_, member) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory, _organization.Id,
+            OrganizationUserType.User);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/{member.Id}",
+            UpdateRequest(accessPam: true));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(new PamNotEnabled().Message, await response.Content.ReadAsStringAsync());
+        await AssertAccessPamAsync(member, false);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Put_RevokingPamWithoutOrganizationPam_PersistsRevocation(bool flagOn)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.ChangeMemberEmailNoMp).Returns(flagOn);
+        // Revoking access must stay possible on an organization whose PAM entitlement has lapsed.
+        await SetUsePamAsync(false);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var (_, member) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory, _organization.Id,
+            OrganizationUserType.User);
+        await GrantPamAsync(member);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/{member.Id}",
+            UpdateRequest(accessPam: false));
+
+        Assert.Equal(ExpectedSuccess(flagOn), response.StatusCode);
+        await AssertAccessPamAsync(member, false);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Put_EditingMemberWhoAlreadyHasPamWithoutOrganizationPam_PreservesAccess(bool flagOn)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.ChangeMemberEmailNoMp).Returns(flagOn);
+        // Not a grant, so an unrelated edit to a member who already has access is not blocked.
+        await SetUsePamAsync(false);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var (_, member) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory, _organization.Id,
+            OrganizationUserType.User);
+        await GrantPamAsync(member);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/{member.Id}",
+            UpdateRequest(accessPam: true));
+
+        Assert.Equal(ExpectedSuccess(flagOn), response.StatusCode);
+        await AssertAccessPamAsync(member, true);
+    }
+
     [Fact]
     public async Task Put_WhenChangingRoleAndNameForClaimedMember_ReturnsNoContentAndPersistsBoth()
     {
@@ -491,6 +572,25 @@ public class OrganizationUserControllerPutTests : IClassFixture<ApiApplicationFa
         await _factory.GetService<IOrganizationRepository>().ReplaceAsync(_organization);
     }
 
+    private async Task SetUsePamAsync(bool value)
+    {
+        _organization.UsePam = value;
+        await _factory.GetService<IOrganizationRepository>().ReplaceAsync(_organization);
+    }
+
+    private async Task GrantPamAsync(OrganizationUser organizationUser)
+    {
+        organizationUser.AccessPam = true;
+        await _factory.GetService<IOrganizationUserRepository>().ReplaceAsync(organizationUser);
+    }
+
+    private async Task AssertAccessPamAsync(OrganizationUser organizationUser, bool expected)
+    {
+        var reloaded = await _factory.GetService<IOrganizationUserRepository>().GetByIdAsync(organizationUser.Id);
+        Assert.NotNull(reloaded);
+        Assert.Equal(expected, reloaded.AccessPam);
+    }
+
     private async Task<Group> CreateGroupAsync() =>
         await _factory.GetService<IGroupRepository>().CreateAsync(new Group
         {
@@ -582,7 +682,8 @@ public class OrganizationUserControllerPutTests : IClassFixture<ApiApplicationFa
         return (member, domain);
     }
 
-    private static OrganizationUserUpdateRequestModel UpdateRequest(string? email = null, string? name = null) =>
+    private static OrganizationUserUpdateRequestModel UpdateRequest(string? email = null, string? name = null,
+        bool accessPam = false) =>
         new()
         {
             Type = OrganizationUserType.User,
@@ -590,7 +691,8 @@ public class OrganizationUserControllerPutTests : IClassFixture<ApiApplicationFa
             Collections = [],
             Groups = [],
             Email = email,
-            Name = name
+            Name = name,
+            AccessPam = accessPam
         };
 
     private static async Task AssertValidationProblemAsync(

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
@@ -393,6 +393,48 @@ public class OrganizationUserControllerPutTests : IClassFixture<ApiApplicationFa
         await AssertAccessPamAsync(member, true);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Put_OmittingAccessPam_RevokesExistingAccess(bool flagOn)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.ChangeMemberEmailNoMp).Returns(flagOn);
+        await SetUsePamAsync(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var (_, member) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory, _organization.Id,
+            OrganizationUserType.User);
+        await GrantPamAsync(member);
+
+        // A client that predates the field sends no accessPam at all, which binds to the default of false.
+        // Callers must send the member's current value to preserve it.
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/{member.Id}",
+            new { type = OrganizationUserType.User, permissions = new Permissions(), collections = Array.Empty<object>(), groups = Array.Empty<Guid>() });
+
+        Assert.Equal(ExpectedSuccess(flagOn), response.StatusCode);
+        await AssertAccessPamAsync(member, false);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Put_AdminGrantingPamToSelf_Succeeds(bool flagOn)
+    {
+        _featureService.IsEnabled(FeatureFlagKeys.ChangeMemberEmailNoMp).Returns(flagOn);
+        await SetUsePamAsync(true);
+
+        // ManageUsers is the only gate on the endpoint, so an admin can grant themselves the access.
+        var (adminEmail, admin) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory,
+            _organization.Id, OrganizationUserType.Admin);
+        await _loginHelper.LoginAsync(adminEmail);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/{admin.Id}",
+            UpdateRequest(accessPam: true, type: OrganizationUserType.Admin));
+
+        Assert.Equal(ExpectedSuccess(flagOn), response.StatusCode);
+        await AssertAccessPamAsync(admin, true);
+    }
+
     [Fact]
     public async Task Put_WhenChangingRoleAndNameForClaimedMember_ReturnsNoContentAndPersistsBoth()
     {
@@ -683,10 +725,10 @@ public class OrganizationUserControllerPutTests : IClassFixture<ApiApplicationFa
     }
 
     private static OrganizationUserUpdateRequestModel UpdateRequest(string? email = null, string? name = null,
-        bool accessPam = false) =>
+        bool accessPam = false, OrganizationUserType type = OrganizationUserType.User) =>
         new()
         {
-            Type = OrganizationUserType.User,
+            Type = type,
             Permissions = new Permissions(),
             Collections = [],
             Groups = [],

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerBulkEnablePamTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerBulkEnablePamTests.cs
@@ -118,6 +118,53 @@ public class OrganizationUsersControllerBulkEnablePamTests
         await AssertAccessPamAsync(otherOrgMember, false);
     }
 
+    [Fact]
+    public async Task BulkEnablePam_GrantsAccessToInvitedAndRevokedMembers()
+    {
+        await SetUsePamAsync(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        // The endpoint filters on AccessPam only, so members who cannot currently use the access are still granted it.
+        var invitedMember = await CreateMemberAsync(status: OrganizationUserStatusType.Invited);
+        var revokedMember = await CreateMemberAsync();
+        await _factory.GetService<IOrganizationUserRepository>()
+            .RevokeAsync(revokedMember.Id, RevocationReason.Manual);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/enable-pam",
+            new OrganizationUserBulkRequestModel { Ids = [invitedMember.Id, revokedMember.Id] });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await AssertAccessPamAsync(invitedMember, true);
+        await AssertAccessPamAsync(revokedMember, true);
+    }
+
+    [Fact]
+    public async Task BulkEnablePam_WithUnknownIds_ReturnsBadRequest()
+    {
+        await SetUsePamAsync(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/enable-pam",
+            new OrganizationUserBulkRequestModel { Ids = [Guid.NewGuid()] });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(new V1_RestoreUserCommand.UsersInvalid().Message, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task BulkEnablePam_WithEmptyIds_ReturnsModelStateBadRequest()
+    {
+        await SetUsePamAsync(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/enable-pam",
+            new OrganizationUserBulkRequestModel { Ids = [] });
+
+        // Ids is [Required, MinLength(1)], so this is rejected by model validation before the endpoint runs.
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains("model state is invalid", await response.Content.ReadAsStringAsync());
+    }
+
     [Theory]
     [InlineData(OrganizationUserType.User)]
     [InlineData(OrganizationUserType.Custom)]
@@ -138,11 +185,13 @@ public class OrganizationUsersControllerBulkEnablePamTests
         await AssertAccessPamAsync(member, false);
     }
 
-    private async Task<OrganizationUser> CreateMemberAsync(Guid? organizationId = null)
+    private async Task<OrganizationUser> CreateMemberAsync(Guid? organizationId = null,
+        OrganizationUserStatusType status = OrganizationUserStatusType.Confirmed)
     {
-        var (_, member) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory,
-            organizationId ?? _organization.Id, OrganizationUserType.User);
-        return member;
+        var email = $"bulk-enable-pam-member-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(email);
+        return await OrganizationTestHelpers.CreateUserAsync(_factory, organizationId ?? _organization.Id, email,
+            OrganizationUserType.User, userStatusType: status);
     }
 
     private async Task SetUsePamAsync(bool value)

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerBulkEnablePamTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerBulkEnablePamTests.cs
@@ -1,0 +1,166 @@
+﻿using System.Net;
+using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.UpdateUser.v2;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Core.Repositories;
+using Xunit;
+using V1_RestoreUserCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RestoreUser.v1;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
+
+public class OrganizationUsersControllerBulkEnablePamTests
+    : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly ApiApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private readonly LoginHelper _loginHelper;
+
+    private Organization _organization = null!;
+    private string _ownerEmail = null!;
+
+    public OrganizationUsersControllerBulkEnablePamTests(ApiApplicationFactory apiFactory)
+    {
+        _factory = apiFactory;
+        _client = _factory.CreateClient();
+        _loginHelper = new LoginHelper(_factory, _client);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ownerEmail = $"bulk-enable-pam-{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(_ownerEmail);
+        (_organization, _) = await OrganizationTestHelpers.SignUpAsync(_factory, plan: PlanType.EnterpriseAnnually,
+            ownerEmail: _ownerEmail, passwordManagerSeats: 5, paymentMethod: PaymentMethodType.Card);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task BulkEnablePam_GrantsAccessAndLeavesMembersThatAlreadyHaveItUntouched()
+    {
+        await SetUsePamAsync(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var member = await CreateMemberAsync();
+        var alreadyEnabledMember = await CreateMemberAsync();
+        await GrantPamAsync(alreadyEnabledMember);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/enable-pam",
+            new OrganizationUserBulkRequestModel { Ids = [member.Id, alreadyEnabledMember.Id] });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await AssertAccessPamAsync(member, true);
+        await AssertAccessPamAsync(alreadyEnabledMember, true);
+    }
+
+    [Fact]
+    public async Task BulkEnablePam_WhenOrganizationDoesNotUsePam_ReturnsBadRequestAndPersistsNothing()
+    {
+        await SetUsePamAsync(false);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var member = await CreateMemberAsync();
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/enable-pam",
+            new OrganizationUserBulkRequestModel { Ids = [member.Id] });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(new PamNotEnabled().Message, await response.Content.ReadAsStringAsync());
+        await AssertAccessPamAsync(member, false);
+    }
+
+    [Fact]
+    public async Task BulkEnablePam_WhenEveryMemberAlreadyHasAccess_ReturnsBadRequest()
+    {
+        await SetUsePamAsync(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var member = await CreateMemberAsync();
+        await GrantPamAsync(member);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/enable-pam",
+            new OrganizationUserBulkRequestModel { Ids = [member.Id] });
+
+        // The empty-set check runs before the UsePam check, so this is "Users invalid." rather than the PAM error.
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Contains(new V1_RestoreUserCommand.UsersInvalid().Message, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task BulkEnablePam_DoesNotGrantAccessToMembersOfAnotherOrganization()
+    {
+        await SetUsePamAsync(true);
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var member = await CreateMemberAsync();
+
+        // A second organization owned by the same account, so the request is authorized for the first one only.
+        var (otherOrganization, _) = await OrganizationTestHelpers.SignUpAsync(_factory,
+            plan: PlanType.EnterpriseAnnually, ownerEmail: _ownerEmail, passwordManagerSeats: 5,
+            paymentMethod: PaymentMethodType.Card);
+        var otherOrgMember = await CreateMemberAsync(otherOrganization.Id);
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/enable-pam",
+            new OrganizationUserBulkRequestModel { Ids = [member.Id, otherOrgMember.Id] });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        await AssertAccessPamAsync(member, true);
+        await AssertAccessPamAsync(otherOrgMember, false);
+    }
+
+    [Theory]
+    [InlineData(OrganizationUserType.User)]
+    [InlineData(OrganizationUserType.Custom)]
+    public async Task BulkEnablePam_WithoutManageUsersPermission_ReturnsForbidden(OrganizationUserType userType)
+    {
+        await SetUsePamAsync(true);
+
+        var (callerEmail, _) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory,
+            _organization.Id, userType, new Permissions { ManageUsers = false });
+        await _loginHelper.LoginAsync(callerEmail);
+
+        var member = await CreateMemberAsync();
+
+        var response = await _client.PutAsJsonAsync($"organizations/{_organization.Id}/users/enable-pam",
+            new OrganizationUserBulkRequestModel { Ids = [member.Id] });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        await AssertAccessPamAsync(member, false);
+    }
+
+    private async Task<OrganizationUser> CreateMemberAsync(Guid? organizationId = null)
+    {
+        var (_, member) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory,
+            organizationId ?? _organization.Id, OrganizationUserType.User);
+        return member;
+    }
+
+    private async Task SetUsePamAsync(bool value)
+    {
+        _organization.UsePam = value;
+        await _factory.GetService<IOrganizationRepository>().ReplaceAsync(_organization);
+    }
+
+    private async Task GrantPamAsync(OrganizationUser organizationUser)
+    {
+        organizationUser.AccessPam = true;
+        await _factory.GetService<IOrganizationUserRepository>().ReplaceAsync(organizationUser);
+    }
+
+    private async Task AssertAccessPamAsync(OrganizationUser organizationUser, bool expected)
+    {
+        var reloaded = await _factory.GetService<IOrganizationUserRepository>().GetByIdAsync(organizationUser.Id);
+        Assert.NotNull(reloaded);
+        Assert.Equal(expected, reloaded.AccessPam);
+    }
+}

--- a/test/Api.IntegrationTest/AdminConsole/Public/Controllers/MembersControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Public/Controllers/MembersControllerTests.cs
@@ -230,6 +230,36 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
             orgUser.GetPermissions());
     }
 
+    /// <summary>
+    /// The public member model exposes neither AccessPam nor AccessSecretsManager, so an update through this
+    /// API must leave the member's PAM access as it found it rather than resetting it to the default.
+    /// </summary>
+    [Fact]
+    public async Task Put_ExistingMemberWithPamAccess_DoesNotRevokeIt()
+    {
+        var (_, orgUser) = await OrganizationTestHelpers.CreateNewUserWithAccountAsync(_factory, _organization.Id,
+            OrganizationUserType.User);
+
+        var organizationUserRepository = _factory.GetService<IOrganizationUserRepository>();
+        orgUser.AccessPam = true;
+        await organizationUserRepository.ReplaceAsync(orgUser);
+
+        var request = new MemberUpdateRequestModel
+        {
+            Type = OrganizationUserType.User,
+            ExternalId = "example",
+            Collections = []
+        };
+
+        var response = await _client.PutAsync($"/public/members/{orgUser.Id}", JsonContent.Create(request));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var updatedOrgUser = await organizationUserRepository.GetByIdAsync(orgUser.Id);
+        Assert.NotNull(updatedOrgUser);
+        Assert.True(updatedOrgUser.AccessPam);
+    }
+
     [Fact]
     public async Task Revoke_Member_Success()
     {

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -49,6 +49,103 @@ public class OrganizationUsersControllerTests
 {
     [Theory]
     [BitAutoData]
+    public async Task BulkEnablePam_GrantsAccessToMembersWithoutIt(Guid orgId,
+        OrganizationUserBulkRequestModel model, Organization organization, List<OrganizationUser> orgUsers,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        organization.UsePam = true;
+        foreach (var orgUser in orgUsers)
+        {
+            orgUser.OrganizationId = orgId;
+            orgUser.AccessPam = false;
+        }
+
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetManyAsync(model.Ids).Returns(orgUsers);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(orgId).Returns(organization);
+
+        await sutProvider.Sut.BulkEnablePamAsync(orgId, model);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceManyAsync(Arg.Is<IEnumerable<OrganizationUser>>(users => users.All(u => u.AccessPam)));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task BulkEnablePam_SkipsMembersOfOtherOrganizationsAndThoseWithAccess(Guid orgId,
+        OrganizationUserBulkRequestModel model, Organization organization, OrganizationUser targetUser,
+        OrganizationUser alreadyEnabledUser, OrganizationUser otherOrgUser,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        organization.UsePam = true;
+        targetUser.OrganizationId = alreadyEnabledUser.OrganizationId = orgId;
+        targetUser.AccessPam = false;
+        alreadyEnabledUser.AccessPam = true;
+        otherOrgUser.AccessPam = false;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetManyAsync(model.Ids)
+            .Returns([targetUser, alreadyEnabledUser, otherOrgUser]);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(orgId).Returns(organization);
+
+        await sutProvider.Sut.BulkEnablePamAsync(orgId, model);
+
+        Assert.False(otherOrgUser.AccessPam);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceManyAsync(Arg.Is<IEnumerable<OrganizationUser>>(users =>
+                users.Count() == 1 && users.Single().Id == targetUser.Id && users.Single().AccessPam));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task BulkEnablePam_WhenOrganizationDoesNotUsePam_Throws(Guid orgId,
+        OrganizationUserBulkRequestModel model, Organization organization, List<OrganizationUser> orgUsers,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        organization.UsePam = false;
+        foreach (var orgUser in orgUsers)
+        {
+            orgUser.OrganizationId = orgId;
+            orgUser.AccessPam = false;
+        }
+
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetManyAsync(model.Ids).Returns(orgUsers);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(orgId).Returns(organization);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.BulkEnablePamAsync(orgId, model));
+
+        Assert.Contains("must have PAM enabled", exception.Message);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceManyAsync(default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task BulkEnablePam_WhenNoMembersNeedAccess_Throws(Guid orgId,
+        OrganizationUserBulkRequestModel model, List<OrganizationUser> orgUsers,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        foreach (var orgUser in orgUsers)
+        {
+            orgUser.OrganizationId = orgId;
+            orgUser.AccessPam = true;
+        }
+
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetManyAsync(model.Ids).Returns(orgUsers);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.BulkEnablePamAsync(orgId, model));
+
+        Assert.Equal("Users invalid.", exception.Message);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceManyAsync(default);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task PutResetPasswordEnrollment_InvitedUser_AcceptsInvite(Guid orgId, Guid userId, OrganizationUserResetPasswordEnrollmentRequestModel model,
         User user, OrganizationUser orgUser, SutProvider<OrganizationUsersController> sutProvider)
     {

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -39,6 +39,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using NSubstitute;
 using OneOf.Types;
 using Xunit;
+using V1_RestoreUserCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.RestoreUser.v1;
 using V2_UpdateUserCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.UpdateUser.v2;
 
 namespace Bit.Api.Test.AdminConsole.Controllers;
@@ -115,7 +116,7 @@ public class OrganizationUsersControllerTests
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.BulkEnablePamAsync(orgId, model));
 
-        Assert.Contains("must have PAM enabled", exception.Message);
+        Assert.Equal(new V2_UpdateUserCommand.PamNotEnabled().Message, exception.Message);
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .DidNotReceiveWithAnyArgs()
             .ReplaceManyAsync(default);
@@ -138,7 +139,7 @@ public class OrganizationUsersControllerTests
         var exception = await Assert.ThrowsAsync<BadRequestException>(
             () => sutProvider.Sut.BulkEnablePamAsync(orgId, model));
 
-        Assert.Equal("Users invalid.", exception.Message);
+        Assert.Equal(new V1_RestoreUserCommand.UsersInvalid().Message, exception.Message);
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .DidNotReceiveWithAnyArgs()
             .ReplaceManyAsync(default);

--- a/test/Core.Test/AdminConsole/Entities/OrganizationUserTests.cs
+++ b/test/Core.Test/AdminConsole/Entities/OrganizationUserTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Enums;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Bit.Core.Test.AdminConsole.Entities;
@@ -98,5 +99,43 @@ public class OrganizationUserTests
         };
 
         Assert.Equal(OrganizationUserStatusType.Confirmed, orgUser.GetPriorActiveOrganizationUserStatusType());
+    }
+
+    /// <summary>
+    /// The two entitlement flags are adjacent bool parameters, so a swapped call site would compile and
+    /// silently grant the wrong one. Every combination is asserted to land in its own field.
+    /// </summary>
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void UpdateOrganizationUser_MapsEntitlementFlagsIndependently(bool accessSecretsManager, bool accessPam)
+    {
+        var orgUser = new OrganizationUser
+        {
+            Type = OrganizationUserType.User,
+            AccessSecretsManager = !accessSecretsManager,
+            AccessPam = !accessPam
+        };
+
+        orgUser.UpdateOrganizationUser(OrganizationUserType.Admin, null, accessSecretsManager, accessPam,
+            TimeProvider.System);
+
+        Assert.Equal(accessSecretsManager, orgUser.AccessSecretsManager);
+        Assert.Equal(accessPam, orgUser.AccessPam);
+        Assert.Equal(OrganizationUserType.Admin, orgUser.Type);
+    }
+
+    [Fact]
+    public void UpdateOrganizationUser_SetsRevisionDateFromTimeProvider()
+    {
+        var now = new DateTimeOffset(2026, 8, 10, 12, 0, 0, TimeSpan.Zero);
+        var timeProvider = new FakeTimeProvider(now);
+        var orgUser = new OrganizationUser { Type = OrganizationUserType.User };
+
+        orgUser.UpdateOrganizationUser(OrganizationUserType.User, null, false, false, timeProvider);
+
+        Assert.Equal(now.UtcDateTime, orgUser.RevisionDate);
     }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
@@ -197,6 +197,77 @@ public class UpdateOrganizationUserCommandTests
             Arg.Is<IEnumerable<Guid>>(i => i.Contains(newUserData.Id)));
     }
 
+    [Theory, BitAutoData]
+    public async Task UpdateUserAsync_WhenGrantingPam_AndOrganizationDoesNotUsePam_Throws(
+        Organization organization,
+        OrganizationUser oldUserData,
+        OrganizationUser newUserData,
+        [OrganizationUser(type: OrganizationUserType.Owner)] OrganizationUser savingUser,
+        SutProvider<UpdateOrganizationUserCommand> sutProvider)
+    {
+        Setup(sutProvider, organization, newUserData, oldUserData);
+        organization.UsePam = false;
+        newUserData.Permissions = null;
+        oldUserData.AccessPam = false;
+        newUserData.AccessPam = true;
+        newUserData.Type = OrganizationUserType.User;
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.UpdateUserAsync(newUserData, OrganizationUserType.User, savingUser.UserId, null, null));
+
+        Assert.Contains("must have PAM enabled", exception.Message);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceAsync(default, default(IEnumerable<CollectionAccessSelection>));
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateUserAsync_WhenGrantingPam_AndOrganizationUsesPam_Persists(
+        Organization organization,
+        OrganizationUser oldUserData,
+        OrganizationUser newUserData,
+        [OrganizationUser(type: OrganizationUserType.Owner)] OrganizationUser savingUser,
+        SutProvider<UpdateOrganizationUserCommand> sutProvider)
+    {
+        Setup(sutProvider, organization, newUserData, oldUserData);
+        organization.UsePam = true;
+        newUserData.Permissions = null;
+        oldUserData.AccessPam = false;
+        newUserData.AccessPam = true;
+        newUserData.Type = OrganizationUserType.User;
+
+        await sutProvider.Sut.UpdateUserAsync(newUserData, OrganizationUserType.User, savingUser.UserId, null, null);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceAsync(Arg.Is<OrganizationUser>(ou => ou.AccessPam),
+                Arg.Any<IEnumerable<CollectionAccessSelection>>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task UpdateUserAsync_WhenRevokingPam_AndOrganizationDoesNotUsePam_Persists(
+        Organization organization,
+        OrganizationUser oldUserData,
+        OrganizationUser newUserData,
+        [OrganizationUser(type: OrganizationUserType.Owner)] OrganizationUser savingUser,
+        SutProvider<UpdateOrganizationUserCommand> sutProvider)
+    {
+        // Revoking access must stay possible on an organization whose PAM entitlement has lapsed.
+        Setup(sutProvider, organization, newUserData, oldUserData);
+        organization.UsePam = false;
+        newUserData.Permissions = null;
+        oldUserData.AccessPam = true;
+        newUserData.AccessPam = false;
+        newUserData.Type = OrganizationUserType.User;
+
+        await sutProvider.Sut.UpdateUserAsync(newUserData, OrganizationUserType.User, savingUser.UserId, null, null);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceAsync(Arg.Is<OrganizationUser>(ou => !ou.AccessPam),
+                Arg.Any<IEnumerable<CollectionAccessSelection>>());
+    }
+
     [Theory]
     [BitAutoData(OrganizationUserType.Admin)]
     [BitAutoData(OrganizationUserType.Owner)]

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateOrganizationUserCommandTests.cs
@@ -23,6 +23,7 @@ using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
 using Xunit;
+using V2_UpdateUserCommand = Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.UpdateUser.v2;
 
 namespace Bit.Core.Test.AdminConsole.OrganizationFeatures.OrganizationUsers;
 
@@ -215,7 +216,7 @@ public class UpdateOrganizationUserCommandTests
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
             sutProvider.Sut.UpdateUserAsync(newUserData, OrganizationUserType.User, savingUser.UserId, null, null));
 
-        Assert.Contains("must have PAM enabled", exception.Message);
+        Assert.Equal(new V2_UpdateUserCommand.PamNotEnabled().Message, exception.Message);
         await sutProvider.GetDependency<IOrganizationUserRepository>()
             .DidNotReceiveWithAnyArgs()
             .ReplaceAsync(default, default(IEnumerable<CollectionAccessSelection>));

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserCommandTests.cs
@@ -66,6 +66,44 @@ public class UpdateOrganizationUserCommandTests
 
     [Theory]
     [BitAutoData]
+    public async Task UpdateUserAsync_WhenGrantingPam_PersistsAccessPam(
+        SutProvider<UpdateOrganizationUserCommand> sutProvider,
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser organizationUser)
+    {
+        organizationUser.AccessPam = false;
+        var request = Setup(sutProvider, organization, organizationUser, targetAccessPam: true);
+
+        var result = await sutProvider.Sut.UpdateUserAsync(request);
+
+        Assert.True(result.IsSuccess);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceAsync(Arg.Is<OrganizationUser>(ou => ou.AccessPam),
+                Arg.Any<IEnumerable<CollectionAccessSelection>>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task UpdateUserAsync_WhenRevokingPam_PersistsAccessPamAsFalse(
+        SutProvider<UpdateOrganizationUserCommand> sutProvider,
+        Organization organization,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser organizationUser)
+    {
+        organizationUser.AccessPam = true;
+        var request = Setup(sutProvider, organization, organizationUser, targetAccessPam: false);
+
+        var result = await sutProvider.Sut.UpdateUserAsync(request);
+
+        Assert.True(result.IsSuccess);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceAsync(Arg.Is<OrganizationUser>(ou => !ou.AccessPam),
+                Arg.Any<IEnumerable<CollectionAccessSelection>>());
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task UpdateUserAsync_WhenEmailChanged_NotifiesMemberAtPreviousEmail(
         SutProvider<UpdateOrganizationUserCommand> sutProvider,
         Organization organization,
@@ -429,7 +467,8 @@ public class UpdateOrganizationUserCommandTests
         bool targetAccessSecretsManager = false,
         string defaultUserCollectionName = null,
         string newEmail = null,
-        string newName = null)
+        string newName = null,
+        bool targetAccessPam = false)
     {
         organization.PlanType = PlanType.EnterpriseAnnually;
         organizationUser.OrganizationId = organization.Id;
@@ -446,6 +485,7 @@ public class UpdateOrganizationUserCommandTests
             type,
             null,
             targetAccessSecretsManager,
+            targetAccessPam,
             collections,
             groups,
             newEmail,

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserValidatorTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/UpdateUser/v2/UpdateOrganizationUserValidatorTests.cs
@@ -168,6 +168,73 @@ public class UpdateOrganizationUserValidatorTests
 
     [Theory]
     [BitAutoData]
+    public async Task ValidateAsync_WhenGrantingPamAndOrganizationDoesNotUsePam_ReturnsPamNotEnabled(
+        SutProvider<UpdateOrganizationUserValidator> sutProvider,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser)
+    {
+        orgUser.AccessPam = false;
+        var organization = CreateOrganization(orgUser.OrganizationId, PlanType.EnterpriseAnnually, usePam: false);
+        var request = CreateRequest(sutProvider, orgUser, OrganizationUserType.User, organization: organization,
+            newAccessPam: true);
+
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<PamNotEnabled>(result.AsError);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_WhenGrantingPamAndOrganizationUsesPam_ReturnsValid(
+        SutProvider<UpdateOrganizationUserValidator> sutProvider,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser)
+    {
+        orgUser.AccessPam = false;
+        var organization = CreateOrganization(orgUser.OrganizationId, PlanType.EnterpriseAnnually, usePam: true);
+        var request = CreateRequest(sutProvider, orgUser, OrganizationUserType.User, organization: organization,
+            newAccessPam: true);
+
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_WhenRevokingPamAndOrganizationDoesNotUsePam_ReturnsValid(
+        SutProvider<UpdateOrganizationUserValidator> sutProvider,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser)
+    {
+        // Revoking access must stay possible on an organization whose PAM entitlement has lapsed.
+        orgUser.AccessPam = true;
+        var organization = CreateOrganization(orgUser.OrganizationId, PlanType.EnterpriseAnnually, usePam: false);
+        var request = CreateRequest(sutProvider, orgUser, OrganizationUserType.User, organization: organization,
+            newAccessPam: false);
+
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_WhenMemberAlreadyHasPamAndOrganizationDoesNotUsePam_ReturnsValid(
+        SutProvider<UpdateOrganizationUserValidator> sutProvider,
+        [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.User)] OrganizationUser orgUser)
+    {
+        // Not a grant, so an unrelated edit to a member who already has access is not blocked.
+        orgUser.AccessPam = true;
+        var organization = CreateOrganization(orgUser.OrganizationId, PlanType.EnterpriseAnnually, usePam: false);
+        var request = CreateRequest(sutProvider, orgUser, OrganizationUserType.User, organization: organization,
+            newAccessPam: true);
+
+        var result = await sutProvider.Sut.ValidateAsync(request);
+
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [BitAutoData]
     public async Task ValidateAsync_WhenRemovingLastConfirmedOwner_ReturnsMustHaveConfirmedOwner(
         SutProvider<UpdateOrganizationUserValidator> sutProvider,
         [OrganizationUser(OrganizationUserStatusType.Confirmed, OrganizationUserType.Owner)] OrganizationUser orgUser)
@@ -580,7 +647,8 @@ public class UpdateOrganizationUserValidatorTests
         Permissions newPermissions = null,
         string newEmail = null,
         string newName = null,
-        User userToUpdate = null)
+        User userToUpdate = null,
+        bool newAccessPam = false)
     {
         sutProvider.GetDependency<IHasConfirmedOwnersExceptQuery>()
             .HasConfirmedOwnersExceptAsync(organizationUser.OrganizationId, Arg.Any<IEnumerable<Guid>>())
@@ -609,6 +677,7 @@ public class UpdateOrganizationUserValidatorTests
             newType,
             newPermissions,
             false,
+            newAccessPam,
             collectionAccess,
             groups,
             newEmail,
@@ -618,6 +687,7 @@ public class UpdateOrganizationUserValidatorTests
             userToUpdate);
     }
 
-    private static Organization CreateOrganization(Guid id, PlanType planType, bool useCustomPermissions = true) =>
-        new() { Id = id, PlanType = planType, UseCustomPermissions = useCustomPermissions };
+    private static Organization CreateOrganization(Guid id, PlanType planType, bool useCustomPermissions = true,
+        bool usePam = false) =>
+        new() { Id = id, PlanType = planType, UseCustomPermissions = useCustomPermissions, UsePam = usePam };
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserReplaceTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserReplaceTests.cs
@@ -94,4 +94,63 @@ public class OrganizationUserReplaceTests
         Assert.NotNull(actualCollection);
         Assert.Equal(orgUser.RevisionDate, actualCollection.RevisionDate, TimeSpan.FromMilliseconds(10));
     }
+
+    /// <summary>
+    /// The persistence path behind the single-member PAM grant and revoke.
+    /// </summary>
+    [DatabaseTheory, DatabaseData]
+    public async Task ReplaceAsync_RoundTripsAccessPam(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository)
+    {
+        var organization = await organizationRepository.CreateTestOrganizationAsync();
+        var user = await userRepository.CreateTestUserAsync();
+        var orgUser = await organizationUserRepository.CreateTestOrganizationUserAsync(organization, user);
+        Assert.False(orgUser.AccessPam);
+
+        orgUser.AccessPam = true;
+        await organizationUserRepository.ReplaceAsync(orgUser);
+
+        var granted = await organizationUserRepository.GetByIdAsync(orgUser.Id);
+        Assert.NotNull(granted);
+        Assert.True(granted.AccessPam);
+
+        granted.AccessPam = false;
+        await organizationUserRepository.ReplaceAsync(granted);
+
+        var revoked = await organizationUserRepository.GetByIdAsync(orgUser.Id);
+        Assert.NotNull(revoked);
+        Assert.False(revoked.AccessPam);
+    }
+
+    /// <summary>
+    /// The persistence path behind the bulk PAM grant, which writes several members in one statement.
+    /// </summary>
+    [DatabaseTheory, DatabaseData]
+    public async Task ReplaceManyAsync_RoundTripsAccessPam(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository)
+    {
+        var organization = await organizationRepository.CreateTestOrganizationAsync();
+        var firstUser = await userRepository.CreateTestUserAsync("pam-first");
+        var secondUser = await userRepository.CreateTestUserAsync("pam-second");
+        var firstOrgUser = await organizationUserRepository.CreateTestOrganizationUserAsync(organization, firstUser);
+        var secondOrgUser = await organizationUserRepository.CreateTestOrganizationUserAsync(organization, secondUser);
+
+        // Load through the repository first, as the bulk endpoint does: the EF implementation can only update
+        // entities that came from a query.
+        var toUpdate = await organizationUserRepository.GetManyAsync([firstOrgUser.Id, secondOrgUser.Id]);
+        foreach (var orgUser in toUpdate)
+        {
+            orgUser.AccessPam = true;
+        }
+
+        await organizationUserRepository.ReplaceManyAsync(toUpdate);
+
+        var actual = await organizationUserRepository.GetManyAsync([firstOrgUser.Id, secondOrgUser.Id]);
+        Assert.Equal(2, actual.Count);
+        Assert.All(actual, ou => Assert.True(ou.AccessPam));
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40210

## 📔 Objective

The member-management flows that grant and revoke `AccessPam`, the admin-controlled per-member PAM access grant. Both paths are plain field writes behind an org-level `UsePam` check.

Worth flagging for review:

- **No seat logic anywhere.** PAM has no seats, so there is deliberately no analogue of the SM pattern — no `CountNewSmSeatsRequiredQuery`, no `UpdateSecretsManagerSubscriptionCommand`, no autoscale-last ordering rule. The story's earlier `AllocatePamSeats` version is superseded.
- **Why an explicit `UsePam` guard.** SM has no explicit check in these flows; it leans on `CountNewSmSeatsRequiredQuery` throwing *"Organization does not use Secrets Manager"* as a side effect of counting seats. With no seat count to piggyback on, PAM checks `UsePam` directly — otherwise `AccessPam = true` on a non-PAM org is inert but unvalidated, since claim emission ANDs the two (PM-40209), and the admin gets a silently ineffective toggle instead of an error.
- **Only the grant is gated.** Revoking access is not checked against `UsePam`, so removing a member's access stays possible on an org whose entitlement has lapsed. Editing a member who already holds access is likewise not a grant.
- **Both sides of the flag.** The single-user path is implemented in both the v1 command and the v2 command behind `ChangeMemberEmailNoMp`, so the toggle behaves identically whichever serves the request. v2 gets an `IsEnablingPam()` transition helper and a typed `PamNotEnabled` validator error; v1 guards inline with the other validation.
- **Bulk endpoint** is `PUT organizations/{orgId}/users/enable-pam`, mirroring `BulkEnableSecretsManagerAsync` minus the seat block. SM's obsolete `PATCH` alias is not replicated, and like SM's bulk path it logs no events (breakdown review note 5).

`UpdateOrganizationUser` gains an `accessPam` parameter; its only production caller is the v2 command.

Depends on #8160 (claims plumbing) — review that first.
