### PR TITLE
[PM-41866] [server] add event logging for attachment downloads

### DIFF
--- a/src/Core/Dirt/Enums/EventType.cs
+++ b/src/Core/Dirt/Enums/EventType.cs
@@ -49,6 +49,7 @@ public enum EventType : int
     Cipher_ClientToggledIbanVisible = 1130,
     Cipher_ClientCopiedNationalIdentificationNumber = 1131,
     Cipher_ClientToggledNationalIdentificationNumberVisible = 1132,
+    Cipher_AttachmentDownloaded = 1133,
 
     Collection_Created = 1300,
     Collection_Updated = 1301,

--- a/src/Core/Vault/Services/Implementations/CipherService.cs
+++ b/src/Core/Vault/Services/Implementations/CipherService.cs
@@ -423,6 +423,8 @@ public class CipherService : ICipherService
             Url = url,
         };
 
+        await _eventService.LogCipherEventAsync(cipher, Bit.Core.Enums.EventType.Cipher_AttachmentDownloaded);
+
         return response;
     }
 

--- a/test/Core.Test/Vault/Services/CipherServiceTests.cs
+++ b/test/Core.Test/Vault/Services/CipherServiceTests.cs
@@ -2412,6 +2412,9 @@ public class CipherServiceTests
     {
         await Assert.ThrowsAsync<NotFoundException>(
             () => sutProvider.Sut.GetAttachmentDownloadDataAsync(null, attachmentId));
+
+        await sutProvider.GetDependency<IEventService>().DidNotReceiveWithAnyArgs()
+            .LogCipherEventAsync(default, default);
     }
 
     [Theory, BitAutoData]
@@ -2422,6 +2425,9 @@ public class CipherServiceTests
 
         await Assert.ThrowsAsync<NotFoundException>(
             () => sutProvider.Sut.GetAttachmentDownloadDataAsync(cipher, "nonexistent"));
+
+        await sutProvider.GetDependency<IEventService>().DidNotReceiveWithAnyArgs()
+            .LogCipherEventAsync(default, default);
     }
 
     [Theory, BitAutoData]
@@ -2454,6 +2460,9 @@ public class CipherServiceTests
 
         Assert.Equal(expectedUrl, result.Url);
         Assert.Equal(attachmentId, result.Id);
+
+        await sutProvider.GetDependency<IEventService>().Received(1)
+            .LogCipherEventAsync(cipher, EventType.Cipher_AttachmentDownloaded);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

This is related to https://bitwarden.atlassian.net/browse/PFI-824

## 📔 Objective

Attachment interactions on vault items can be a critical action in regulated environments where organizations need a full audit trail of who accessed sensitive files and when. Today, Cipher_AttachmentCreated (1103) and Cipher_AttachmentDeleted (1104) are logged, but downloads are not. This leaves a gap in the event history for compliance reviews. This PR introduces a new event, Cipher_AttachmentDownloaded (1133), emitted server-side from CipherService.GetAttachmentDownloadDataAsync whenever a user requests the signed download URL for an attachment. 
Because the server issues the URL, the event cannot be bypassed by a modified client - distinguishing it from client-reported Cipher_Client* events. Attachment metadata already flows on sync, so this signal is limited to genuine user-initiated download actions and won't inflate the event table with sync noise.

## 📸 Screenshots
<img width="1442" height="446" alt="Screenshot 2026-08-11 at 12 36 54 PM" src="https://github.com/user-attachments/assets/17afb6ba-da02-4f8b-b1eb-6f8e404e87f9" />
