### PR TITLE
feat(seeder): age seeded users by default

### DIFF
--- a/test/SeederApi.IntegrationTest/Factories/UserSeederTests.cs
+++ b/test/SeederApi.IntegrationTest/Factories/UserSeederTests.cs
@@ -77,6 +77,48 @@ public class UserSeederTests
     }
 
     [Fact]
+    public void Create_ByDefault_SeedsAgedCreationDate()
+    {
+        var (user, _) = UserSeeder.Create(new UserSeed { Email = _email }, _passwordHasher, new NoOpManglerService());
+
+        Assert.True(user.CreationDate < DateTime.UtcNow.AddDays(-90));
+    }
+
+    [Fact]
+    public void Create_WhenAccountAgeDaysZero_SeedsToday()
+    {
+        var before = DateTime.UtcNow;
+
+        var (user, _) = UserSeeder.Create(
+            new UserSeed { Email = _email, AccountAgeDays = 0 }, _passwordHasher, new NoOpManglerService());
+
+        Assert.InRange(user.CreationDate, before, DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void Create_WhenAccountAgeDaysSet_BackdatesExactly()
+    {
+        var before = DateTime.UtcNow;
+
+        var (user, _) = UserSeeder.Create(
+            new UserSeed { Email = _email, AccountAgeDays = 200 }, _passwordHasher, new NoOpManglerService());
+
+        Assert.InRange(user.CreationDate, before.AddDays(-200), DateTime.UtcNow.AddDays(-200));
+    }
+
+    [Fact]
+    public void Create_LeavesRevisionDatesAtNow()
+    {
+        var before = DateTime.UtcNow;
+
+        var (user, _) = UserSeeder.Create(
+            new UserSeed { Email = _email, AccountAgeDays = 200 }, _passwordHasher, new NoOpManglerService());
+
+        Assert.InRange(user.RevisionDate, before, DateTime.UtcNow);
+        Assert.InRange(user.AccountRevisionDate, before, DateTime.UtcNow);
+    }
+
+    [Fact]
     public void Create_WhenNotPremium_LeavesExpirationNull()
     {
         var (user, _) = UserSeeder.Create(new UserSeed { Email = _email }, _passwordHasher, new NoOpManglerService());

--- a/util/Seeder/Factories/UserSeeder.cs
+++ b/util/Seeder/Factories/UserSeeder.cs
@@ -61,6 +61,9 @@ internal static class UserSeeder
             user.SetTwoFactorProviders(seed.TwoFactorProviders);
         }
 
+        var ageDays = seed.AccountAgeDays ?? Random.Shared.Next(91, 1096);
+        user.CreationDate = DateTime.UtcNow.AddDays(-ageDays);
+
         user.MasterPassword = passwordHasher.HashPassword(user, keys.MasterPasswordHash);
 
         return (user, keys);

--- a/util/Seeder/Models/UserSeed.cs
+++ b/util/Seeder/Models/UserSeed.cs
@@ -110,4 +110,11 @@ internal record UserSeed
     /// WebAuthn credentials) is the caller's to supply.
     /// </summary>
     public Dictionary<TwoFactorProviderType, TwoFactorProvider>? TwoFactorProviders { get; init; }
+
+    /// <summary>
+    /// Age of the account in days, used to backdate <see cref="User.CreationDate"/>. Null (default)
+    /// randomizes an aged date beyond 90 days in the past; 0 seeds today's date; N seeds exactly N
+    /// days ago. <see cref="User.RevisionDate"/> and <see cref="User.AccountRevisionDate"/> are unaffected.
+    /// </summary>
+    public int? AccountAgeDays { get; init; }
 }

--- a/util/Seeder/Options/IndividualUserOptions.cs
+++ b/util/Seeder/Options/IndividualUserOptions.cs
@@ -48,4 +48,10 @@ public record IndividualUserOptions
     /// Required for self-hosted instances that validate premium status by reading the license file.
     /// </summary>
     public bool SelfHosted { get; init; }
+
+    /// <summary>
+    /// Age of the account in days. Null (default) randomizes an aged date beyond 90 days in the past;
+    /// 0 seeds today's date; N seeds exactly N days ago.
+    /// </summary>
+    public int? AccountAgeDays { get; init; }
 }

--- a/util/Seeder/Pipeline/RecipeBuilderExtensions.cs
+++ b/util/Seeder/Pipeline/RecipeBuilderExtensions.cs
@@ -163,13 +163,14 @@ public static class RecipeBuilderExtensions
     /// <param name="premium">Whether the account has premium status</param>
     /// <param name="maxStorageGb">Optional max storage override in GB</param>
     /// <param name="selfHosted">When true, writes a license file after user creation (required for self-hosted premium validation)</param>
