### PR TITLE
[PM-40640] Adjust error messages for Send policy enforcement

### DIFF
--- a/src/Core/Tools/SendFeatures/Services/SendValidationService.cs
+++ b/src/Core/Tools/SendFeatures/Services/SendValidationService.cs
@@ -82,13 +82,13 @@ public class SendValidationService : ISendValidationService
 
         if (disableSendRequirement.DisableSend)
         {
-            throw new BadRequestException("Due to an Enterprise Policy, you are only able to delete an existing Send.");
+            throw new BadRequestException("Due to an Enterprise policy, you are only able to delete an existing Send.");
         }
 
         if (sendOptionsRequirement.DisableHideEmail && send.HideEmail.GetValueOrDefault())
         {
             throw new BadRequestException(
-                "Due to an Enterprise Policy, you are not allowed to hide your email address from recipients when creating or editing a Send.");
+                "Due to an Enterprise policy, you are not allowed to hide your email address from recipients when creating or editing a Send.");
         }
 
         var passwordRequired = sendControlsRequirement.WhoCanAccess == SendWhoCanAccessType.PasswordProtected;
@@ -96,12 +96,12 @@ public class SendValidationService : ISendValidationService
         if ((passwordRequired && send.Password == null) || (emailsRequired && send.Emails == null))
         {
             var requiredAccessControl = passwordRequired ? "password" : emailsRequired ? "email verification" : "(cannot determine required auth)";
-            throw new BadRequestException($"Due to an Enterprise Policy your Sends must be protected by {requiredAccessControl}");
+            throw new BadRequestException($"Due to an Enterprise policy your Sends must be protected by {requiredAccessControl}");
         }
 
         if (emailsRequired && sendControlsRequirement.AllowedDomains != null && !SendAllEmailsHaveAllowedDomains(send.Emails, sendControlsRequirement.AllowedDomains))
         {
-            throw new BadRequestException($"Due to an Enterprise Policy your Sends must be protected by email verification and access granted only to the following domain(s): {sendControlsRequirement.AllowedDomains}");
+            throw new BadRequestException($"Due to an Enterprise policy your Sends must be protected by email verification and access granted only to the following domain(s): {sendControlsRequirement.AllowedDomains}");
         }
 
         if (sendControlsRequirement.AllowedSendTypes != null && !sendControlsRequirement.AllowedSendTypes.Contains(send.Type))

--- a/test/Core.Test/Tools/Services/NonAnonymousSendCommandTests.cs
+++ b/test/Core.Test/Tools/Services/NonAnonymousSendCommandTests.cs
@@ -82,13 +82,13 @@ public class NonAnonymousSendCommandTests
 
         // Configure validation service to throw when DisableSend policy applies
         _sendValidationService.ValidateUserCanSaveAsync(send.UserId.Value, send)
-            .Throws(new BadRequestException("Due to an Enterprise Policy, you are only able to delete an existing Send."));
+            .Throws(new BadRequestException("Due to an Enterprise policy, you are only able to delete an existing Send."));
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
             _nonAnonymousSendCommand.SaveSendAsync(send));
 
-        Assert.Contains("Enterprise Policy", exception.Message);
+        Assert.Contains("Enterprise policy", exception.Message);
 
         // Verify the validation service was called
         await _sendValidationService.Received(1).ValidateUserCanSaveAsync(send.UserId.Value, send);
@@ -161,7 +161,7 @@ public class NonAnonymousSendCommandTests
 
         // Configure validation service to throw when HideEmail policy applies
         _sendValidationService.ValidateUserCanSaveAsync(userId, send)
-            .Throws(new BadRequestException("Due to an Enterprise Policy, you are not allowed to hide your email address from recipients when creating or editing a Send."));
+            .Throws(new BadRequestException("Due to an Enterprise policy, you are not allowed to hide your email address from recipients when creating or editing a Send."));
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
@@ -250,13 +250,13 @@ public class NonAnonymousSendCommandTests
 
         // Configure validation service to throw when DisableSend policy applies in vNext implementation
         _sendValidationService.ValidateUserCanSaveAsync(userId, send)
-            .Returns(Task.FromException(new BadRequestException("Due to an Enterprise Policy, you are only able to delete an existing Send.")));
+            .Returns(Task.FromException(new BadRequestException("Due to an Enterprise policy, you are only able to delete an existing Send.")));
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>
             _nonAnonymousSendCommand.SaveSendAsync(send));
 
-        Assert.Contains("Enterprise Policy", exception.Message);
+        Assert.Contains("Enterprise policy", exception.Message);
 
         // Verify validation service was called
         await _sendValidationService.Received(1).ValidateUserCanSaveAsync(userId, send);
@@ -333,7 +333,7 @@ public class NonAnonymousSendCommandTests
 
         // Configure validation service to throw when DisableHideEmail policy applies in vNext implementation
         _sendValidationService.ValidateUserCanSaveAsync(userId, send)
-            .Throws(new BadRequestException("Due to an Enterprise Policy, you are not allowed to hide your email address from recipients when creating or editing a Send."));
+            .Throws(new BadRequestException("Due to an Enterprise policy, you are not allowed to hide your email address from recipients when creating or editing a Send."));
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<BadRequestException>(() =>

--- a/test/Core.Test/Tools/Services/SendValidationServiceTests.cs
+++ b/test/Core.Test/Tools/Services/SendValidationServiceTests.cs
@@ -206,7 +206,7 @@ public class SendValidationServiceTests
             .Returns(new SendControlsPolicyRequirement { DisableSend = false, DisableHideEmail = false, WhoCanAccess = SendWhoCanAccessType.PasswordProtected });
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.ValidateUserCanSaveAsync(userId, send));
-        Assert.Equal("Due to an Enterprise Policy your Sends must be protected by password", exception.Message);
+        Assert.Equal("Due to an Enterprise policy your Sends must be protected by password", exception.Message);
     }
 
     [Theory, BitAutoData]
@@ -228,7 +228,7 @@ public class SendValidationServiceTests
             .Returns(new SendControlsPolicyRequirement { DisableSend = false, DisableHideEmail = false, WhoCanAccess = SendWhoCanAccessType.SpecificPeople });
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.ValidateUserCanSaveAsync(userId, send));
-        Assert.Equal("Due to an Enterprise Policy your Sends must be protected by email verification", exception.Message);
+        Assert.Equal("Due to an Enterprise policy your Sends must be protected by email verification", exception.Message);
     }
 
     [Theory, BitAutoData]
@@ -250,7 +250,7 @@ public class SendValidationServiceTests
             .Returns(new SendControlsPolicyRequirement { DisableSend = false, DisableHideEmail = false, WhoCanAccess = SendWhoCanAccessType.SpecificPeople, AllowedDomains = "bitwarden.com" });
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.ValidateUserCanSaveAsync(userId, send));
-        Assert.Equal("Due to an Enterprise Policy your Sends must be protected by email verification and access granted only to the following domain(s): bitwarden.com", exception.Message);
+        Assert.Equal("Due to an Enterprise policy your Sends must be protected by email verification and access granted only to the following domain(s): bitwarden.com", exception.Message);
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40640

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR adjusts the error strings that are returned when Send policies are enforced so that all instances of "Enterprise Policy" are corrected to "Enterprise policy". No logic changes, only error messages.
