### PR TITLE
[PM-41871] Add Chrome extension beta to allowed passkey origins

### DIFF
--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -111,6 +111,7 @@ public static class Constants
     public static class BrowserExtensions
     {
         public const string ChromeId = "chrome-extension://nngceckbapebfimnlniiiahkandclblb/";
+        public const string ChromeBetaId = "chrome-extension://hccnnhgbibccigepcmlgppchkpfdophk/";
         public const string EdgeId = "chrome-extension://jbkfoedolllekgbhcbcoahefnbanhhlh/";
         public const string OperaId = "chrome-extension://ccnckbpmaceehanjmeomladnmlffdjgn/";
     }

--- a/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
+++ b/src/SharedWeb/Utilities/ServiceCollectionExtensions.cs
@@ -640,6 +640,7 @@ public static class ServiceCollectionExtensions
                 options.Origins = new HashSet<string> {
                     globalSettings.BaseServiceUri.Vault,
                     Constants.BrowserExtensions.ChromeId,
+                    Constants.BrowserExtensions.ChromeBetaId,
                     Constants.BrowserExtensions.EdgeId,
                     Constants.BrowserExtensions.OperaId
                  };


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41871

## 📔 Objective

Adds the extension URL to the allowed origins for our Chrome store beta extension.

This will be used in the extension beta release being designed in https://github.com/bitwarden/clients/pull/22191.

The extension identifier was pulled from https://chromewebstore.google.com/detail/bitwarden-password-manage/hccnnhgbibccigepcmlgppchkpfdophk.
