### PR TITLE
[PM-38272] fix: handle null or empty permissions in OrganizationUserResponseModel

### DIFF
--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
@@ -8,7 +8,6 @@ using Bit.Core.Enums;
 using Bit.Core.Models.Api;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
-using Bit.Core.Utilities;
 
 namespace Bit.Api.AdminConsole.Models.Response.Organizations;
 
@@ -29,9 +28,7 @@ public class OrganizationUserResponseModel : ResponseModel
         ExternalId = organizationUser.ExternalId;
         AccessSecretsManager = organizationUser.AccessSecretsManager;
         AccessPam = organizationUser.AccessPam;
-        Permissions = string.IsNullOrWhiteSpace(organizationUser.Permissions)
-            ? null
-            : CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
+        Permissions = organizationUser.GetPermissions();
         ResetPasswordEnrolled = OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey);
     }
 
@@ -51,9 +48,7 @@ public class OrganizationUserResponseModel : ResponseModel
         ExternalId = organizationUser.ExternalId;
         AccessSecretsManager = organizationUser.AccessSecretsManager;
         AccessPam = organizationUser.AccessPam;
-        Permissions = string.IsNullOrWhiteSpace(organizationUser.Permissions)
-            ? null
-            : CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
+        Permissions = organizationUser.GetPermissions();
         ResetPasswordEnrolled = OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey);
         UsesKeyConnector = organizationUser.UsesKeyConnector;
         HasMasterPassword = organizationUser.HasMasterPassword;

--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
@@ -29,7 +29,9 @@ public class OrganizationUserResponseModel : ResponseModel
         ExternalId = organizationUser.ExternalId;
         AccessSecretsManager = organizationUser.AccessSecretsManager;
         AccessPam = organizationUser.AccessPam;
-        Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
+        Permissions = string.IsNullOrWhiteSpace(organizationUser.Permissions)
+            ? null
+            : CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
         ResetPasswordEnrolled = OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey);
     }
 
@@ -49,7 +51,9 @@ public class OrganizationUserResponseModel : ResponseModel
         ExternalId = organizationUser.ExternalId;
         AccessSecretsManager = organizationUser.AccessSecretsManager;
         AccessPam = organizationUser.AccessPam;
-        Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
+        Permissions = string.IsNullOrWhiteSpace(organizationUser.Permissions)
+            ? null
+            : CoreHelpers.LoadClassFromJsonData<Permissions>(organizationUser.Permissions);
         ResetPasswordEnrolled = OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey);
         UsesKeyConnector = organizationUser.UsesKeyConnector;
         HasMasterPassword = organizationUser.HasMasterPassword;
@@ -62,6 +66,7 @@ public class OrganizationUserResponseModel : ResponseModel
     public string ExternalId { get; set; }
     public bool AccessSecretsManager { get; set; }
     public bool AccessPam { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Permissions Permissions { get; set; }
     public bool ResetPasswordEnrolled { get; set; }
     public bool UsesKeyConnector { get; set; }


### PR DESCRIPTION


## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-38272

## 📔 Objective

Stops sending back empty permissions model for non-custom users
