### PR TITLE
[PM-39455] Let the organization rotate the account recovery key

### DIFF
--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -140,9 +140,3 @@ public class OrganizationUserBulkRequestModel
     public string? DefaultUserCollectionName { get; set; }
 }
 #nullable disable
-
-public class ResetPasswordWithOrgIdRequestModel : OrganizationUserResetPasswordEnrollmentRequestModel
-{
-    [Required]
-    public Guid OrganizationId { get; set; }
-}

--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -138,9 +138,3 @@ public class OrganizationUserBulkRequestModel
     public string? DefaultUserCollectionName { get; set; }
 }
 #nullable disable
-
-public class ResetPasswordWithOrgIdRequestModel : OrganizationUserResetPasswordEnrollmentRequestModel
-{
-    [Required]
-    public Guid OrganizationId { get; set; }
-}

--- a/src/Api/KeyManagement/Controllers/AccountsKeyManagementController.cs
+++ b/src/Api/KeyManagement/Controllers/AccountsKeyManagementController.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Api.AdminConsole.Models.Request.Organizations;
-using Bit.Api.Auth.Models.Request;
+﻿using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.WebAuthn;
 using Bit.Api.KeyManagement.Enums;
 using Bit.Api.KeyManagement.Models.Requests;
@@ -41,8 +40,7 @@ public class AccountsKeyManagementController : Controller
     private readonly IRotationValidator<IEnumerable<SendWithIdRequestModel>, IReadOnlyList<Send>> _sendValidator;
     private readonly IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>
         _emergencyAccessValidator;
-    private readonly IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>,
-            IReadOnlyList<OrganizationUser>>
+    private readonly IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>
         _organizationUserValidator;
     private readonly IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>
         _webauthnKeyValidator;
@@ -65,7 +63,7 @@ public class AccountsKeyManagementController : Controller
         IRotationValidator<IEnumerable<SendWithIdRequestModel>, IReadOnlyList<Send>> sendValidator,
         IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>
             emergencyAccessValidator,
-        IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>, IReadOnlyList<OrganizationUser>>
+        IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>
             organizationUserValidator,
         IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>
             webAuthnKeyValidator,
@@ -141,7 +139,12 @@ public class AccountsKeyManagementController : Controller
                         model.AccountUnlockData.EmergencyAccessUnlockData),
                 OrganizationUsers =
                     await _organizationUserValidator.ValidateAsync(user,
-                        model.AccountUnlockData.OrganizationAccountRecoveryUnlockData),
+                        new OrganizationAccountRecoveryRotationData
+                        {
+                            AccountRecoveryUnlockData = model.AccountUnlockData.OrganizationAccountRecoveryUnlockData,
+                            // A manual key rotation carries no upgrade token, see V2UpgradeToken below.
+                            HasV2UpgradeToken = false
+                        }),
                 WebAuthnKeys =
                     await _webauthnKeyValidator.ValidateAsync(user, model.AccountUnlockData.PasskeyUnlockData),
                 DeviceKeys = await _deviceValidator.ValidateAsync(user, model.AccountUnlockData.DeviceKeyUnlockData),
@@ -291,11 +294,14 @@ public class AccountsKeyManagementController : Controller
                 await _emergencyAccessValidator.ValidateAsync(user, request.UnlockData.EmergencyAccessUnlockData),
             OrganizationUsers =
                 await _organizationUserValidator.ValidateAsync(user,
-                    request.UnlockData.OrganizationAccountRecoveryUnlockData),
+                    new OrganizationAccountRecoveryRotationData
+                    {
+                        AccountRecoveryUnlockData = request.UnlockData.OrganizationAccountRecoveryUnlockData,
+                        HasV2UpgradeToken = request.UnlockData.V2UpgradeToken != null
+                    }),
             WebAuthnKeys = await _webauthnKeyValidator.ValidateAsync(user, request.UnlockData.PasskeyUnlockData),
             DeviceKeys = await _deviceValidator.ValidateAsync(user, request.UnlockData.DeviceKeyUnlockData),
             V2UpgradeToken = request.UnlockData.V2UpgradeToken?.ToData(),
-
             Ciphers = await _cipherValidator.ValidateAsync(user, request.AccountData.Ciphers),
             Folders = await _folderValidator.ValidateAsync(user, request.AccountData.Folders),
             Sends = await _sendValidator.ValidateAsync(user, request.AccountData.Sends),

--- a/src/Api/KeyManagement/Controllers/AccountsKeyManagementController.cs
+++ b/src/Api/KeyManagement/Controllers/AccountsKeyManagementController.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Api.AdminConsole.Models.Request.Organizations;
-using Bit.Api.Auth.Models.Request;
+﻿using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.WebAuthn;
 using Bit.Api.KeyManagement.Enums;
 using Bit.Api.KeyManagement.Models.Requests;
@@ -41,8 +40,7 @@ public class AccountsKeyManagementController : Controller
     private readonly IRotationValidator<IEnumerable<SendWithIdRequestModel>, IReadOnlyList<Send>> _sendValidator;
     private readonly IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>
         _emergencyAccessValidator;
-    private readonly IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>,
-            IReadOnlyList<OrganizationUser>>
+    private readonly IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>
         _organizationUserValidator;
     private readonly IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>
         _webauthnKeyValidator;
@@ -64,7 +62,7 @@ public class AccountsKeyManagementController : Controller
         IRotationValidator<IEnumerable<SendWithIdRequestModel>, IReadOnlyList<Send>> sendValidator,
         IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>
             emergencyAccessValidator,
-        IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>, IReadOnlyList<OrganizationUser>>
+        IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>
             organizationUserValidator,
         IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>
             webAuthnKeyValidator,
@@ -124,7 +122,12 @@ public class AccountsKeyManagementController : Controller
                         model.AccountUnlockData.EmergencyAccessUnlockData),
                 OrganizationUsers =
                     await _organizationUserValidator.ValidateAsync(user,
-                        model.AccountUnlockData.OrganizationAccountRecoveryUnlockData),
+                        new OrganizationAccountRecoveryRotationData
+                        {
+                            AccountRecoveryUnlockData = model.AccountUnlockData.OrganizationAccountRecoveryUnlockData,
+                            // A manual key rotation carries no upgrade token, see V2UpgradeToken below.
+                            HasV2UpgradeToken = false
+                        }),
                 WebAuthnKeys =
                     await _webauthnKeyValidator.ValidateAsync(user, model.AccountUnlockData.PasskeyUnlockData),
                 DeviceKeys = await _deviceValidator.ValidateAsync(user, model.AccountUnlockData.DeviceKeyUnlockData),
