### PR TITLE
Allow seeder to create a Free org with Secrets Manager

### DIFF
--- a/test/SeederApi.IntegrationTest/Factories/OrganizationSeederTests.cs
+++ b/test/SeederApi.IntegrationTest/Factories/OrganizationSeederTests.cs
@@ -127,9 +127,22 @@ public class OrganizationSeederTests
     }
 
     [Fact]
+    public void Create_FreeWithSecretsManager_SetsFreeTierDefaults()
+    {
+        var free = OrganizationSeeder.Create(
+            Seed() with { PlanType = PlanType.Free, EnableSecretsManager = true },
+            new NoOpManglerService());
+
+        Assert.True(free.UseSecretsManager);
+        Assert.Equal(2, free.SmSeats);            // Free tier base seats
+        Assert.Equal(3, free.SmServiceAccounts);  // Free tier base service accounts
+    }
+
+    [Fact]
     public void Create_SecretsManagerOnUnsupportedPlan_Throws()
     {
-        var seed = Seed() with { PlanType = PlanType.Free, EnableSecretsManager = true };
+        // Families has no Secrets Manager tier, so enabling it must still throw.
+        var seed = Seed() with { PlanType = PlanType.FamiliesAnnually, EnableSecretsManager = true };
 
         Assert.Throws<ArgumentException>(() => OrganizationSeeder.Create(seed, new NoOpManglerService()));
     }

--- a/util/Seeder/Factories/PlanFeatures.cs
+++ b/util/Seeder/Factories/PlanFeatures.cs
@@ -119,18 +119,20 @@ public static class PlanFeatures
     /// </summary>
     internal static void EnableSecretsManager(Organization org, int? smSeats, int? smServiceAccounts)
     {
-        var baseServiceAccounts = org.PlanType switch
+        var (baseSeats, baseServiceAccounts) = org.PlanType switch
         {
             PlanType.EnterpriseMonthly or PlanType.EnterpriseAnnually
-                or PlanType.TeamsAnnually => 50,
-            PlanType.TeamsMonthly or PlanType.TeamsStarter => 20,
+                or PlanType.TeamsAnnually => (org.Seats, 50),
+            PlanType.TeamsMonthly or PlanType.TeamsStarter => (org.Seats, 20),
+            // Free Secrets Manager tier: 2 seats, 3 service accounts (see FreePlan mock).
+            PlanType.Free => (2, 3),
             _ => throw new ArgumentException(
                 $"PlanType '{org.PlanType}' does not support Secrets Manager. " +
-                "Supported: TeamsMonthly, TeamsAnnually, TeamsStarter, EnterpriseMonthly, EnterpriseAnnually.")
+                "Supported: Free, TeamsMonthly, TeamsAnnually, TeamsStarter, EnterpriseMonthly, EnterpriseAnnually.")
         };
 
         org.UseSecretsManager = true;
-        org.SmSeats = smSeats ?? org.Seats;
+        org.SmSeats = smSeats ?? baseSeats;
         org.SmServiceAccounts = smServiceAccounts ?? baseServiceAccounts;
     }
 

--- a/util/Seeder/Models/OrganizationSeed.cs
+++ b/util/Seeder/Models/OrganizationSeed.cs
@@ -27,7 +27,7 @@ internal record OrganizationSeed
     public required int Seats { get; init; }
 
     /// <summary>
-    /// Drives ~25 feature flags through <c>PlanFeatures.Apply</c>. Free and Families reject Secrets Manager.
+    /// Drives ~25 feature flags through <c>PlanFeatures.Apply</c>. Families rejects Secrets Manager.
     /// </summary>
     public PlanType PlanType { get; init; } = PlanType.EnterpriseAnnually;
 
@@ -62,17 +62,18 @@ internal record OrganizationSeed
     public string? GatewaySubscriptionId { get; init; }
 
     /// <summary>
-    /// Throws for plans without a Secrets Manager tier (Free, Families).
+    /// Throws for plans without a Secrets Manager tier (e.g. Families).
     /// </summary>
     public bool EnableSecretsManager { get; init; }
 
     /// <summary>
-    /// Defaults to <see cref="Seats"/>. Ignored unless <see cref="EnableSecretsManager"/>.
+    /// Defaults to the plan's base seats: <see cref="Seats"/> for paid plans, 2 for Free.
+    /// Ignored unless <see cref="EnableSecretsManager"/>.
     /// </summary>
     public int? SmSeats { get; init; }
 
     /// <summary>
-    /// Defaults to the plan's base allotment: 50 for Enterprise and Teams-Annual, 20 for Teams.
+    /// Defaults to the plan's base allotment: 50 for Enterprise and Teams-Annual, 20 for Teams, 3 for Free.
     /// Ignored unless <see cref="EnableSecretsManager"/>.
     /// </summary>
     public int? SmServiceAccounts { get; init; }


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/QA-1864

## 📔 Objective
The seeder rejected any Free org that requested Secrets Manager with a 400, because PlanFeatures.EnableSecretsManager only allow-listed Teams/Enterprise plans. This diverges from production, where Bitwarden offers a free Secrets Manager tier.

Add a PlanType.Free case that provisions the real free-tier base values (2 seats, 3 service accounts, per the FreePlan mock). Paid plans keep their existing smSeats-defaults-to-org.Seats behavior. Families and legacy plans still throw, matching production (they have no Secrets Manager tier).

Update the stale OrganizationSeed doc comments and the unit tests: add a Free positive-path test and repoint the throw test at FamiliesAnnually.
