### PR TITLE
Document the AccessRuleId write contract on ICollectionRepository

### DIFF
--- a/src/Core/AdminConsole/Repositories/ICollectionRepository.cs
+++ b/src/Core/AdminConsole/Repositories/ICollectionRepository.cs
@@ -54,8 +54,20 @@ public interface ICollectionRepository : IRepository<Collection, Guid>
     /// </summary>
     Task<CollectionAdminDetails?> GetByIdWithPermissionsAsync(Guid collectionId, Guid? userId, bool includeAccessRelationships);
 
+    /// <remarks>
+    /// Ignores <see cref="Collection.AccessRuleId"/>: a new collection is always created ungoverned, whatever the
+    /// caller set on <paramref name="obj"/>. Use <see cref="SetAccessRuleAssociationsAsync"/> to associate it with an
+    /// access rule.
+    /// </remarks>
     Task CreateAsync(Collection obj, IEnumerable<CollectionAccessSelection>? groups, IEnumerable<CollectionAccessSelection>? users);
+
+    /// <remarks>
+    /// Ignores <see cref="Collection.AccessRuleId"/>, whatever the caller set on <paramref name="obj"/>, so an
+    /// ordinary collection edit can neither erase nor forge a PAM association. Use
+    /// <see cref="SetAccessRuleAssociationsAsync"/> to change it.
+    /// </remarks>
     Task ReplaceAsync(Collection obj, IEnumerable<CollectionAccessSelection>? groups, IEnumerable<CollectionAccessSelection>? users);
+
     Task DeleteUserAsync(Guid collectionId, Guid organizationUserId);
     Task UpdateUsersAsync(Guid id, IEnumerable<CollectionAccessSelection> users);
     Task<ICollection<CollectionAccessSelection>> GetManyUsersByIdAsync(Guid id);

--- a/src/Infrastructure.Dapper/AdminConsole/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.Dapper/AdminConsole/Repositories/CollectionRepository.cs
@@ -225,10 +225,9 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
     }
 
     /// <remarks>
-    /// Does not persist <see cref="Collection.AccessRuleId"/>. The serialization round-trip copies it onto the
-    /// wrapper and Dapper binds it, but <c>[dbo].[Collection_Create]</c> accepts <c>@AccessRuleId</c> and
-    /// deliberately ignores it, so a new collection is always created ungoverned. Use
-    /// <see cref="SetAccessRuleAssociationsAsync"/> to associate it with an access rule.
+    /// Upholds the interface's <see cref="Collection.AccessRuleId"/> contract through the stored procedure: the
+    /// serialization round-trip copies the property onto the wrapper and Dapper binds it, but
+    /// <c>[dbo].[Collection_Create]</c> accepts <c>@AccessRuleId</c> and deliberately ignores it.
     /// </remarks>
     public async Task CreateAsync(Collection obj, IEnumerable<CollectionAccessSelection>? groups, IEnumerable<CollectionAccessSelection>? users)
     {
@@ -249,10 +248,9 @@ public class CollectionRepository : Repository<Collection, Guid>, ICollectionRep
     }
 
     /// <remarks>
-    /// Does not persist <see cref="Collection.AccessRuleId"/>. Every branch below routes through
-    /// <c>[dbo].[Collection_Update]</c>, which accepts <c>@AccessRuleId</c> and deliberately ignores it, so an
-    /// ordinary collection edit can neither erase nor forge a PAM association. Use
-    /// <see cref="SetAccessRuleAssociationsAsync"/> to change it.
+    /// Upholds the interface's <see cref="Collection.AccessRuleId"/> contract through the stored procedures: every
+    /// branch below routes into <c>[dbo].[Collection_Update]</c>, which accepts <c>@AccessRuleId</c> and deliberately
+    /// ignores it.
     /// </remarks>
     public async Task ReplaceAsync(Collection obj, IEnumerable<CollectionAccessSelection>? groups, IEnumerable<CollectionAccessSelection>? users)
     {


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up to [#7981 review comment](https://github.com/bitwarden/server/pull/7981#discussion_r3754951204).

## 📔 Objective

`CreateAsync` and `ReplaceAsync` both ignore `Collection.AccessRuleId` — a new collection is always created ungoverned, and an ordinary collection edit can neither erase nor forge a PAM association. That is a contract of `ICollectionRepository`, not a quirk of MSSQL: EF Core enforces exactly the same thing via `PropertySaveBehavior.Ignore` on the property in `DatabaseContext`, and both are covered by the shared `[DatabaseTheory]` tests in `CollectionRepositoryReplaceTests`.

Documenting it only on the Dapper implementation hid it from the consumers who need it, and implied it was provider-specific.

- The contract moves to `ICollectionRepository.CreateAsync` / `ReplaceAsync`, where callers see it and every implementation inherits it.
- What stays on the Dapper methods is only the mechanism by which MSSQL upholds it (the sprocs accept `@AccessRuleId` and deliberately ignore it).

Documentation only — no behaviour change.