@@ -274,11 +277,14 @@ public class AccountsKeyManagementController : Controller
                 await _emergencyAccessValidator.ValidateAsync(user, request.UnlockData.EmergencyAccessUnlockData),
             OrganizationUsers =
                 await _organizationUserValidator.ValidateAsync(user,
-                    request.UnlockData.OrganizationAccountRecoveryUnlockData),
+                    new OrganizationAccountRecoveryRotationData
+                    {
+                        AccountRecoveryUnlockData = request.UnlockData.OrganizationAccountRecoveryUnlockData,
+                        HasV2UpgradeToken = request.UnlockData.V2UpgradeToken != null
+                    }),
             WebAuthnKeys = await _webauthnKeyValidator.ValidateAsync(user, request.UnlockData.PasskeyUnlockData),
             DeviceKeys = await _deviceValidator.ValidateAsync(user, request.UnlockData.DeviceKeyUnlockData),
             V2UpgradeToken = request.UnlockData.V2UpgradeToken?.ToData(),
-
             Ciphers = await _cipherValidator.ValidateAsync(user, request.AccountData.Ciphers),
             Folders = await _folderValidator.ValidateAsync(user, request.AccountData.Folders),
             Sends = await _sendValidator.ValidateAsync(user, request.AccountData.Sends),

--- a/src/Api/KeyManagement/Models/Requests/CommonUnlockDataRequestModel.cs
+++ b/src/Api/KeyManagement/Models/Requests/CommonUnlockDataRequestModel.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Api.AdminConsole.Models.Request.Organizations;
-using Bit.Api.Auth.Models.Request;
+﻿using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.WebAuthn;
 using Bit.Core.Auth.Models.Api.Request;
 