+    /// <param name="accountAgeDays">Backdates CreationDate: null randomizes an aged date, 0 seeds today, N seeds N days ago</param>
     /// <returns>The builder for fluent chaining</returns>
     public static RecipeBuilder CreateIndividualUser(
-        this RecipeBuilder builder, string email, bool premium, short maxStorageGb, bool selfHosted = false)
+        this RecipeBuilder builder, string email, bool premium, short maxStorageGb, bool selfHosted = false, int? accountAgeDays = null)
     {
         builder.HasIndividualUser = true;
         builder.HasOwner = true;
-        builder.AddStep(_ => new CreateIndividualUserStep(email, premium, maxStorageGb, true));
+        builder.AddStep(_ => new CreateIndividualUserStep(email, premium, maxStorageGb, true, accountAgeDays));
         if (selfHosted)
         {
             builder.AddAsyncStep(sp => new GenerateSelfHostUserLicenseStep(sp.GetRequiredService<ILicensingService>()));

--- a/util/Seeder/Pipeline/RecipeOrchestrator.cs
+++ b/util/Seeder/Pipeline/RecipeOrchestrator.cs
@@ -150,7 +150,7 @@ internal sealed class RecipeOrchestrator(SeederDependencies deps)
         var recipeName = "individual-from-options";
         var builder = services.AddRecipe(recipeName);
 
-        builder.CreateIndividualUser(email, premium, maxStorageGb, options.SelfHosted);
+        builder.CreateIndividualUser(email, premium, maxStorageGb, options.SelfHosted, options.AccountAgeDays);
         builder.WithGenerator("individual.example");
 
         if (options.GenerateVault)

--- a/util/Seeder/Scenes/SingleUserScene.cs
+++ b/util/Seeder/Scenes/SingleUserScene.cs
@@ -44,6 +44,7 @@ public class SingleUserScene(
         public GatewayType? Gateway { get; set; }
         public string? GatewayCustomerId { get; set; }
         public string? GatewaySubscriptionId { get; set; }
+        public int? AccountAgeDays { get; set; }
     }
 
     public async Task<SceneResult<SingleUserSceneResult>> SeedAsync(Request request)
@@ -58,7 +59,8 @@ public class SingleUserScene(
                 Password = request.Password,
                 Gateway = request.Gateway,
                 GatewayCustomerId = request.GatewayCustomerId,
-                GatewaySubscriptionId = request.GatewaySubscriptionId
+                GatewaySubscriptionId = request.GatewaySubscriptionId,
+                AccountAgeDays = request.AccountAgeDays
             },
             passwordHasher,
             manglerService);

--- a/util/Seeder/Steps/CreateIndividualUserStep.cs
+++ b/util/Seeder/Steps/CreateIndividualUserStep.cs
@@ -8,7 +8,7 @@ namespace Bit.Seeder.Steps;
 /// Creates a standalone user with no organization, registering them as the context owner.
 /// </summary>
 internal sealed class CreateIndividualUserStep(
-    string email, bool premium, short maxStorageGb, bool emailVerified) : IStep
+    string email, bool premium, short maxStorageGb, bool emailVerified, int? accountAgeDays = null) : IStep
 {
     public void Execute(SeederContext context)
     {
@@ -23,7 +23,8 @@ internal sealed class CreateIndividualUserStep(
                 Premium = premium,
                 MaxStorageGb = maxStorageGb > 0 ? Math.Min(maxStorageGb, (short)5) : null,
                 Password = password,
-                KdfIterations = kdfIterations
+                KdfIterations = kdfIterations,
+                AccountAgeDays = accountAgeDays
             },
             context.GetPasswordHasher(),
             context.GetMangler());

--- a/util/SeederUtility/Commands/IndividualArgs.cs
+++ b/util/SeederUtility/Commands/IndividualArgs.cs
@@ -36,6 +36,9 @@ public class IndividualArgs : IArgumentModel
     [Option("mangle", Description = "Enable ID mangling for test isolation")]
     public bool Mangle { get; set; }
 
+    [Option("account-age-days", Description = "Backdate the account: 0 = today; omit for a randomized aged (>90 day) account")]
+    public int? AccountAgeDays { get; set; }
+
     public void Validate()
     {
         var sub = Subscription?.ToLowerInvariant();
@@ -47,6 +50,11 @@ public class IndividualArgs : IArgumentModel
         if (KdfIterations < 5_000)
         {
             throw new ArgumentException("KDF iterations must be at least 5,000.");
+        }
+
+        if (AccountAgeDays is < 0)
+        {
+            throw new ArgumentException("Account age days must be zero or greater.");
         }
 
         var hasFirst = !string.IsNullOrWhiteSpace(FirstName);
@@ -73,6 +81,7 @@ public class IndividualArgs : IArgumentModel
         GenerateVault = Vault,
         Password = Password,
         KdfIterations = KdfIterations,
-        SelfHosted = SelfHosted
+        SelfHosted = SelfHosted,
+        AccountAgeDays = AccountAgeDays
     };
 }

--- a/util/SeederUtility/README.md
+++ b/util/SeederUtility/README.md
@@ -50,9 +50,14 @@ dotnet run -- individual --subscription premium --vault
 
 # Self-hosted instance — writes a license file so premium status is recognized
 dotnet run -- individual --subscription premium --first-name Jane --last-name Smith --self-hosted
+
+# Fresh account created today (suppresses age-gated behavior like the premium upsell)
+dotnet run -- individual --subscription free --account-age-days 0
 ```
 
 Add `--self-hosted` when targeting a self-hosted instance — without it, premium status won't be recognized.
+
+Seeded accounts are **aged by default**: `CreationDate` is randomized beyond 90 days in the past. Pass `--account-age-days 0` for today's date, or `--account-age-days N` for exactly N days ago.
 
 ### `preset` - Fixture-Based Seeding
 


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/QA-2310

## 📔 Objective
Seeded users previously fell back to the User entity's CreationDate initializer (DateTime.UtcNow), so every account looked brand-new and age-gated scenarios (e.g. the premium upsell path) could not be reproduced.

UserSeeder.Create now backdates CreationDate for every seeding path. A new nullable UserSeed.AccountAgeDays controls it: null (default) randomizes an aged date between 91 days and 3 years ago, 0 seeds today, and N seeds exactly N days ago. RevisionDate and AccountRevisionDate are left at now.

The knob is exposed through the individual CLI command (--account-age-days) and the SingleUserScene request. Org owner, bulk member, and roster paths inherit the aged default automatically.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
