### PR TITLE
[PM-38326] Utilize cache for UsePolicies

### DIFF
--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -7,6 +7,7 @@ using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.AdminConsole.Models.Response.Helpers;
 using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Api.Models.Response;
+using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationDomains.Interfaces;
 using Bit.Core.AdminConsole.OrganizationFeatures.Policies;
@@ -27,7 +28,7 @@ public class PoliciesController : Controller
 {
     private readonly ICurrentContext _currentContext;
     private readonly IOrganizationHasVerifiedDomainsQuery _organizationHasVerifiedDomainsQuery;
-    private readonly IOrganizationRepository _organizationRepository;
+    private readonly IOrganizationAbilityCacheService _organizationAbilityCacheService;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly IDataProtectorTokenFactory<OrgUserInviteTokenable> _orgUserInviteTokenDataFactory;
     private readonly IPolicyRepository _policyRepository;
@@ -39,14 +40,14 @@ public class PoliciesController : Controller
         ICurrentContext currentContext,
         IDataProtectorTokenFactory<OrgUserInviteTokenable> orgUserInviteTokenDataFactory,
         IOrganizationHasVerifiedDomainsQuery organizationHasVerifiedDomainsQuery,
-        IOrganizationRepository organizationRepository,
+        IOrganizationAbilityCacheService organizationAbilityCacheService,
         ISavePolicyCommand savePolicyCommand,
         IPolicyQuery policyQuery)
     {
         _policyRepository = policyRepository;
         _organizationUserRepository = organizationUserRepository;
         _currentContext = currentContext;
-        _organizationRepository = organizationRepository;
+        _organizationAbilityCacheService = organizationAbilityCacheService;
         _orgUserInviteTokenDataFactory = orgUserInviteTokenDataFactory;
         _organizationHasVerifiedDomainsQuery = organizationHasVerifiedDomainsQuery;
         _savePolicyCommand = savePolicyCommand;
@@ -85,9 +86,9 @@ public class PoliciesController : Controller
     public async Task<ListResponseModel<PolicyResponseModel>> GetByToken(Guid orgId, [FromQuery] string email,
         [FromQuery] string token, [FromQuery] Guid organizationUserId)
     {
-        var organization = await _organizationRepository.GetByIdAsync(orgId);
+        var organizationAbility = await _organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId);
 
-        if (organization is not { UsePolicies: true })
+        if (organizationAbility is not { UsePolicies: true })
         {
             throw new NotFoundException();
         }
@@ -115,9 +116,9 @@ public class PoliciesController : Controller
     [Authorize<OrgUserLinkedToUserIdRequirement>]
     public async Task<PolicyResponseModel> GetMasterPasswordPolicy(Guid orgId)
     {
-        var organization = await _organizationRepository.GetByIdAsync(orgId);
+        var organizationAbility = await _organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId);
 
-        if (organization is not { UsePolicies: true })
+        if (organizationAbility is not { UsePolicies: true })
         {
             throw new NotFoundException();
         }

--- a/test/Api.Test/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -3,6 +3,7 @@ using Bit.Api.AdminConsole.Controllers;
 using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Api.Test.Utilities;
+using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Enums;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
@@ -13,6 +14,7 @@ using Bit.Core.Auth.Models.Business.Tokenables;
 using Bit.Core.Context;
 using Bit.Core.Entities;
 using Bit.Core.Exceptions;
+using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Repositories;
 using Bit.Core.Tokens;
 using Bit.Test.Common.AutoFixture;
@@ -42,13 +44,13 @@ public class PoliciesControllerTests
         Guid orgId,
         Policy policy,
         MasterPasswordPolicyData mpPolicyData,
-        Organization organization)
+        OrganizationAbility organizationAbility)
     {
         // Arrange
-        organization.UsePolicies = true;
+        organizationAbility.UsePolicies = true;
 
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns(organizationAbility);
 
         policy.Type = PolicyType.MasterPassword;
         policy.Enabled = true;
@@ -125,8 +127,8 @@ public class PoliciesControllerTests
         Guid orgId)
     {
         // Arrange
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns((Organization)null);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns((OrganizationAbility)null);
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetMasterPasswordPolicy(orgId));
@@ -137,13 +139,13 @@ public class PoliciesControllerTests
     public async Task GetMasterPasswordPolicy_WhenOrgIsNull_ThrowsNotFoundException(
         SutProvider<PoliciesController> sutProvider,
         Guid orgId,
-        Organization organization)
+        OrganizationAbility organizationAbility)
     {
         // Arrange
-        organization.UsePolicies = false;
+        organizationAbility.UsePolicies = false;
 
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns(organizationAbility);
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.GetMasterPasswordPolicy(orgId));
@@ -181,13 +183,13 @@ public class PoliciesControllerTests
     [BitAutoData]
     public async Task GetByToken_WhenOrganizationUseUsePoliciesIsFalse_ThrowsNotFoundException(
         SutProvider<PoliciesController> sutProvider, Guid orgId, Guid organizationUserId, string token, string email,
-        Organization organization)
+        OrganizationAbility organizationAbility)
     {
         // Arrange
-        organization.UsePolicies = false;
+        organizationAbility.UsePolicies = false;
 
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns(organizationAbility);
 
 
         // Act & Assert
@@ -201,8 +203,8 @@ public class PoliciesControllerTests
         SutProvider<PoliciesController> sutProvider, Guid orgId, Guid organizationUserId, string token, string email)
     {
         // Arrange
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns((Organization)null);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns((OrganizationAbility)null);
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(() =>
@@ -217,14 +219,14 @@ public class PoliciesControllerTests
         Guid organizationUserId,
         string token,
         string email,
-        Organization organization
+        OrganizationAbility organizationAbility
     )
     {
         // Arrange
-        organization.UsePolicies = true;
+        organizationAbility.UsePolicies = true;
 
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns(organizationAbility);
 
         var decryptedToken = Substitute.For<OrgUserInviteTokenable>();
         decryptedToken.Valid.Returns(false);
@@ -252,14 +254,14 @@ public class PoliciesControllerTests
         Guid organizationUserId,
         string token,
         string email,
-        Organization organization
+        OrganizationAbility organizationAbility
     )
     {
         // Arrange
-        organization.UsePolicies = true;
+        organizationAbility.UsePolicies = true;
 
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns(organizationAbility);
 
         var decryptedToken = Substitute.For<OrgUserInviteTokenable>();
         decryptedToken.Valid.Returns(true);
@@ -294,14 +296,14 @@ public class PoliciesControllerTests
         string token,
         string email,
         OrganizationUser orgUser,
-        Organization organization
+        OrganizationAbility organizationAbility
     )
     {
         // Arrange
-        organization.UsePolicies = true;
+        organizationAbility.UsePolicies = true;
 
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns(organizationAbility);
 
         var decryptedToken = Substitute.For<OrgUserInviteTokenable>();
         decryptedToken.Valid.Returns(true);
@@ -338,14 +340,14 @@ public class PoliciesControllerTests
         string token,
         string email,
         OrganizationUser orgUser,
-        Organization organization
+        OrganizationAbility organizationAbility
     )
     {
         // Arrange
-        organization.UsePolicies = true;
+        organizationAbility.UsePolicies = true;
 
-        var organizationRepository = sutProvider.GetDependency<IOrganizationRepository>();
-        organizationRepository.GetByIdAsync(orgId).Returns(organization);
+        var organizationAbilityCacheService = sutProvider.GetDependency<IOrganizationAbilityCacheService>();
+        organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId).Returns(organizationAbility);
 
         var decryptedToken = Substitute.For<OrgUserInviteTokenable>();
         decryptedToken.Valid.Returns(true);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38326

## 📔 Objective

Replaces the per-request `Organization` DB lookup in `PoliciesController.GetByToken` and `GetMasterPasswordPolicy` with a read from the existing `OrganizationAbility` cache, since the only thing needed (`UsePolicies`) is already cached there. This avoids an unnecessary full database call on every invite-link click and master password policy check