@@ -8,7 +7,7 @@ namespace Bit.Api.KeyManagement.Models.Requests;
 public class CommonUnlockDataRequestModel
 {
     public required IEnumerable<EmergencyAccessWithIdRequestModel> EmergencyAccessUnlockData { get; set; }
-    public required IEnumerable<ResetPasswordWithOrgIdRequestModel> OrganizationAccountRecoveryUnlockData { get; set; }
+    public required IEnumerable<OrganizationUserAccountRecoveryRequestModel> OrganizationAccountRecoveryUnlockData { get; set; }
     public required IEnumerable<WebAuthnLoginRotateKeyRequestModel> PasskeyUnlockData { get; set; }
     public required IEnumerable<OtherDeviceKeysUpdateRequestModel> DeviceKeyUnlockData { get; set; }
     public V2UpgradeTokenRequestModel? V2UpgradeToken { get; set; }

--- a/src/Api/KeyManagement/Models/Requests/OrganizationAccountRecoveryRotationData.cs
+++ b/src/Api/KeyManagement/Models/Requests/OrganizationAccountRecoveryRotationData.cs
@@ -1,0 +1,11 @@
+﻿namespace Bit.Api.KeyManagement.Models.Requests;
+
+/// <summary>
+/// The account recovery keys submitted for a key rotation, together with whether the rotation carries a
+/// V2 upgrade token. The token changes what the server accepts, so the validator needs to see both.
+/// </summary>
+public class OrganizationAccountRecoveryRotationData
+{
+    public required IEnumerable<OrganizationUserAccountRecoveryRequestModel> AccountRecoveryUnlockData { get; init; }
+    public required bool HasV2UpgradeToken { get; init; }
+}

--- a/src/Api/KeyManagement/Models/Requests/OrganizationUserAccountRecoveryRequestModel.cs
+++ b/src/Api/KeyManagement/Models/Requests/OrganizationUserAccountRecoveryRequestModel.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Utilities;
+
+namespace Bit.Api.KeyManagement.Models.Requests;
+
+/// <summary>
+/// An organization membership's account recovery key, submitted during key rotation.
+/// </summary>
+public class OrganizationUserAccountRecoveryRequestModel
+{
+    [Required]
+    public Guid OrganizationId { get; set; }
+
+    /// <summary>
+    /// The user key encapsulated by the organization's public key. NULL during a V1 to V2 upgrade rotation,
+    /// where an admin re-encapsulates it later from the upgrade token.
+    /// </summary>
+    [EncryptedString]
+    public string? ResetPasswordKey { get; set; }
+}

--- a/src/Api/KeyManagement/Models/Requests/UnlockDataRequestModel.cs
+++ b/src/Api/KeyManagement/Models/Requests/UnlockDataRequestModel.cs
@@ -1,5 +1,4 @@
-﻿using Bit.Api.AdminConsole.Models.Request.Organizations;
-using Bit.Api.Auth.Models.Request;
+﻿using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.WebAuthn;
 using Bit.Core.Auth.Models.Api.Request;
 
@@ -10,7 +9,7 @@ public class UnlockDataRequestModel
     // All methods to get to the userkey
     public required MasterPasswordUnlockAndAuthenticationDataModel MasterPasswordUnlockData { get; set; }
     public required IEnumerable<EmergencyAccessWithIdRequestModel> EmergencyAccessUnlockData { get; set; }
-    public required IEnumerable<ResetPasswordWithOrgIdRequestModel> OrganizationAccountRecoveryUnlockData { get; set; }
+    public required IEnumerable<OrganizationUserAccountRecoveryRequestModel> OrganizationAccountRecoveryUnlockData { get; set; }
     public required IEnumerable<WebAuthnLoginRotateKeyRequestModel> PasskeyUnlockData { get; set; }
     public required IEnumerable<OtherDeviceKeysUpdateRequestModel> DeviceKeyUnlockData { get; set; }
     public V2UpgradeTokenRequestModel? V2UpgradeToken { get; set; }

--- a/src/Api/KeyManagement/Validators/OrganizationUserRotationValidator.cs
+++ b/src/Api/KeyManagement/Validators/OrganizationUserRotationValidator.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Api.AdminConsole.Models.Request.Organizations;
+﻿using Bit.Api.KeyManagement.Models.Requests;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
 using Bit.Core.Repositories;
@@ -7,9 +7,9 @@ namespace Bit.Api.KeyManagement.Validators;
 
 /// <summary>
 /// Organization user implementation for <see cref="IRotationValidator{T,R}"/>
-/// Currently responsible for validation of user reset password keys (used by admins to perform account recovery) during user key rotation
+/// Currently responsible for validation of account recovery keys (used by admins to perform account recovery) during user key rotation
 /// </summary>
-public class OrganizationUserRotationValidator : IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>,
+public class OrganizationUserRotationValidator : IRotationValidator<OrganizationAccountRecoveryRotationData,
     IReadOnlyList<OrganizationUser>>
 {
     private readonly IOrganizationUserRepository _organizationUserRepository;
@@ -18,7 +18,7 @@ public class OrganizationUserRotationValidator : IRotationValidator<IEnumerable<
         _organizationUserRepository = organizationUserRepository;
 
     public async Task<IReadOnlyList<OrganizationUser>> ValidateAsync(User user,
-        IEnumerable<ResetPasswordWithOrgIdRequestModel> resetPasswordKeys)
+        OrganizationAccountRecoveryRotationData data)
     {
         if (user == null)
         {
@@ -34,25 +34,42 @@ public class OrganizationUserRotationValidator : IRotationValidator<IEnumerable<
         }
 
         // Exclude any account recovery that do not have a key.
-        existing = existing.Where(o => OrganizationUser.IsValidResetPasswordKey(o.ResetPasswordKey)).ToList();
+        var enrolled = existing.Where(o => o.IsEnrolledInAccountRecovery()).ToList();
 
-        foreach (var ou in existing)
+        // A V1 to V2 upgrade cannot re-encapsulate the account recovery key, because that needs the organization's
+        // public key to be trusted and the upgrade shows the member no prompt.
+        var isUpgradeRotation = data.HasV2UpgradeToken && !user.HasV2KeyShape();
+
+        foreach (var organizationUser in enrolled)
         {
-            var organizationUser = resetPasswordKeys.FirstOrDefault(a => a.OrganizationId == ou.OrganizationId);
-            if (organizationUser == null)
+            var accountRecovery = data.AccountRecoveryUnlockData
+                .FirstOrDefault(a => a.OrganizationId == organizationUser.OrganizationId);
+            if (accountRecovery == null)
             {
-                throw new BadRequestException("All existing reset password keys must be included in the rotation.");
+                throw new BadRequestException("All existing account recovery keys must be included in the rotation.");
             }
 
-            // Should be migrated to: if (!OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey))
-            // after https://bitwarden.atlassian.net/browse/PM-31001 is resolved
-            if (organizationUser.ResetPasswordKey == null)
+            if (isUpgradeRotation)
             {
-                throw new BadRequestException("Reset Password keys cannot be set to null during rotation.");
+                if (OrganizationUser.IsValidResetPasswordKey(accountRecovery.ResetPasswordKey))
+                {
+                    throw new BadRequestException(
+                        "Account recovery keys cannot be rotated during a V1 to V2 upgrade rotation.");
+                }
+
+                // Keep the stored key. Nothing downstream guards against a null, so overwriting it here would lock
+                // the organization out of account recovery for this member.
+                result.Add(organizationUser);
+                continue;
             }
 
-            ou.ResetPasswordKey = organizationUser.ResetPasswordKey;
-            result.Add(ou);
+            if (!OrganizationUser.IsValidResetPasswordKey(accountRecovery.ResetPasswordKey))
+            {
+                throw new BadRequestException("Account recovery keys cannot be null or empty during rotation.");
+            }
+
+            organizationUser.ResetPasswordKey = accountRecovery.ResetPasswordKey;
+            result.Add(organizationUser);
         }
 
         return result;

--- a/src/Api/Startup.cs
+++ b/src/Api/Startup.cs
@@ -7,8 +7,8 @@ using Stripe;
 using Bit.Core.Utilities;
 using Duende.IdentityModel;
 using System.Globalization;
-using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.Auth.Models.Request;
+using Bit.Api.KeyManagement.Models.Requests;
 using Bit.Api.KeyManagement.Validators;
 using Bit.Api.Tools.Models.Request;
 using Bit.Api.Vault.Models.Request;
@@ -171,7 +171,7 @@ public class Startup
             .AddScoped<IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>,
                 EmergencyAccessRotationValidator>();
         services
-            .AddScoped<IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>,
+            .AddScoped<IRotationValidator<OrganizationAccountRecoveryRotationData,
                     IReadOnlyList<OrganizationUser>>
                 , OrganizationUserRotationValidator>();
         services

--- a/src/Core/Entities/User.cs
+++ b/src/Core/Entities/User.cs
@@ -248,7 +248,10 @@ public class User : ITableObject<Guid>, IStorableSubscriber, IRevisable, ITwoFac
         return HasV2KeyShape() && IsSecurityVersionTwo();
     }
 
-    private bool HasV2KeyShape()
+    /// <summary>
+    /// Whether the private key is wrapped with V2 encryption.
+    /// </summary>
+    public bool HasV2KeyShape()
     {
         if (string.IsNullOrEmpty(PrivateKey))
         {

--- a/src/Core/Entities/User.cs
+++ b/src/Core/Entities/User.cs
@@ -251,7 +251,10 @@ public class User : ITableObject<Guid>, IStorableSubscriber, IRevisable, ITwoFac
         return HasV2KeyShape() && IsSecurityVersionTwo();
     }
 
-    private bool HasV2KeyShape()
+    /// <summary>
+    /// Whether the private key is wrapped with V2 encryption.
+    /// </summary>
+    public bool HasV2KeyShape()
     {
         if (string.IsNullOrEmpty(PrivateKey))
         {

--- a/src/Core/KeyManagement/UserKey/Implementations/RotateUserAccountKeysCommand.cs
+++ b/src/Core/KeyManagement/UserKey/Implementations/RotateUserAccountKeysCommand.cs
@@ -193,7 +193,7 @@ public class RotateUserAccountKeysCommand : IRotateUserAccountKeysCommand
     {
         ValidatePublicKeyEncryptionKeyPairUnchanged(model, user);
 
-        if (IsV2EncryptionUser(user))
+        if (user.HasV2KeyShape())
         {
             await RotateV2AccountKeysAsync(model, user, saveEncryptedDataActions);
         }
@@ -237,14 +237,6 @@ public class RotateUserAccountKeysCommand : IRotateUserAccountKeysCommand
             var sendsWithUpdatedDate = model.Sends.ToList().Select(s => { s.RevisionDate = now; return s; });
             saveEncryptedDataActions.Add(_sendRepository.UpdateForKeyRotation(user.Id, sendsWithUpdatedDate));
         }
-    }
-
-    private static bool IsV2EncryptionUser(User user)
-    {
-        // Returns whether the user is a V2 user based on the private key's encryption type.
-        ArgumentNullException.ThrowIfNull(user);
-        var isPrivateKeyEncryptionV2 = EncryptionParsing.GetEncryptionType(user.PrivateKey) == EncryptionType.XChaCha20Poly1305_B64;
-        return isPrivateKeyEncryptionV2;
     }
 
     private async Task ValidateVerifyingKeyUnchangedAsync(BaseRotateUserAccountKeysData model, User user)
@@ -326,7 +318,7 @@ public class RotateUserAccountKeysCommand : IRotateUserAccountKeysCommand
 
         // V2UpgradeToken is only valid for V1 users transitioning to V2.
         // For V2 users the token is semantically invalid — discard it and perform a full logout.
-        var shouldPersistV2UpgradeToken = baseModel.V2UpgradeToken != null && !IsV2EncryptionUser(user);
+        var shouldPersistV2UpgradeToken = baseModel.V2UpgradeToken != null && !user.HasV2KeyShape();
         if (shouldPersistV2UpgradeToken)
         {
             user.V2UpgradeToken = baseModel.V2UpgradeToken!.ToJson();

--- a/src/Core/KeyManagement/UserKey/Implementations/RotateUserAccountKeysCommand.cs
+++ b/src/Core/KeyManagement/UserKey/Implementations/RotateUserAccountKeysCommand.cs
@@ -193,7 +193,7 @@ public class RotateUserAccountKeysCommand : IRotateUserAccountKeysCommand
     {
         ValidatePublicKeyEncryptionKeyPairUnchanged(model, user);
 
-        if (IsV2EncryptionUser(user))
+        if (user.HasV2KeyShape())
         {
             await RotateV2AccountKeysAsync(model, user, saveEncryptedDataActions);
         }
@@ -237,14 +237,6 @@ public class RotateUserAccountKeysCommand : IRotateUserAccountKeysCommand
             var sendsWithUpdatedDate = model.Sends.ToList().Select(s => { s.RevisionDate = now; return s; });
             saveEncryptedDataActions.Add(_sendRepository.UpdateForKeyRotation(user.Id, sendsWithUpdatedDate));
         }
-    }
-
-    private static bool IsV2EncryptionUser(User user)
-    {
-        // Returns whether the user is a V2 user based on the private key's encryption type.
-        ArgumentNullException.ThrowIfNull(user);
-        var isPrivateKeyEncryptionV2 = EncryptionParsing.GetEncryptionType(user.PrivateKey) == EncryptionType.XChaCha20Poly1305_B64;
-        return isPrivateKeyEncryptionV2;
     }
 
     private async Task ValidateVerifyingKeyUnchangedAsync(BaseRotateUserAccountKeysData model, User user)
@@ -327,7 +319,7 @@ public class RotateUserAccountKeysCommand : IRotateUserAccountKeysCommand
 
         // V2UpgradeToken is only valid for V1 users transitioning to V2.
         // For V2 users the token is semantically invalid — discard it and perform a full logout.
-        var shouldPersistV2UpgradeToken = baseModel.V2UpgradeToken != null && !IsV2EncryptionUser(user);
+        var shouldPersistV2UpgradeToken = baseModel.V2UpgradeToken != null && !user.HasV2KeyShape();
         if (shouldPersistV2UpgradeToken)
         {
             user.V2UpgradeToken = baseModel.V2UpgradeToken!.ToJson();

--- a/test/Api.IntegrationTest/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
+++ b/test/Api.IntegrationTest/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System.Net;
 using System.Text.Json;
-using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.IntegrationTest.Factories;
 using Bit.Api.IntegrationTest.Helpers;
 using Bit.Api.KeyManagement.Models.Requests;
@@ -903,7 +902,7 @@ public class AccountsKeyManagementControllerTests : IClassFixture<ApiApplication
 
     [Theory]
     [BitAutoData]
-    public async Task RotateUserKeysAsync_V1ToV2Rotation_OrganizationUserEnrolledInAccountRecovery_SetsTokenOnMembership(
+    public async Task RotateUserKeysAsync_V1ToV2Rotation_OrganizationUserEnrolledInAccountRecovery_SetsTokenAndKeepsAccountRecoveryKey(
         RotateUserKeysRequestModel request)
     {
         // Arrange
@@ -915,13 +914,14 @@ public class AccountsKeyManagementControllerTests : IClassFixture<ApiApplication
         organizationUser.ResetPasswordKey = _mockEncryptedString;
         await _organizationUserRepository.ReplaceAsync(organizationUser);
 
+        // An upgrade rotation cannot re-encapsulate the account recovery key, so the client sends none
         SetupMasterPasswordRotateUserAccount(request, user, upgradeToken: true);
         request.UnlockData.OrganizationAccountRecoveryUnlockData =
         [
-            new ResetPasswordWithOrgIdRequestModel
+            new OrganizationUserAccountRecoveryRequestModel
             {
                 OrganizationId = organization.Id,
-                ResetPasswordKey = _mockEncryptedString
+                ResetPasswordKey = null
             }
         ];
 
@@ -937,6 +937,44 @@ public class AccountsKeyManagementControllerTests : IClassFixture<ApiApplication
         var membership = await _organizationUserRepository.GetByIdAsync(organizationUser.Id);
         Assert.NotNull(membership);
         Assert.Equal(userNewState.V2UpgradeToken, membership.V2UpgradeToken);
+
+        // The stored key survives, so the organization keeps account recovery for this member
+        Assert.Equal(_mockEncryptedString, membership.ResetPasswordKey);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task RotateUserKeysAsync_V1ToV2Rotation_WithAccountRecoveryKey_BadRequest(
+        RotateUserKeysRequestModel request)
+    {
+        // Arrange
+        var (organization, organizationUser) = await OrganizationTestHelpers.SignUpAsync(_factory,
+            PlanType.EnterpriseAnnually, _ownerEmail, passwordManagerSeats: 10,
+            paymentMethod: PaymentMethodType.Card);
+        var user = await SetupUserForKeyRotationAsync();
+
+        organizationUser.ResetPasswordKey = _mockEncryptedString;
+        await _organizationUserRepository.ReplaceAsync(organizationUser);
+
+        SetupMasterPasswordRotateUserAccount(request, user, upgradeToken: true);
+        request.UnlockData.OrganizationAccountRecoveryUnlockData =
+        [
+            new OrganizationUserAccountRecoveryRequestModel
+            {
+                OrganizationId = organization.Id,
+                ResetPasswordKey = _mockEncryptedType2String2
+            }
+        ];
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/accounts/key-management/rotate-user-keys", request);
+
+        // Assert - Sending a key during an upgrade is a client bug, so the whole rotation is refused
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var membership = await _organizationUserRepository.GetByIdAsync(organizationUser.Id);
+        Assert.NotNull(membership);
+        Assert.Equal(_mockEncryptedString, membership.ResetPasswordKey);
     }
 
     [Theory]

--- a/test/Api.IntegrationTest/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
+++ b/test/Api.IntegrationTest/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System.Net;
 using System.Text.Json;
-using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.IntegrationTest.Factories;
 using Bit.Api.IntegrationTest.Helpers;
 using Bit.Api.KeyManagement.Models.Requests;
@@ -796,7 +795,7 @@ public class AccountsKeyManagementControllerTests : IClassFixture<ApiApplication
 
     [Theory]
     [BitAutoData]
-    public async Task RotateUserKeysAsync_V1ToV2Rotation_OrganizationUserEnrolledInAccountRecovery_SetsTokenOnMembership(
+    public async Task RotateUserKeysAsync_V1ToV2Rotation_OrganizationUserEnrolledInAccountRecovery_SetsTokenAndKeepsAccountRecoveryKey(
         RotateUserKeysRequestModel request)
     {
         // Arrange
@@ -808,13 +807,14 @@ public class AccountsKeyManagementControllerTests : IClassFixture<ApiApplication
         organizationUser.ResetPasswordKey = _mockEncryptedString;
         await _organizationUserRepository.ReplaceAsync(organizationUser);
 
+        // An upgrade rotation cannot re-encapsulate the account recovery key, so the client sends none
         SetupMasterPasswordRotateUserAccount(request, user, upgradeToken: true);
         request.UnlockData.OrganizationAccountRecoveryUnlockData =
         [
-            new ResetPasswordWithOrgIdRequestModel
+            new OrganizationUserAccountRecoveryRequestModel
             {
                 OrganizationId = organization.Id,
-                ResetPasswordKey = _mockEncryptedString
+                ResetPasswordKey = null
             }
         ];
 
@@ -830,6 +830,44 @@ public class AccountsKeyManagementControllerTests : IClassFixture<ApiApplication
         var membership = await _organizationUserRepository.GetByIdAsync(organizationUser.Id);
         Assert.NotNull(membership);
         Assert.Equal(userNewState.V2UpgradeToken, membership.V2UpgradeToken);
+
+        // The stored key survives, so the organization keeps account recovery for this member
+        Assert.Equal(_mockEncryptedString, membership.ResetPasswordKey);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task RotateUserKeysAsync_V1ToV2Rotation_WithAccountRecoveryKey_BadRequest(
+        RotateUserKeysRequestModel request)
+    {
+        // Arrange
+        var (organization, organizationUser) = await OrganizationTestHelpers.SignUpAsync(_factory,
+            PlanType.EnterpriseAnnually, _ownerEmail, passwordManagerSeats: 10,
+            paymentMethod: PaymentMethodType.Card);
+        var user = await SetupUserForKeyRotationAsync();
+
+        organizationUser.ResetPasswordKey = _mockEncryptedString;
+        await _organizationUserRepository.ReplaceAsync(organizationUser);
+
+        SetupMasterPasswordRotateUserAccount(request, user, upgradeToken: true);
+        request.UnlockData.OrganizationAccountRecoveryUnlockData =
+        [
+            new OrganizationUserAccountRecoveryRequestModel
+            {
+                OrganizationId = organization.Id,
+                ResetPasswordKey = _mockEncryptedType2String2
+            }
+        ];
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/accounts/key-management/rotate-user-keys", request);
+
+        // Assert - Sending a key during an upgrade is a client bug, so the whole rotation is refused
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var membership = await _organizationUserRepository.GetByIdAsync(organizationUser.Id);
+        Assert.NotNull(membership);
+        Assert.Equal(_mockEncryptedString, membership.ResetPasswordKey);
     }
 
     [Theory]

--- a/test/Api.Test/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
+++ b/test/Api.Test/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using System.Security.Claims;
-using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.WebAuthn;
 using Bit.Api.KeyManagement.Controllers;
@@ -105,8 +104,10 @@ public class AccountsKeyManagementControllerTests
 
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.EmergencyAccessUnlockData));
-        await sutProvider.GetDependency<IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>, IReadOnlyList<OrganizationUser>>>().Received(1)
-            .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.OrganizationAccountRecoveryUnlockData));
+        await sutProvider.GetDependency<IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>>().Received(1)
+            .ValidateAsync(Arg.Any<User>(), Arg.Is<OrganizationAccountRecoveryRotationData>(d =>
+                d.AccountRecoveryUnlockData == data.AccountUnlockData.OrganizationAccountRecoveryUnlockData
+                && !d.HasV2UpgradeToken));
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.PasskeyUnlockData));
 
@@ -158,8 +159,10 @@ public class AccountsKeyManagementControllerTests
 
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.EmergencyAccessUnlockData));
-        await sutProvider.GetDependency<IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>, IReadOnlyList<OrganizationUser>>>().Received(1)
-            .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.OrganizationAccountRecoveryUnlockData));
+        await sutProvider.GetDependency<IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>>().Received(1)
+            .ValidateAsync(Arg.Any<User>(), Arg.Is<OrganizationAccountRecoveryRotationData>(d =>
+                d.AccountRecoveryUnlockData == data.AccountUnlockData.OrganizationAccountRecoveryUnlockData
+                && !d.HasV2UpgradeToken));
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.PasskeyUnlockData));
 
@@ -868,8 +871,10 @@ public class AccountsKeyManagementControllerTests
     {
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(request.UnlockData.EmergencyAccessUnlockData));
-        await sutProvider.GetDependency<IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>, IReadOnlyList<OrganizationUser>>>().Received(1)
-            .ValidateAsync(Arg.Any<User>(), Arg.Is(request.UnlockData.OrganizationAccountRecoveryUnlockData));
+        await sutProvider.GetDependency<IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>>().Received(1)
+            .ValidateAsync(Arg.Any<User>(), Arg.Is<OrganizationAccountRecoveryRotationData>(d =>
+                d.AccountRecoveryUnlockData == request.UnlockData.OrganizationAccountRecoveryUnlockData
+                && d.HasV2UpgradeToken == (request.UnlockData.V2UpgradeToken != null)));
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(request.UnlockData.PasskeyUnlockData));
 

--- a/test/Api.Test/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
+++ b/test/Api.Test/KeyManagement/Controllers/AccountsKeyManagementControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 using System.Security.Claims;
-using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.Auth.Models.Request;
 using Bit.Api.Auth.Models.Request.WebAuthn;
 using Bit.Api.KeyManagement.Controllers;
@@ -132,8 +131,10 @@ public class AccountsKeyManagementControllerTests
 
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.EmergencyAccessUnlockData));
-        await sutProvider.GetDependency<IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>, IReadOnlyList<OrganizationUser>>>().Received(1)
-            .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.OrganizationAccountRecoveryUnlockData));
+        await sutProvider.GetDependency<IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>>().Received(1)
+            .ValidateAsync(Arg.Any<User>(), Arg.Is<OrganizationAccountRecoveryRotationData>(d =>
+                d.AccountRecoveryUnlockData == data.AccountUnlockData.OrganizationAccountRecoveryUnlockData
+                && !d.HasV2UpgradeToken));
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.PasskeyUnlockData));
 
@@ -185,8 +186,10 @@ public class AccountsKeyManagementControllerTests
 
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.EmergencyAccessUnlockData));
-        await sutProvider.GetDependency<IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>, IReadOnlyList<OrganizationUser>>>().Received(1)
-            .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.OrganizationAccountRecoveryUnlockData));
+        await sutProvider.GetDependency<IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>>().Received(1)
+            .ValidateAsync(Arg.Any<User>(), Arg.Is<OrganizationAccountRecoveryRotationData>(d =>
+                d.AccountRecoveryUnlockData == data.AccountUnlockData.OrganizationAccountRecoveryUnlockData
+                && !d.HasV2UpgradeToken));
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(data.AccountUnlockData.PasskeyUnlockData));
 
@@ -895,8 +898,10 @@ public class AccountsKeyManagementControllerTests
     {
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<EmergencyAccessWithIdRequestModel>, IEnumerable<EmergencyAccess>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(request.UnlockData.EmergencyAccessUnlockData));
-        await sutProvider.GetDependency<IRotationValidator<IEnumerable<ResetPasswordWithOrgIdRequestModel>, IReadOnlyList<OrganizationUser>>>().Received(1)
-            .ValidateAsync(Arg.Any<User>(), Arg.Is(request.UnlockData.OrganizationAccountRecoveryUnlockData));
+        await sutProvider.GetDependency<IRotationValidator<OrganizationAccountRecoveryRotationData, IReadOnlyList<OrganizationUser>>>().Received(1)
+            .ValidateAsync(Arg.Any<User>(), Arg.Is<OrganizationAccountRecoveryRotationData>(d =>
+                d.AccountRecoveryUnlockData == request.UnlockData.OrganizationAccountRecoveryUnlockData
+                && d.HasV2UpgradeToken == (request.UnlockData.V2UpgradeToken != null)));
         await sutProvider.GetDependency<IRotationValidator<IEnumerable<WebAuthnLoginRotateKeyRequestModel>, IEnumerable<WebAuthnLoginRotateKeyData>>>().Received(1)
             .ValidateAsync(Arg.Any<User>(), Arg.Is(request.UnlockData.PasskeyUnlockData));
 

--- a/test/Api.Test/KeyManagement/Validators/OrganizationUserRotationValidatorTests.cs
+++ b/test/Api.Test/KeyManagement/Validators/OrganizationUserRotationValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Api.AdminConsole.Models.Request.Organizations;
+﻿using Bit.Api.KeyManagement.Models.Requests;
 using Bit.Api.KeyManagement.Validators;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
@@ -13,13 +13,16 @@ namespace Bit.Api.Test.KeyManagement.Validators;
 [SutProviderCustomize]
 public class OrganizationUserRotationValidatorTests
 {
+    private const string _v1PrivateKey = "2.AOs41Hd8OQiCPXjyJKCiDA==|O6OHgt2U2hJGBSNGnimJmg==|iD33s8B69C8JhYYhSa4V1tArjvLr8eEaGqOV7BRo5Jk=";
+    private const string _v2PrivateKey = "7.AOs41Hd8OQiCPXjyJKCiDA==";
+
     [Theory]
     [BitAutoData]
     public async Task ValidateAsync_Success_ReturnsValid(
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        IEnumerable<ResetPasswordWithOrgIdRequestModel> resetPasswordKeys)
+        IEnumerable<OrganizationUserAccountRecoveryRequestModel> accountRecoveryKeys)
     {
-        var existingUserResetPassword = resetPasswordKeys
+        var existingUserResetPassword = accountRecoveryKeys
             .Select(a =>
                 new OrganizationUser
                 {
@@ -30,21 +33,21 @@ public class OrganizationUserRotationValidatorTests
         sutProvider.GetDependency<IOrganizationUserRepository>().GetManyByUserAsync(user.Id)
             .Returns(existingUserResetPassword);
 
-        var result = await sutProvider.Sut.ValidateAsync(user, resetPasswordKeys);
+        var result = await sutProvider.Sut.ValidateAsync(user, Rotation(accountRecoveryKeys));
 
-        Assert.Equal(result.Select(r => r.OrganizationId), resetPasswordKeys.Select(a => a.OrganizationId));
+        Assert.Equal(result.Select(r => r.OrganizationId), accountRecoveryKeys.Select(a => a.OrganizationId));
     }
 
     [Theory]
     [BitAutoData]
-    public async Task ValidateAsync_NullResetPasswordKeys_ReturnsEmptyList(
+    public async Task ValidateAsync_NullAccountRecoveryKeys_ReturnsEmptyList(
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user)
     {
         // Arrange
-        IEnumerable<ResetPasswordWithOrgIdRequestModel> resetPasswordKeys = null;
+        IEnumerable<OrganizationUserAccountRecoveryRequestModel> accountRecoveryKeys = null;
 
         // Act
-        var result = await sutProvider.Sut.ValidateAsync(user, resetPasswordKeys);
+        var result = await sutProvider.Sut.ValidateAsync(user, Rotation(accountRecoveryKeys));
 
         // Assert
         Assert.NotNull(result);
@@ -55,14 +58,14 @@ public class OrganizationUserRotationValidatorTests
     [BitAutoData]
     public async Task ValidateAsync_NoOrgUsers_ReturnsEmptyList(
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        IEnumerable<ResetPasswordWithOrgIdRequestModel> resetPasswordKeys)
+        IEnumerable<OrganizationUserAccountRecoveryRequestModel> accountRecoveryKeys)
     {
         // Arrange
         sutProvider.GetDependency<IOrganizationUserRepository>().GetManyByUserAsync(user.Id)
             .Returns(new List<OrganizationUser>()); // Return an empty list
 
         // Act
-        var result = await sutProvider.Sut.ValidateAsync(user, resetPasswordKeys);
+        var result = await sutProvider.Sut.ValidateAsync(user, Rotation(accountRecoveryKeys));
 
         // Assert
         Assert.NotNull(result);
@@ -75,7 +78,7 @@ public class OrganizationUserRotationValidatorTests
     public async Task ValidateAsync_OrgUsersWithNullOrEmptyResetPasswordKey_FiltersOutInvalidKeys(
         string? invalidResetPasswordKey,
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        ResetPasswordWithOrgIdRequestModel validResetPasswordKey)
+        OrganizationUserAccountRecoveryRequestModel validAccountRecoveryKey)
     {
         // Arrange
         var existingUserResetPassword = new List<OrganizationUser>
@@ -84,8 +87,8 @@ public class OrganizationUserRotationValidatorTests
             new OrganizationUser
             {
                 Id = Guid.NewGuid(),
-                OrganizationId = validResetPasswordKey.OrganizationId,
-                ResetPasswordKey = validResetPasswordKey.ResetPasswordKey
+                OrganizationId = validAccountRecoveryKey.OrganizationId,
+                ResetPasswordKey = validAccountRecoveryKey.ResetPasswordKey
             },
             // Invalid org user with null or empty reset password key - should be filtered out
             new OrganizationUser
@@ -99,21 +102,21 @@ public class OrganizationUserRotationValidatorTests
             .Returns(existingUserResetPassword);
 
         // Act
-        var result = await sutProvider.Sut.ValidateAsync(user, new[] { validResetPasswordKey });
+        var result = await sutProvider.Sut.ValidateAsync(user, Rotation([validAccountRecoveryKey]));
 
         // Assert
         Assert.NotNull(result);
         Assert.Single(result);
-        Assert.Equal(validResetPasswordKey.OrganizationId, result[0].OrganizationId);
+        Assert.Equal(validAccountRecoveryKey.OrganizationId, result[0].OrganizationId);
     }
 
     [Theory]
     [BitAutoData]
-    public async Task ValidateAsync_MissingResetPassword_Throws(
+    public async Task ValidateAsync_MissingAccountRecoveryKey_Throws(
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        IEnumerable<ResetPasswordWithOrgIdRequestModel> resetPasswordKeys)
+        IEnumerable<OrganizationUserAccountRecoveryRequestModel> accountRecoveryKeys)
     {
-        var existingUserResetPassword = resetPasswordKeys
+        var existingUserResetPassword = accountRecoveryKeys
             .Select(a =>
                 new OrganizationUser
                 {
@@ -131,16 +134,16 @@ public class OrganizationUserRotationValidatorTests
 
 
         await Assert.ThrowsAsync<BadRequestException>(async () =>
-            await sutProvider.Sut.ValidateAsync(user, resetPasswordKeys));
+            await sutProvider.Sut.ValidateAsync(user, Rotation(accountRecoveryKeys)));
     }
 
     [Theory]
     [BitAutoData]
-    public async Task ValidateAsync_ResetPasswordDoesNotBelongToUser_NotReturned(
+    public async Task ValidateAsync_AccountRecoveryKeyDoesNotBelongToUser_NotReturned(
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        IEnumerable<ResetPasswordWithOrgIdRequestModel> resetPasswordKeys)
+        IEnumerable<OrganizationUserAccountRecoveryRequestModel> accountRecoveryKeys)
     {
-        var existingUserResetPassword = resetPasswordKeys
+        var existingUserResetPassword = accountRecoveryKeys
             .Select(a =>
                 new OrganizationUser
                 {
@@ -152,18 +155,18 @@ public class OrganizationUserRotationValidatorTests
         sutProvider.GetDependency<IOrganizationUserRepository>().GetManyByUserAsync(user.Id)
             .Returns(existingUserResetPassword);
 
-        var result = await sutProvider.Sut.ValidateAsync(user, resetPasswordKeys);
+        var result = await sutProvider.Sut.ValidateAsync(user, Rotation(accountRecoveryKeys));
 
-        Assert.DoesNotContain(result, c => c.Id == resetPasswordKeys.First().OrganizationId);
+        Assert.DoesNotContain(result, c => c.Id == accountRecoveryKeys.First().OrganizationId);
     }
 
     [Theory]
     [BitAutoData]
     public async Task ValidateAsync_AttemptToSetKeyToNull_Throws(
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        IEnumerable<ResetPasswordWithOrgIdRequestModel> resetPasswordKeys)
+        IEnumerable<OrganizationUserAccountRecoveryRequestModel> accountRecoveryKeys)
     {
-        var existingUserResetPassword = resetPasswordKeys
+        var existingUserResetPassword = accountRecoveryKeys
             .Select(a =>
                 new OrganizationUser
                 {
@@ -173,19 +176,19 @@ public class OrganizationUserRotationValidatorTests
                 }).ToList();
         sutProvider.GetDependency<IOrganizationUserRepository>().GetManyByUserAsync(user.Id)
             .Returns(existingUserResetPassword);
-        resetPasswordKeys.First().ResetPasswordKey = null;
+        accountRecoveryKeys.First().ResetPasswordKey = null;
 
         await Assert.ThrowsAsync<BadRequestException>(async () =>
-            await sutProvider.Sut.ValidateAsync(user, resetPasswordKeys));
+            await sutProvider.Sut.ValidateAsync(user, Rotation(accountRecoveryKeys)));
     }
 
     [Theory]
     [BitAutoData]
     public async Task ValidateAsync_NoOrganizationsInRequestButInDatabase_Throws(
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        IEnumerable<ResetPasswordWithOrgIdRequestModel> resetPasswordKeys)
+        IEnumerable<OrganizationUserAccountRecoveryRequestModel> accountRecoveryKeys)
     {
-        var existingUserResetPassword = resetPasswordKeys
+        var existingUserResetPassword = accountRecoveryKeys
             .Select(a =>
                 new OrganizationUser
                 {
@@ -197,20 +200,17 @@ public class OrganizationUserRotationValidatorTests
             .Returns(existingUserResetPassword);
 
         await Assert.ThrowsAsync<BadRequestException>(async () =>
-            await sutProvider.Sut.ValidateAsync(user, Enumerable.Empty<ResetPasswordWithOrgIdRequestModel>()));
+            await sutProvider.Sut.ValidateAsync(user,
+                Rotation(Enumerable.Empty<OrganizationUserAccountRecoveryRequestModel>())));
     }
 
-    // TODO: Remove this test after https://bitwarden.atlassian.net/browse/PM-31001 is resolved.
-    // Clients currently send "" as a reset password key value during rotation due to a client-side bug.
-    // The server must accept "" to avoid blocking key rotation for affected users.
-    // After PM-31001 is fixed, this should be replaced with a test asserting that "" throws BadRequestException.
     [Theory]
     [BitAutoData("")]
     [BitAutoData(" ")]
-    public async Task ValidateAsync_EmptyOrWhitespaceKey_AcceptedDueToClientBug(
+    public async Task ValidateAsync_EmptyOrWhitespaceKey_Throws(
         string emptyKey,
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        ResetPasswordWithOrgIdRequestModel validResetPasswordKey)
+        OrganizationUserAccountRecoveryRequestModel validAccountRecoveryKey)
     {
         // Arrange
         var existingUserResetPassword = new List<OrganizationUser>
@@ -218,23 +218,18 @@ public class OrganizationUserRotationValidatorTests
             new OrganizationUser
             {
                 Id = Guid.NewGuid(),
-                OrganizationId = validResetPasswordKey.OrganizationId,
+                OrganizationId = validAccountRecoveryKey.OrganizationId,
                 ResetPasswordKey = "existing-valid-key"
             }
         };
         sutProvider.GetDependency<IOrganizationUserRepository>().GetManyByUserAsync(user.Id)
             .Returns(existingUserResetPassword);
 
-        // Set the incoming key to empty/whitespace (simulating client bug)
-        validResetPasswordKey.ResetPasswordKey = emptyKey;
+        validAccountRecoveryKey.ResetPasswordKey = emptyKey;
 
-        // Act — rotation should succeed (not throw) to preserve backward compatibility
-        var result = await sutProvider.Sut.ValidateAsync(user, new[] { validResetPasswordKey });
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Single(result);
-        Assert.Equal(emptyKey, result[0].ResetPasswordKey);
+        // Act & Assert - An empty key leaves the organization unable to recover the account
+        await Assert.ThrowsAsync<BadRequestException>(async () =>
+            await sutProvider.Sut.ValidateAsync(user, Rotation([validAccountRecoveryKey])));
     }
 
     [Theory]
@@ -242,7 +237,7 @@ public class OrganizationUserRotationValidatorTests
     public async Task ValidateAsync_WhitespaceOnlyExistingKey_FiltersOut(
         string whitespaceKey,
         SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
-        ResetPasswordWithOrgIdRequestModel validResetPasswordKey)
+        OrganizationUserAccountRecoveryRequestModel validAccountRecoveryKey)
     {
         // Arrange
         var existingUserResetPassword = new List<OrganizationUser>
@@ -250,8 +245,8 @@ public class OrganizationUserRotationValidatorTests
             new OrganizationUser
             {
                 Id = Guid.NewGuid(),
-                OrganizationId = validResetPasswordKey.OrganizationId,
-                ResetPasswordKey = validResetPasswordKey.ResetPasswordKey
+                OrganizationId = validAccountRecoveryKey.OrganizationId,
+                ResetPasswordKey = validAccountRecoveryKey.ResetPasswordKey
             },
             // Whitespace-only key should be filtered out
             new OrganizationUser
@@ -265,11 +260,110 @@ public class OrganizationUserRotationValidatorTests
             .Returns(existingUserResetPassword);
 
         // Act
-        var result = await sutProvider.Sut.ValidateAsync(user, new[] { validResetPasswordKey });
+        var result = await sutProvider.Sut.ValidateAsync(user, Rotation([validAccountRecoveryKey]));
 
         // Assert
         Assert.NotNull(result);
         Assert.Single(result);
-        Assert.Equal(validResetPasswordKey.OrganizationId, result[0].OrganizationId);
+        Assert.Equal(validAccountRecoveryKey.OrganizationId, result[0].OrganizationId);
+    }
+
+    // An upgrade rotation treats a missing or empty key as "none sent" rather than a violation, so a client that
+    // sends one keeps its stored key instead of having the whole rotation refused.
+    [Theory]
+    [BitAutoData([null])]
+    [BitAutoData("")]
+    [BitAutoData(" ")]
+    public async Task ValidateAsync_V2UpgradeTokenWithoutAccountRecoveryKey_KeepsStoredKey(
+        string? missingKey,
+        SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
+        OrganizationUserAccountRecoveryRequestModel accountRecoveryKey)
+    {
+        // Arrange
+        user.PrivateKey = _v1PrivateKey;
+        var existing = SetupEnrolledMembership(sutProvider, user, accountRecoveryKey.OrganizationId);
+        accountRecoveryKey.ResetPasswordKey = missingKey;
+
+        // Act
+        var result = await sutProvider.Sut.ValidateAsync(user,
+            Rotation([accountRecoveryKey], hasV2UpgradeToken: true));
+
+        // Assert - The stored key survives, so the organization keeps account recovery for this member
+        Assert.Single(result);
+        Assert.Equal(existing.ResetPasswordKey, result[0].ResetPasswordKey);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_V2UpgradeTokenWithKey_Throws(
+        SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
+        OrganizationUserAccountRecoveryRequestModel accountRecoveryKey)
+    {
+        // Arrange
+        user.PrivateKey = _v1PrivateKey;
+        SetupEnrolledMembership(sutProvider, user, accountRecoveryKey.OrganizationId);
+
+        // Act & Assert - A client cannot re-encapsulate the key during an upgrade, so sending one is a bug
+        await Assert.ThrowsAsync<BadRequestException>(async () =>
+            await sutProvider.Sut.ValidateAsync(user,
+                Rotation([accountRecoveryKey], hasV2UpgradeToken: true)));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_V2UpgradeTokenWithMissingOrganization_Throws(
+        SutProvider<OrganizationUserRotationValidator> sutProvider, User user)
+    {
+        // Arrange
+        user.PrivateKey = _v1PrivateKey;
+        SetupEnrolledMembership(sutProvider, user, Guid.NewGuid());
+
+        // Act & Assert - An enrolled organization must still be included, so it cannot be silently skipped
+        await Assert.ThrowsAsync<BadRequestException>(async () =>
+            await sutProvider.Sut.ValidateAsync(user,
+                Rotation(Enumerable.Empty<OrganizationUserAccountRecoveryRequestModel>(),
+                    hasV2UpgradeToken: true)));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task ValidateAsync_V2UserWithV2UpgradeTokenAndNullKey_Throws(
+        SutProvider<OrganizationUserRotationValidator> sutProvider, User user,
+        OrganizationUserAccountRecoveryRequestModel accountRecoveryKey)
+    {
+        // Arrange - The command discards a V2 user's token, so their key must rotate as usual
+        user.PrivateKey = _v2PrivateKey;
+        SetupEnrolledMembership(sutProvider, user, accountRecoveryKey.OrganizationId);
+        accountRecoveryKey.ResetPasswordKey = null;
+
+        // Act & Assert
+        await Assert.ThrowsAsync<BadRequestException>(async () =>
+            await sutProvider.Sut.ValidateAsync(user,
+                Rotation([accountRecoveryKey], hasV2UpgradeToken: true)));
+    }
+
+    private static OrganizationUser SetupEnrolledMembership(
+        SutProvider<OrganizationUserRotationValidator> sutProvider, User user, Guid organizationId)
+    {
+        var existing = new OrganizationUser
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = organizationId,
+            ResetPasswordKey = "4.stored-account-recovery-key"
+        };
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetManyByUserAsync(user.Id)
+            .Returns(new List<OrganizationUser> { existing });
+        return existing;
+    }
+
+    private static OrganizationAccountRecoveryRotationData Rotation(
+        IEnumerable<OrganizationUserAccountRecoveryRequestModel> accountRecoveryKeys,
+        bool hasV2UpgradeToken = false)
+    {
+        return new OrganizationAccountRecoveryRotationData
+        {
+            AccountRecoveryUnlockData = accountRecoveryKeys,
+            HasV2UpgradeToken = hasV2UpgradeToken
+        };
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39455
Depends on #8158

## 📔 Objective

The organization holds the existing account recovery key and its own private key, so it can derive the new one from the V2 upgrade token without the member's client involved (covered in later PRs). Sending a new account recovery key during user key rotation would expose it, so the server leaves the stored value in place for the organization to replace.
(Since malicious server could send public key of it's own choice to the user.)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
