### PR TITLE
[PM-39925] feat: add the invoice preview projection to Bit.Invoicing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,7 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
-# core.ignorecase treats *.user above as matching the Bit.Subscriptions.User library directory
-# on case-insensitive checkouts, so re-include it explicitly.
+# Re-include Subscriptions.User: on case-insensitive checkouts *.user above matches this dir.
 !src/Libraries/Subscriptions.User/
 
 # Build results

--- a/bitwarden_license/test/Services/Pam.IntegrationTest/packages.lock.json
+++ b/bitwarden_license/test/Services/Pam.IntegrationTest/packages.lock.json
@@ -2035,7 +2035,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "migrator": {

--- a/src/Api/packages.lock.json
+++ b/src/Api/packages.lock.json
@@ -1273,7 +1273,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "organizationauthorization": {

--- a/src/Core/Billing/Constants/StripeConstants.cs
+++ b/src/Core/Billing/Constants/StripeConstants.cs
@@ -121,7 +121,6 @@ public static class StripeConstants
 
     /// <summary>
     /// The stable, plan-agnostic values carried in <see cref="MetadataKeys.PurchasableReference"/>.
-    /// Identifies what a price represents, not which plan variant, so pm-seat covers every tier and cadence.
     /// </summary>
     public static class PurchasableReferences
     {

--- a/src/Core/Billing/Constants/StripeConstants.cs
+++ b/src/Core/Billing/Constants/StripeConstants.cs
@@ -116,6 +116,19 @@ public static class StripeConstants
         public const string MigrationCohortName = "migration_cohort_name";
         public const string MigrationGraceServiceAccounts = "migration_grace_service_accounts";
         public const string CancellingUserId = "cancellingUserId";
+        public const string PurchasableReference = "purchasable_reference";
+    }
+
+    /// <summary>
+    /// The stable, plan-agnostic values carried in <see cref="MetadataKeys.PurchasableReference"/>.
+    /// Identifies what a price represents, not which plan variant, so pm-seat covers every tier and cadence.
+    /// </summary>
+    public static class PurchasableReferences
+    {
+        public const string PasswordManagerSeat = "pm-seat";
+        public const string PasswordManagerStorage = "pm-storage";
+        public const string SecretsManagerSeat = "sm-seat";
+        public const string SecretsManagerServiceAccount = "sm-service-account";
     }
 
     public static class CancellationOrigins

--- a/src/Core/Billing/Services/IStripeAdapter.cs
+++ b/src/Core/Billing/Services/IStripeAdapter.cs
@@ -28,6 +28,7 @@ public interface IStripeAdapter
     Task<List<Invoice>> ListInvoicesAsync(StripeInvoiceListOptions options);
     Task<Invoice> CreateInvoiceAsync(InvoiceCreateOptions options);
     Task<Invoice> CreateInvoicePreviewAsync(InvoiceCreatePreviewOptions options);
+    Task<List<InvoiceLineItem>> ListInvoiceLineItemsAsync(string invoiceId, InvoiceLineItemListOptions options);
     Task<List<Invoice>> SearchInvoiceAsync(InvoiceSearchOptions options);
     Task<Invoice> UpdateInvoiceAsync(string id, InvoiceUpdateOptions options);
     Task<Invoice> FinalizeInvoiceAsync(string id, InvoiceFinalizeOptions options = null);

--- a/src/Core/Billing/Services/Implementations/StripeAdapter.cs
+++ b/src/Core/Billing/Services/Implementations/StripeAdapter.cs
@@ -19,6 +19,7 @@ public class StripeAdapter : IStripeAdapter
     private readonly CustomerService _customerService;
     private readonly SubscriptionService _subscriptionService;
     private readonly InvoiceService _invoiceService;
+    private readonly InvoiceLineItemService _invoiceLineItemService;
     private readonly PaymentMethodService _paymentMethodService;
     private readonly TaxIdService _taxIdService;
     private readonly ChargeService _chargeService;
@@ -41,6 +42,7 @@ public class StripeAdapter : IStripeAdapter
         _customerService = new CustomerService();
         _subscriptionService = new SubscriptionService();
         _invoiceService = new InvoiceService();
+        _invoiceLineItemService = new InvoiceLineItemService();
         _paymentMethodService = new PaymentMethodService();
         _taxIdService = new TaxIdService();
         _chargeService = new ChargeService();
@@ -140,6 +142,21 @@ public class StripeAdapter : IStripeAdapter
 
     public Task<Invoice> CreateInvoicePreviewAsync(InvoiceCreatePreviewOptions options) =>
         _invoiceService.CreatePreviewAsync(options);
+
+    public async Task<List<InvoiceLineItem>> ListInvoiceLineItemsAsync(string invoiceId,
+        InvoiceLineItemListOptions options)
+    {
+        options.Limit = 100;
+
+        var lineItems = new List<InvoiceLineItem>();
+
+        await foreach (var lineItem in _invoiceLineItemService.ListAutoPagingAsync(invoiceId, options))
+        {
+            lineItems.Add(lineItem);
+        }
+
+        return lineItems;
+    }
 
     public async Task<List<Invoice>> SearchInvoiceAsync(InvoiceSearchOptions options) =>
         (await _invoiceService.SearchAsync(options)).Data;

--- a/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
@@ -34,6 +34,12 @@ internal static class DiscountMapper
         var attached = new HashSet<string>();
         foreach (var line in invoice.Lines?.Data ?? [])
         {
+            // Prorations are discountable=false: the discount rides in the line amount, not discount_amounts.
+            if (line.Parent?.SubscriptionItemDetails?.Proration == true)
+            {
+                continue;
+            }
+
             var reference = line.Pricing?.PriceDetails?.Price?.Metadata?.GetValueOrDefault(StripeConstants.MetadataKeys.PurchasableReference);
             if (string.IsNullOrEmpty(reference) || !PurchasableReferences.IsKnown(reference))
             {

--- a/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Constants;
+﻿using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Subscriptions.Models;
 using Bit.Invoicing.InvoicePreviews.Models;
 using Microsoft.Extensions.Logging;

--- a/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
@@ -1,0 +1,85 @@
+using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Subscriptions.Models;
+using Bit.Invoicing.InvoicePreviews.Models;
+using Microsoft.Extensions.Logging;
+using Stripe;
+
+namespace Bit.Invoicing.InvoicePreviews;
+
+internal sealed record PartitionedDiscounts(
+    InvoicePreviewDiscount[] CartLevel,
+    IReadOnlyDictionary<string, InvoicePreviewDiscount[]> ItemLevel);
+
+/// <summary>Classifies each invoice discount by scope. Coupons are resolved once via the top-level total_discount_amounts expansion and matched onto lines by DiscountId.</summary>
+internal static class DiscountMapper
+{
+    internal static PartitionedDiscounts Partition(Invoice invoice, ILogger logger)
+    {
+        var resolved = new Dictionary<string, ResolvedDiscount>();
+        foreach (var total in invoice.TotalDiscountAmounts ?? [])
+        {
+            // Log, don't drop: a lost coupon expansion would otherwise erase every discount unseen.
+            if (total.Discount?.Source?.Coupon is not { } coupon)
+            {
+                logger.LogError("Discount {DiscountId} has no expanded coupon; dropped.", total.DiscountId);
+                continue;
+            }
+            resolved.Add(total.DiscountId, new ResolvedDiscount(coupon, total.Amount / 100m));
+        }
+
+        var cartLevel = resolved.Values.Where(discount => !discount.IsItemScoped)
+            .Select(discount => discount.ToPreviewDiscount(discount.AggregateAmount)).ToArray();
+
+        var itemLevel = new Dictionary<string, InvoicePreviewDiscount[]>();
+        var attached = new HashSet<string>();
+        foreach (var line in invoice.Lines?.Data ?? [])
+        {
+            var reference = line.Pricing?.PriceDetails?.Price?.Metadata?.GetValueOrDefault(StripeConstants.MetadataKeys.PurchasableReference);
+            if (string.IsNullOrEmpty(reference))
+            {
+                continue;
+            }
+
+            // Match on DiscountId: line.DiscountAmounts[].Discount is unexpanded (null) on real responses.
+            var matches = (line.DiscountAmounts ?? [])
+                .Where(amount => !string.IsNullOrEmpty(amount.DiscountId)
+                                 && resolved.TryGetValue(amount.DiscountId, out var discount) && discount.IsItemScoped)
+                .ToArray();
+            if (matches.Length == 0)
+            {
+                continue;
+            }
+
+            var lineDiscounts = matches.Select(amount => resolved[amount.DiscountId].ToPreviewDiscount(amount.Amount / 100m)).ToArray();
+            foreach (var amount in matches)
+            {
+                attached.Add(amount.DiscountId);
+            }
+            itemLevel[reference] = itemLevel.TryGetValue(reference, out var existing) ? [.. existing, .. lineDiscounts] : lineDiscounts;
+        }
+
+        // An item-scoped coupon matching no referenced line vanishes from both sets — never silently.
+        foreach (var (discountId, discount) in resolved)
+        {
+            if (discount.IsItemScoped && !attached.Contains(discountId))
+            {
+                logger.LogError("Item-scoped discount {DiscountId} ({Label}) matched no line; dropped.", discountId, discount.Coupon.Name);
+            }
+        }
+
+        return new PartitionedDiscounts(cartLevel, itemLevel);
+    }
+
+    private readonly record struct ResolvedDiscount(Coupon Coupon, decimal AggregateAmount)
+    {
+        internal bool IsItemScoped => Coupon.AppliesTo?.Products?.Count > 0;
+
+        internal InvoicePreviewDiscount ToPreviewDiscount(decimal amount) => new()
+        {
+            Type = Coupon.PercentOff is not null ? BitwardenDiscountType.PercentOff : BitwardenDiscountType.AmountOff,
+            Value = Coupon.PercentOff ?? (Coupon.AmountOff ?? 0) / 100m,
+            Amount = amount,
+            Label = Coupon.Name,
+        };
+    }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
@@ -22,7 +22,7 @@ internal static class DiscountMapper
 {
     internal static PartitionedDiscounts Partition(Invoice invoice, ILogger logger)
     {
-        var resolved = ResolveCoupons(invoice, logger);
+        var resolved = ResolveInvoiceDiscounts(invoice, logger);
 
         var cartLevel = resolved.Values
             .Where(discount => !discount.IsItemScoped)
@@ -74,7 +74,7 @@ internal static class DiscountMapper
             itemLevel.ToDictionary(entry => entry.Key, entry => entry.Value.ToArray()));
     }
 
-    private static Dictionary<string, ResolvedDiscount> ResolveCoupons(Invoice invoice, ILogger logger)
+    private static Dictionary<string, ResolvedDiscount> ResolveInvoiceDiscounts(Invoice invoice, ILogger logger)
     {
         var resolved = new Dictionary<string, ResolvedDiscount>();
         foreach (var total in invoice.TotalDiscountAmounts ?? [])

--- a/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
@@ -35,7 +35,7 @@ internal static class DiscountMapper
         foreach (var line in invoice.Lines?.Data ?? [])
         {
             var reference = line.Pricing?.PriceDetails?.Price?.Metadata?.GetValueOrDefault(StripeConstants.MetadataKeys.PurchasableReference);
-            if (string.IsNullOrEmpty(reference))
+            if (string.IsNullOrEmpty(reference) || !PurchasableReferences.IsKnown(reference))
             {
                 continue;
             }

--- a/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
@@ -79,12 +79,17 @@ internal static class DiscountMapper
         var resolved = new Dictionary<string, ResolvedDiscount>();
         foreach (var total in invoice.TotalDiscountAmounts ?? [])
         {
+            if (string.IsNullOrEmpty(total.DiscountId))
+            {
+                logger.LogError("Discount amount ({Amount}) has no discount id; dropped.", total.Amount);
+                continue;
+            }
             if (total.Discount?.Source?.Coupon is not { } coupon)
             {
                 logger.LogError("Discount {DiscountId} has no expanded coupon; dropped.", total.DiscountId);
                 continue;
             }
-            resolved.Add(total.DiscountId, new ResolvedDiscount(coupon, total.Amount / 100m));
+            resolved[total.DiscountId] = new ResolvedDiscount(coupon, total.Amount / 100m);
         }
         return resolved;
     }

--- a/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
@@ -6,31 +6,30 @@ using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews;
 
+/// <summary>
+/// Invoice discounts split by scope: <see cref="CartLevel"/> applies to the whole invoice,
+/// while <see cref="ItemLevel"/> holds per-line discounts keyed by purchasable reference.
+/// </summary>
 internal sealed record PartitionedDiscounts(
     InvoicePreviewDiscount[] CartLevel,
     IReadOnlyDictionary<string, InvoicePreviewDiscount[]> ItemLevel);
 
-/// <summary>Classifies each invoice discount by scope. Coupons are resolved once via the top-level total_discount_amounts expansion and matched onto lines by DiscountId.</summary>
+/// <summary>
+/// Splits invoice discounts into cart-level and item-level buckets. Coupons are resolved
+/// once and matched onto the lines they apply to.
+/// </summary>
 internal static class DiscountMapper
 {
     internal static PartitionedDiscounts Partition(Invoice invoice, ILogger logger)
     {
-        var resolved = new Dictionary<string, ResolvedDiscount>();
-        foreach (var total in invoice.TotalDiscountAmounts ?? [])
-        {
-            // Log, don't drop: a lost coupon expansion would otherwise erase every discount unseen.
-            if (total.Discount?.Source?.Coupon is not { } coupon)
-            {
-                logger.LogError("Discount {DiscountId} has no expanded coupon; dropped.", total.DiscountId);
-                continue;
-            }
-            resolved.Add(total.DiscountId, new ResolvedDiscount(coupon, total.Amount / 100m));
-        }
+        var resolved = ResolveCoupons(invoice, logger);
 
-        var cartLevel = resolved.Values.Where(discount => !discount.IsItemScoped)
-            .Select(discount => discount.ToPreviewDiscount(discount.AggregateAmount)).ToArray();
+        var cartLevel = resolved.Values
+            .Where(discount => !discount.IsItemScoped)
+            .Select(discount => discount.ToPreviewDiscount(discount.AggregateAmount))
+            .ToArray();
 
-        var itemLevel = new Dictionary<string, InvoicePreviewDiscount[]>();
+        var itemLevel = new Dictionary<string, List<InvoicePreviewDiscount>>();
         var attached = new HashSet<string>();
         foreach (var line in invoice.Lines?.Data ?? [])
         {
@@ -41,30 +40,27 @@ internal static class DiscountMapper
             }
 
             var reference = line.Pricing?.PriceDetails?.Price?.Metadata?.GetValueOrDefault(StripeConstants.MetadataKeys.PurchasableReference);
-            if (string.IsNullOrEmpty(reference) || !PurchasableReferences.IsKnown(reference))
+            if (!PurchasableReferences.IsKnown(reference))
             {
                 continue;
             }
 
             // Match on DiscountId: line.DiscountAmounts[].Discount is unexpanded (null) on real responses.
-            var matches = (line.DiscountAmounts ?? [])
-                .Where(amount => !string.IsNullOrEmpty(amount.DiscountId)
-                                 && resolved.TryGetValue(amount.DiscountId, out var discount) && discount.IsItemScoped)
-                .ToArray();
-            if (matches.Length == 0)
+            foreach (var amount in line.DiscountAmounts ?? [])
             {
-                continue;
-            }
+                if (string.IsNullOrEmpty(amount.DiscountId)
+                    || !resolved.TryGetValue(amount.DiscountId, out var discount)
+                    || !discount.IsItemScoped)
+                {
+                    continue;
+                }
 
-            var lineDiscounts = matches.Select(amount => resolved[amount.DiscountId].ToPreviewDiscount(amount.Amount / 100m)).ToArray();
-            foreach (var amount in matches)
-            {
                 attached.Add(amount.DiscountId);
+                itemLevel.TryAdd(reference, []);
+                itemLevel[reference].Add(discount.ToPreviewDiscount(amount.Amount / 100m));
             }
-            itemLevel[reference] = itemLevel.TryGetValue(reference, out var existing) ? [.. existing, .. lineDiscounts] : lineDiscounts;
         }
 
-        // An item-scoped coupon matching no referenced line vanishes from both sets — never silently.
         foreach (var (discountId, discount) in resolved)
         {
             if (discount.IsItemScoped && !attached.Contains(discountId))
@@ -73,7 +69,24 @@ internal static class DiscountMapper
             }
         }
 
-        return new PartitionedDiscounts(cartLevel, itemLevel);
+        return new PartitionedDiscounts(
+            cartLevel,
+            itemLevel.ToDictionary(entry => entry.Key, entry => entry.Value.ToArray()));
+    }
+
+    private static Dictionary<string, ResolvedDiscount> ResolveCoupons(Invoice invoice, ILogger logger)
+    {
+        var resolved = new Dictionary<string, ResolvedDiscount>();
+        foreach (var total in invoice.TotalDiscountAmounts ?? [])
+        {
+            if (total.Discount?.Source?.Coupon is not { } coupon)
+            {
+                logger.LogError("Discount {DiscountId} has no expanded coupon; dropped.", total.DiscountId);
+                continue;
+            }
+            resolved.Add(total.DiscountId, new ResolvedDiscount(coupon, total.Amount / 100m));
+        }
+        return resolved;
     }
 
     private readonly record struct ResolvedDiscount(Coupon Coupon, decimal AggregateAmount)

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -57,8 +57,8 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         {
             PlanTier = planTier,
             Cadence = cadence,
-            PasswordManager = BuildPasswordManagerItems(lineItemsByReference, ProrationMapper.Summarize(passwordManagerProrations, invoice)),
-            SecretsManager = BuildSecretsManagerItems(lineItemsByReference, ProrationMapper.Summarize(secretsManagerProrations, invoice)),
+            PasswordManager = BuildPasswordManagerItems(lineItemsByReference, ProrationMapper.Summarize(passwordManagerProrations)),
+            SecretsManager = BuildSecretsManagerItems(lineItemsByReference, ProrationMapper.Summarize(secretsManagerProrations)),
             Discounts = discounts.CartLevel.Length > 0 ? discounts.CartLevel : null,
             EstimatedTax = (invoice.TotalTaxes?.Sum(tax => tax.Amount) ?? 0) / 100m,
             Total = invoice.Total / 100m,

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -9,14 +9,6 @@ namespace Bit.Invoicing.InvoicePreviews;
 /// <summary>Projects a Stripe invoice or subscription into an <see cref="InvoicePreview"/>. Stripe amounts are cents; every projected amount is dollars.</summary>
 internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logger)
 {
-    private static readonly HashSet<string> KnownReferences =
-    [
-        StripeConstants.PurchasableReferences.PasswordManagerSeat,
-        StripeConstants.PurchasableReferences.PasswordManagerStorage,
-        StripeConstants.PurchasableReferences.SecretsManagerSeat,
-        StripeConstants.PurchasableReferences.SecretsManagerServiceAccount,
-    ];
-
     internal InvoicePreview Build(Invoice invoice, PlanTierType planTier, PlanCadenceType cadence)
     {
         var positions = new Dictionary<string, InvoicePreviewItem>();
@@ -35,7 +27,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
             // Proration status lives on the subscription-item detail; top-level line.Proration is always false here.
             if (line.Parent?.SubscriptionItemDetails?.Proration == true)
             {
-                (reference.StartsWith("pm-", StringComparison.Ordinal) ? passwordManagerProrations : secretsManagerProrations).Add(line);
+                (PurchasableReferences.ProductOf(reference) == ProductType.PasswordManager ? passwordManagerProrations : secretsManagerProrations).Add(line);
                 continue;
             }
 
@@ -120,7 +112,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
             logger.LogError("Line has no purchasable reference; skipped. Price={PriceId}", price?.Id ?? "unknown");
             return null;
         }
-        if (!KnownReferences.Contains(reference))
+        if (!PurchasableReferences.IsKnown(reference))
         {
             logger.LogError("Unknown purchasable reference {Reference} on price {PriceId}; skipped.", reference, price?.Id ?? "unknown");
             return null;

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -131,6 +131,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
     private static PasswordManagerInvoiceItems BuildPasswordManagerItems(
         Dictionary<string, InvoicePreviewItem> lineItemsByReference, PurchasableProration? proration)
     {
+        // Password Manager seats are always present; a missing line is a Stripe misconfiguration, unlike Secrets Manager.
         var seats = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.PasswordManagerSeat)
             ?? throw new InvalidOperationException("The preview resolved no Password Manager seats line.");
         return new PasswordManagerInvoiceItems
@@ -145,7 +146,8 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         Dictionary<string, InvoicePreviewItem> lineItemsByReference, PurchasableProration? proration)
     {
         var seats = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerSeat);
-        if (seats is null)
+        // A mid-cycle removal leaves an SM proration but no seats line; keep the section so the total reconciles.
+        if (seats is null && proration is null)
         {
             return null;
         }

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -24,10 +24,21 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
                 continue;
             }
 
-            // Proration status lives on the subscription-item detail; top-level line.Proration is always false here.
+            // Basil removed the flat line-level proration flag; it now lives on parent.subscription_item_details.
             if (line.Parent?.SubscriptionItemDetails?.Proration == true)
             {
-                (PurchasableReferences.ProductOf(reference) == ProductType.PasswordManager ? passwordManagerProrations : secretsManagerProrations).Add(line);
+                switch (PurchasableReferences.ProductOf(reference))
+                {
+                    case ProductType.PasswordManager:
+                        passwordManagerProrations.Add(line);
+                        break;
+                    case ProductType.SecretsManager:
+                        secretsManagerProrations.Add(line);
+                        break;
+                    case null:
+                        logger.LogError("Proration line references {Reference}, which has no product mapping; skipped.", reference);
+                        break;
+                }
                 continue;
             }
 

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Constants;
+﻿using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
 using Bit.Invoicing.InvoicePreviews.Models;
 using Microsoft.Extensions.Logging;

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -135,7 +135,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         Dictionary<string, InvoicePreviewItem> positions, PurchasableProration? proration)
     {
         var seats = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.PasswordManagerSeat)
-            ?? throw new InvoicePreviewException("The preview resolved no Password Manager seats line.");
+            ?? throw new InvalidOperationException("The preview resolved no Password Manager seats line.");
         return new PasswordManagerInvoiceItems
         {
             Seats = seats,

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -76,7 +76,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         foreach (var subscriptionItem in subscription.Items?.Data ?? [])
         {
             // Every item counts toward the total, even one we cannot place, so the total is never understated.
-            var cost = subscriptionItem.Quantity * (subscriptionItem.Price?.UnitAmount ?? 0) / 100m;
+            var cost = subscriptionItem.Quantity * (subscriptionItem.Price?.UnitAmountDecimal ?? 0) / 100m;
             total += cost;
 
             var reference = ResolvePurchasableReference(subscriptionItem.Price);

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -19,7 +19,8 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
 
         foreach (var line in invoice.Lines?.Data ?? [])
         {
-            var reference = ResolvePurchasableReference(line.Pricing?.PriceDetails?.Price);
+            var price = line.Pricing?.PriceDetails?.Price;
+            var reference = ResolvePurchasableReference(price);
             if (reference is null)
             {
                 continue;
@@ -43,7 +44,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
             {
                 Reference = reference,
                 Quantity = line.Quantity ?? 0,
-                Cost = line.Amount / 100m,
+                Cost = (price?.UnitAmountDecimal ?? 0) / 100m,
                 Discounts = discounts.ItemLevel.GetValueOrDefault(reference),
             };
             if (!lineItemsByReference.TryAdd(reference, item))
@@ -75,9 +76,9 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
 
         foreach (var subscriptionItem in subscription.Items?.Data ?? [])
         {
+            var unitCost = (subscriptionItem.Price?.UnitAmountDecimal ?? 0) / 100m;
             // Every item counts toward the total, even one we cannot place, so the total is never understated.
-            var cost = subscriptionItem.Quantity * (subscriptionItem.Price?.UnitAmountDecimal ?? 0) / 100m;
-            total += cost;
+            total += subscriptionItem.Quantity * unitCost;
 
             var reference = ResolvePurchasableReference(subscriptionItem.Price);
             if (reference is null)
@@ -89,7 +90,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
             {
                 Reference = reference,
                 Quantity = subscriptionItem.Quantity,
-                Cost = cost,
+                Cost = unitCost,
             };
             if (!lineItemsByReference.TryAdd(reference, item))
             {

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -1,0 +1,159 @@
+using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Enums;
+using Bit.Invoicing.InvoicePreviews.Models;
+using Microsoft.Extensions.Logging;
+using Stripe;
+
+namespace Bit.Invoicing.InvoicePreviews;
+
+/// <summary>Projects a Stripe invoice or subscription into an <see cref="InvoicePreview"/>. Stripe amounts are cents; every projected amount is dollars.</summary>
+internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logger)
+{
+    private static readonly HashSet<string> KnownReferences =
+    [
+        StripeConstants.PurchasableReferences.PasswordManagerSeat,
+        StripeConstants.PurchasableReferences.PasswordManagerStorage,
+        StripeConstants.PurchasableReferences.SecretsManagerSeat,
+        StripeConstants.PurchasableReferences.SecretsManagerServiceAccount,
+    ];
+
+    internal InvoicePreview Build(Invoice invoice, PlanTierType planTier, PlanCadenceType cadence)
+    {
+        var positions = new Dictionary<string, InvoicePreviewItem>();
+        var passwordManagerProrations = new List<InvoiceLineItem>();
+        var secretsManagerProrations = new List<InvoiceLineItem>();
+        var discounts = DiscountMapper.Partition(invoice, logger);
+
+        foreach (var line in invoice.Lines?.Data ?? [])
+        {
+            var reference = ResolvePurchasableReference(line.Pricing?.PriceDetails?.Price);
+            if (reference is null)
+            {
+                continue;
+            }
+
+            // Proration status lives on the subscription-item detail; top-level line.Proration is always false here.
+            if (line.Parent?.SubscriptionItemDetails?.Proration == true)
+            {
+                (reference.StartsWith("pm-", StringComparison.Ordinal) ? passwordManagerProrations : secretsManagerProrations).Add(line);
+                continue;
+            }
+
+            var item = new InvoicePreviewItem
+            {
+                Reference = reference,
+                Quantity = line.Quantity ?? 0,
+                Cost = line.Amount / 100m,
+                Discounts = discounts.ItemLevel.GetValueOrDefault(reference),
+            };
+            if (!positions.TryAdd(reference, item))
+            {
+                logger.LogError("Duplicate purchasable reference {Reference} on invoice; kept the first line.", reference);
+            }
+        }
+
+        return new InvoicePreview
+        {
+            PlanTier = planTier,
+            Cadence = cadence,
+            PasswordManager = BuildPasswordManagerItems(positions, ProrationMapper.Summarize(passwordManagerProrations, invoice)),
+            SecretsManager = BuildSecretsManagerItems(positions, ProrationMapper.Summarize(secretsManagerProrations, invoice)),
+            Discounts = discounts.CartLevel.Length > 0 ? discounts.CartLevel : null,
+            EstimatedTax = (invoice.TotalTaxes?.Sum(tax => tax.Amount) ?? 0) / 100m,
+            Total = invoice.Total / 100m,
+            AmountDue = invoice.AmountDue / 100m,
+            StartingBalance = invoice.StartingBalance < 0 ? invoice.StartingBalance / 100m : null,
+            NextPaymentAttempt = null,
+        };
+    }
+
+    internal InvoicePreview Build(Subscription subscription, PlanTierType planTier, PlanCadenceType cadence)
+    {
+        var positions = new Dictionary<string, InvoicePreviewItem>();
+        var total = 0m;
+
+        foreach (var subscriptionItem in subscription.Items?.Data ?? [])
+        {
+            // Every item counts toward the total, even one we cannot place, so the total is never understated.
+            var cost = subscriptionItem.Quantity * (subscriptionItem.Price?.UnitAmount ?? 0) / 100m;
+            total += cost;
+
+            var reference = ResolvePurchasableReference(subscriptionItem.Price);
+            if (reference is null)
+            {
+                continue;
+            }
+
+            var item = new InvoicePreviewItem
+            {
+                Reference = reference,
+                Quantity = subscriptionItem.Quantity,
+                Cost = cost,
+            };
+            if (!positions.TryAdd(reference, item))
+            {
+                logger.LogError("Duplicate purchasable reference {Reference} on subscription; kept the first item.", reference);
+            }
+        }
+
+        return new InvoicePreview
+        {
+            PlanTier = planTier,
+            Cadence = cadence,
+            PasswordManager = BuildPasswordManagerItems(positions, null),
+            SecretsManager = BuildSecretsManagerItems(positions, null),
+            Discounts = null,
+            EstimatedTax = 0m,
+            Total = total,
+            AmountDue = total,
+            StartingBalance = null,
+            NextPaymentAttempt = null,
+        };
+    }
+
+    private string? ResolvePurchasableReference(Price? price)
+    {
+        var reference = price?.Metadata?.GetValueOrDefault(StripeConstants.MetadataKeys.PurchasableReference);
+        if (string.IsNullOrEmpty(reference))
+        {
+            // No price-id fallback: that lookup is the coupling this contract removes.
+            logger.LogError("Line has no purchasable reference; skipped. Price={PriceId}", price?.Id ?? "unknown");
+            return null;
+        }
+        if (!KnownReferences.Contains(reference))
+        {
+            logger.LogError("Unknown purchasable reference {Reference} on price {PriceId}; skipped.", reference, price?.Id ?? "unknown");
+            return null;
+        }
+        return reference;
+    }
+
+    private static PasswordManagerInvoiceItems BuildPasswordManagerItems(
+        Dictionary<string, InvoicePreviewItem> positions, PurchasableProration? proration)
+    {
+        var seats = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.PasswordManagerSeat)
+            ?? throw new InvoicePreviewException("The preview resolved no Password Manager seats line.");
+        return new PasswordManagerInvoiceItems
+        {
+            Seats = seats,
+            AdditionalStorage = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.PasswordManagerStorage),
+            Prorations = proration is { } p ? [p] : null,
+        };
+    }
+
+    private static SecretsManagerInvoiceItems? BuildSecretsManagerItems(
+        Dictionary<string, InvoicePreviewItem> positions, PurchasableProration? proration)
+    {
+        var seats = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerSeat);
+        if (seats is null)
+        {
+            return null;
+        }
+        return new SecretsManagerInvoiceItems
+        {
+            Seats = seats,
+            AdditionalServiceAccounts = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerServiceAccount),
+            Prorations = proration is { } p ? [p] : null,
+        };
+    }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -6,12 +6,13 @@ using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews;
 
-/// <summary>Projects a Stripe invoice or subscription into an <see cref="InvoicePreview"/>. Stripe amounts are cents; every projected amount is dollars.</summary>
+/// <summary>Projects a Stripe invoice or subscription into an <see cref="InvoicePreview"/>. Every projected amount is dollars.</summary>
 internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logger)
 {
+    /// <summary>Projects a preview invoice, including prorations, discounts, and tax, into an <see cref="InvoicePreview"/>.</summary>
     internal InvoicePreview Build(Invoice invoice, PlanTierType planTier, PlanCadenceType cadence)
     {
-        var positions = new Dictionary<string, InvoicePreviewItem>();
+        var lineItemsByReference = new Dictionary<string, InvoicePreviewItem>();
         var passwordManagerProrations = new List<InvoiceLineItem>();
         var secretsManagerProrations = new List<InvoiceLineItem>();
         var discounts = DiscountMapper.Partition(invoice, logger);
@@ -24,7 +25,6 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
                 continue;
             }
 
-            // Basil removed the flat line-level proration flag; it now lives on parent.subscription_item_details.
             if (line.Parent?.SubscriptionItemDetails?.Proration == true)
             {
                 switch (PurchasableReferences.ProductOf(reference))
@@ -49,7 +49,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
                 Cost = line.Amount / 100m,
                 Discounts = discounts.ItemLevel.GetValueOrDefault(reference),
             };
-            if (!positions.TryAdd(reference, item))
+            if (!lineItemsByReference.TryAdd(reference, item))
             {
                 logger.LogError("Duplicate purchasable reference {Reference} on invoice; kept the first line.", reference);
             }
@@ -59,8 +59,8 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         {
             PlanTier = planTier,
             Cadence = cadence,
-            PasswordManager = BuildPasswordManagerItems(positions, ProrationMapper.Summarize(passwordManagerProrations, invoice)),
-            SecretsManager = BuildSecretsManagerItems(positions, ProrationMapper.Summarize(secretsManagerProrations, invoice)),
+            PasswordManager = BuildPasswordManagerItems(lineItemsByReference, ProrationMapper.Summarize(passwordManagerProrations, invoice)),
+            SecretsManager = BuildSecretsManagerItems(lineItemsByReference, ProrationMapper.Summarize(secretsManagerProrations, invoice)),
             Discounts = discounts.CartLevel.Length > 0 ? discounts.CartLevel : null,
             EstimatedTax = (invoice.TotalTaxes?.Sum(tax => tax.Amount) ?? 0) / 100m,
             Total = invoice.Total / 100m,
@@ -70,9 +70,10 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         };
     }
 
+    /// <summary>Projects a subscription's current items into an <see cref="InvoicePreview"/>, without prorations, discounts, or tax.</summary>
     internal InvoicePreview Build(Subscription subscription, PlanTierType planTier, PlanCadenceType cadence)
     {
-        var positions = new Dictionary<string, InvoicePreviewItem>();
+        var lineItemsByReference = new Dictionary<string, InvoicePreviewItem>();
         var total = 0m;
 
         foreach (var subscriptionItem in subscription.Items?.Data ?? [])
@@ -93,7 +94,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
                 Quantity = subscriptionItem.Quantity,
                 Cost = cost,
             };
-            if (!positions.TryAdd(reference, item))
+            if (!lineItemsByReference.TryAdd(reference, item))
             {
                 logger.LogError("Duplicate purchasable reference {Reference} on subscription; kept the first item.", reference);
             }
@@ -103,8 +104,8 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         {
             PlanTier = planTier,
             Cadence = cadence,
-            PasswordManager = BuildPasswordManagerItems(positions, null),
-            SecretsManager = BuildSecretsManagerItems(positions, null),
+            PasswordManager = BuildPasswordManagerItems(lineItemsByReference, null),
+            SecretsManager = BuildSecretsManagerItems(lineItemsByReference, null),
             Discounts = null,
             EstimatedTax = 0m,
             Total = total,
@@ -132,22 +133,22 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
     }
 
     private static PasswordManagerInvoiceItems BuildPasswordManagerItems(
-        Dictionary<string, InvoicePreviewItem> positions, PurchasableProration? proration)
+        Dictionary<string, InvoicePreviewItem> lineItemsByReference, PurchasableProration? proration)
     {
-        var seats = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.PasswordManagerSeat)
+        var seats = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.PasswordManagerSeat)
             ?? throw new InvalidOperationException("The preview resolved no Password Manager seats line.");
         return new PasswordManagerInvoiceItems
         {
             Seats = seats,
-            AdditionalStorage = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.PasswordManagerStorage),
+            AdditionalStorage = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.PasswordManagerStorage),
             Prorations = proration is { } p ? [p] : null,
         };
     }
 
     private static SecretsManagerInvoiceItems? BuildSecretsManagerItems(
-        Dictionary<string, InvoicePreviewItem> positions, PurchasableProration? proration)
+        Dictionary<string, InvoicePreviewItem> lineItemsByReference, PurchasableProration? proration)
     {
-        var seats = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerSeat);
+        var seats = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerSeat);
         if (seats is null)
         {
             return null;
@@ -155,7 +156,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         return new SecretsManagerInvoiceItems
         {
             Seats = seats,
-            AdditionalServiceAccounts = positions.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerServiceAccount),
+            AdditionalServiceAccounts = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerServiceAccount),
             Prorations = proration is { } p ? [p] : null,
         };
     }

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -35,9 +35,6 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
                     case ProductType.SecretsManager:
                         secretsManagerProrations.Add(line);
                         break;
-                    case null:
-                        logger.LogError("Proration line references {Reference}, which has no product mapping; skipped.", reference);
-                        break;
                 }
                 continue;
             }
@@ -51,7 +48,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
             };
             if (!lineItemsByReference.TryAdd(reference, item))
             {
-                logger.LogError("Duplicate purchasable reference {Reference} on invoice; kept the first line.", reference);
+                throw new InvalidOperationException($"The preview resolved a duplicate purchasable reference '{reference}' on the invoice.");
             }
         }
 
@@ -96,7 +93,7 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
             };
             if (!lineItemsByReference.TryAdd(reference, item))
             {
-                logger.LogError("Duplicate purchasable reference {Reference} on subscription; kept the first item.", reference);
+                throw new InvalidOperationException($"The preview resolved a duplicate purchasable reference '{reference}' on the subscription.");
             }
         }
 

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -120,7 +120,6 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         var reference = price?.Metadata?.GetValueOrDefault(StripeConstants.MetadataKeys.PurchasableReference);
         if (string.IsNullOrEmpty(reference))
         {
-            // No price-id fallback: that lookup is the coupling this contract removes.
             logger.LogError("Line has no purchasable reference; skipped. Price={PriceId}", price?.Id ?? "unknown");
             return null;
         }

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewBuilder.cs
@@ -146,15 +146,16 @@ internal sealed class InvoicePreviewBuilder(ILogger<InvoicePreviewBuilder> logge
         Dictionary<string, InvoicePreviewItem> lineItemsByReference, PurchasableProration? proration)
     {
         var seats = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerSeat);
-        // A mid-cycle removal leaves an SM proration but no seats line; keep the section so the total reconciles.
-        if (seats is null && proration is null)
+        var serviceAccounts = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerServiceAccount);
+        // Keep the section whenever any line or proration resolved, so no resolved line drops out of the total.
+        if (seats is null && serviceAccounts is null && proration is null)
         {
             return null;
         }
         return new SecretsManagerInvoiceItems
         {
             Seats = seats,
-            AdditionalServiceAccounts = lineItemsByReference.GetValueOrDefault(StripeConstants.PurchasableReferences.SecretsManagerServiceAccount),
+            AdditionalServiceAccounts = serviceAccounts,
             Prorations = proration is { } p ? [p] : null,
         };
     }

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewException.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewException.cs
@@ -1,0 +1,4 @@
+namespace Bit.Invoicing.InvoicePreviews;
+
+/// <summary>Thrown when a required position (Password Manager seats) cannot be resolved from the source.</summary>
+public sealed class InvoicePreviewException(string message) : Exception(message);

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewException.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewException.cs
@@ -1,4 +1,4 @@
-namespace Bit.Invoicing.InvoicePreviews;
+﻿namespace Bit.Invoicing.InvoicePreviews;
 
 /// <summary>Thrown when a required position (Password Manager seats) cannot be resolved from the source.</summary>
 public sealed class InvoicePreviewException(string message) : Exception(message);

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewException.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewException.cs
@@ -1,4 +1,0 @@
-﻿namespace Bit.Invoicing.InvoicePreviews;
-
-/// <summary>Thrown when a required position (Password Manager seats) cannot be resolved from the source.</summary>
-public sealed class InvoicePreviewException(string message) : Exception(message);

--- a/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewService.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/InvoicePreviewService.cs
@@ -1,0 +1,27 @@
+﻿using Bit.Core.Billing.Enums;
+using Bit.Invoicing.InvoicePreviews.Models;
+using Bit.Invoicing.InvoicePreviews.Stripe;
+using Stripe;
+
+namespace Bit.Invoicing.InvoicePreviews;
+
+public interface IInvoicePreviewService
+{
+    /// <summary>Fetches an upcoming Stripe invoice for the given options and projects it into an <see cref="InvoicePreview"/>.</summary>
+    Task<InvoicePreview> GetInvoicePreviewAsync(InvoiceCreatePreviewOptions options, PlanTierType planTier, PlanCadenceType cadence);
+
+    /// <summary>Projects a subscription's current items when it has no upcoming invoice (canceled or suspended).</summary>
+    Task<InvoicePreview> GetInvoicePreviewAsync(Subscription subscription, PlanTierType planTier, PlanCadenceType cadence);
+}
+
+internal sealed class InvoicePreviewService(IInvoicePreviewClient client, InvoicePreviewBuilder builder) : IInvoicePreviewService
+{
+    public async Task<InvoicePreview> GetInvoicePreviewAsync(InvoiceCreatePreviewOptions options, PlanTierType planTier, PlanCadenceType cadence)
+    {
+        var invoice = await client.GetInvoiceForPreviewAsync(options);
+        return builder.Build(invoice, planTier, cadence);
+    }
+
+    public Task<InvoicePreview> GetInvoicePreviewAsync(Subscription subscription, PlanTierType planTier, PlanCadenceType cadence) =>
+        Task.FromResult(builder.Build(subscription, planTier, cadence));
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreview.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreview.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Utilities;
 

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreview.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreview.cs
@@ -10,7 +10,6 @@ public record InvoicePreview
     public required PasswordManagerInvoiceItems PasswordManager { get; init; }
     public SecretsManagerInvoiceItems? SecretsManager { get; init; }
 
-    /// <summary>Required because Annually is the enum's zero value: an omission would serialize as a plausible "annually" rather than failing to compile.</summary>
     [JsonConverter(typeof(EnumMemberJsonConverter<PlanCadenceType>))]
     public required PlanCadenceType Cadence { get; init; }
 
@@ -23,15 +22,15 @@ public record InvoicePreview
     /// <summary>Customer credit in dollars, carried only when negative. Not rendered in this epic.</summary>
     public decimal? StartingBalance { get; init; }
 
-    /// <summary>Estimated tax on the whole invoice, in dollars. Never cents.</summary>
+    /// <summary>Estimated tax on the whole invoice, in dollars.</summary>
     public required decimal EstimatedTax { get; init; }
 
-    /// <summary>Invoice total in dollars, tax included. Never cents.</summary>
+    /// <summary>Invoice total in dollars, tax included.</summary>
     public required decimal Total { get; init; }
 
     /// <summary>What the subscriber is actually charged, in dollars. Differs from Total when customer credit applies.</summary>
     public required decimal AmountDue { get; init; }
 
-    /// <summary>Always null from the projection. Populated downstream from the subscription's current period end, not the invoice's next payment attempt (they diverge during dunning and schedule transitions).</summary>
+    /// <summary>Null from the projection; set downstream from the subscription's current period end, not the invoice's next payment attempt (they diverge during dunning).</summary>
     public DateTime? NextPaymentAttempt { get; init; }
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreview.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreview.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Utilities;
+
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>A structured projection of a Stripe invoice. Every monetary value originates from the invoice, not from local subscription or form state.</summary>
+public record InvoicePreview
+{
+    public required PasswordManagerInvoiceItems PasswordManager { get; init; }
+    public SecretsManagerInvoiceItems? SecretsManager { get; init; }
+
+    /// <summary>Required because Annually is the enum's zero value: an omission would serialize as a plausible "annually" rather than failing to compile.</summary>
+    [JsonConverter(typeof(EnumMemberJsonConverter<PlanCadenceType>))]
+    public required PlanCadenceType Cadence { get; init; }
+
+    [JsonConverter(typeof(EnumMemberJsonConverter<PlanTierType>))]
+    public required PlanTierType PlanTier { get; init; }
+
+    /// <summary>Cart-wide discounts (coupons with no applies-to set).</summary>
+    public InvoicePreviewDiscount[]? Discounts { get; init; }
+
+    /// <summary>Customer credit in dollars, carried only when negative. Not rendered in this epic.</summary>
+    public decimal? StartingBalance { get; init; }
+
+    /// <summary>Estimated tax on the whole invoice, in dollars. Never cents.</summary>
+    public required decimal EstimatedTax { get; init; }
+
+    /// <summary>Invoice total in dollars, tax included. Never cents.</summary>
+    public required decimal Total { get; init; }
+
+    /// <summary>What the subscriber is actually charged, in dollars. Differs from Total when customer credit applies.</summary>
+    public required decimal AmountDue { get; init; }
+
+    /// <summary>Always null from the projection. Populated downstream from the subscription's current period end, not the invoice's next payment attempt (they diverge during dunning and schedule transitions).</summary>
+    public DateTime? NextPaymentAttempt { get; init; }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewDiscount.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewDiscount.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Bit.Core.Billing.Subscriptions.Models;
 using Bit.Core.Utilities;
 

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewDiscount.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewDiscount.cs
@@ -4,13 +4,13 @@ using Bit.Core.Utilities;
 
 namespace Bit.Invoicing.InvoicePreviews.Models;
 
-/// <summary>A discount as the preview renders it. Distinct from Core's BitwardenDiscount: its Value always carries dollars, where the legacy path's carries cents.</summary>
+/// <summary>A discount as the preview renders it.</summary>
 public record InvoicePreviewDiscount
 {
     [JsonConverter(typeof(EnumMemberJsonConverter<BitwardenDiscountType>))]
     public required BitwardenDiscountType Type { get; init; }
 
-    /// <summary>Percent off from 0 to 100, or amount off in dollars. Never cents.</summary>
+    /// <summary>Percent off from 0 to 100, or amount off in dollars.</summary>
     public required decimal Value { get; init; }
 
     /// <summary>The authoritative applied amount in dollars, taken from Stripe.</summary>

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewDiscount.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewDiscount.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+using Bit.Core.Billing.Subscriptions.Models;
+using Bit.Core.Utilities;
+
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>A discount as the preview renders it. Distinct from Core's BitwardenDiscount: its Value always carries dollars, where the legacy path's carries cents.</summary>
+public record InvoicePreviewDiscount
+{
+    [JsonConverter(typeof(EnumMemberJsonConverter<BitwardenDiscountType>))]
+    public required BitwardenDiscountType Type { get; init; }
+
+    /// <summary>Percent off from 0 to 100, or amount off in dollars. Never cents.</summary>
+    public required decimal Value { get; init; }
+
+    /// <summary>The authoritative applied amount in dollars, taken from Stripe.</summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>Coupon name, used as the row label.</summary>
+    public string? Label { get; init; }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewItem.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewItem.cs
@@ -1,4 +1,4 @@
-namespace Bit.Invoicing.InvoicePreviews.Models;
+﻿namespace Bit.Invoicing.InvoicePreviews.Models;
 
 /// <summary>One resolved line of the preview. Carries the purchasable reference, not a translation key; the client maps reference + plan tier + flow context to a key.</summary>
 public record InvoicePreviewItem

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewItem.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewItem.cs
@@ -8,7 +8,7 @@ public record InvoicePreviewItem
 
     public required long Quantity { get; init; }
 
-    /// <summary>Line cost in dollars.</summary>
+    /// <summary>Unit cost in dollars.</summary>
     public required decimal Cost { get; init; }
 
     /// <summary>Item-scoped discounts (coupons with a non-empty applies-to set).</summary>

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewItem.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewItem.cs
@@ -3,12 +3,12 @@
 /// <summary>One resolved line of the preview. Carries the purchasable reference, not a translation key; the client maps reference + plan tier + flow context to a key.</summary>
 public record InvoicePreviewItem
 {
-    /// <summary>One of the four values in StripeConstants.PurchasableReferences.</summary>
+    /// <summary>One of the values in StripeConstants.PurchasableReferences.</summary>
     public required string Reference { get; init; }
 
     public required long Quantity { get; init; }
 
-    /// <summary>Line cost in dollars, never cents.</summary>
+    /// <summary>Line cost in dollars.</summary>
     public required decimal Cost { get; init; }
 
     /// <summary>Item-scoped discounts (coupons with a non-empty applies-to set).</summary>

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewItem.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/InvoicePreviewItem.cs
@@ -1,0 +1,16 @@
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>One resolved line of the preview. Carries the purchasable reference, not a translation key; the client maps reference + plan tier + flow context to a key.</summary>
+public record InvoicePreviewItem
+{
+    /// <summary>One of the four values in StripeConstants.PurchasableReferences.</summary>
+    public required string Reference { get; init; }
+
+    public required long Quantity { get; init; }
+
+    /// <summary>Line cost in dollars, never cents.</summary>
+    public required decimal Cost { get; init; }
+
+    /// <summary>Item-scoped discounts (coupons with a non-empty applies-to set).</summary>
+    public InvoicePreviewDiscount[]? Discounts { get; init; }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PasswordManagerInvoiceItems.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PasswordManagerInvoiceItems.cs
@@ -1,0 +1,9 @@
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>Password Manager positions. Seats is required; a preview without it is invalid.</summary>
+public record PasswordManagerInvoiceItems
+{
+    public required InvoicePreviewItem Seats { get; init; }
+    public InvoicePreviewItem? AdditionalStorage { get; init; }
+    public PurchasableProration[]? Prorations { get; init; }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PasswordManagerInvoiceItems.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PasswordManagerInvoiceItems.cs
@@ -1,4 +1,4 @@
-namespace Bit.Invoicing.InvoicePreviews.Models;
+﻿namespace Bit.Invoicing.InvoicePreviews.Models;
 
 /// <summary>Password Manager positions. Seats is required; a preview without it is invalid.</summary>
 public record PasswordManagerInvoiceItems

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PasswordManagerInvoiceItems.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PasswordManagerInvoiceItems.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bit.Invoicing.InvoicePreviews.Models;
 
-/// <summary>Password Manager positions. Seats is required; a preview without it is invalid.</summary>
+/// <summary>Password Manager line items. Seats is required; a preview without it is invalid.</summary>
 public record PasswordManagerInvoiceItems
 {
     public required InvoicePreviewItem Seats { get; init; }

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PendingSubscriptionChange.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PendingSubscriptionChange.cs
@@ -1,4 +1,4 @@
-namespace Bit.Invoicing.InvoicePreviews.Models;
+﻿namespace Bit.Invoicing.InvoicePreviews.Models;
 
 /// <summary>A scheduled future-phase price (e.g. an annual switch at renewal) and when it takes effect.</summary>
 public record PendingSubscriptionChange

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PendingSubscriptionChange.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PendingSubscriptionChange.cs
@@ -1,0 +1,8 @@
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>A scheduled future-phase price (e.g. an annual switch at renewal) and when it takes effect.</summary>
+public record PendingSubscriptionChange
+{
+    public required InvoicePreview InvoicePreview { get; init; }
+    public required DateTime EffectiveDate { get; init; }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PlanTierType.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PlanTierType.cs
@@ -1,4 +1,4 @@
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Bit.Invoicing.InvoicePreviews.Models;
 

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PlanTierType.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PlanTierType.cs
@@ -1,0 +1,12 @@
+using System.Runtime.Serialization;
+
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>The four paid tiers with a cart to render. Strings match the client billing pricing-tier vocabulary. Free is excluded (no cart); TeamsStarter and custom collapse into Teams/Enterprise upstream.</summary>
+public enum PlanTierType
+{
+    [EnumMember(Value = "families")] Families,
+    [EnumMember(Value = "teams")] Teams,
+    [EnumMember(Value = "enterprise")] Enterprise,
+    [EnumMember(Value = "premium")] Premium
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PurchasableProration.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PurchasableProration.cs
@@ -1,0 +1,19 @@
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>One product's proration lines collapsed into a single renderable credit row. All amounts are dollars.</summary>
+public record PurchasableProration
+{
+    /// <summary>Absolute value of the negative line amounts.</summary>
+    public required decimal Credit { get; init; }
+
+    /// <summary>Sum of the positive line amounts.</summary>
+    public required decimal Charge { get; init; }
+
+    /// <summary>This bucket's proportional share of the invoice tax total.</summary>
+    public required decimal Tax { get; init; }
+
+    /// <summary>Net of charge against credit.</summary>
+    public required decimal Total { get; init; }
+
+    public required int Months { get; init; }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PurchasableProration.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PurchasableProration.cs
@@ -9,7 +9,7 @@ public record PurchasableProration
     /// <summary>Sum of the positive line amounts.</summary>
     public required decimal Charge { get; init; }
 
-    /// <summary>This bucket's proportional share of the invoice tax total.</summary>
+    /// <summary>Sum of Stripe's per-line tax on this bucket's proration lines.</summary>
     public required decimal Tax { get; init; }
 
     /// <summary>Net of charge against credit.</summary>

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/PurchasableProration.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/PurchasableProration.cs
@@ -1,4 +1,4 @@
-namespace Bit.Invoicing.InvoicePreviews.Models;
+﻿namespace Bit.Invoicing.InvoicePreviews.Models;
 
 /// <summary>One product's proration lines collapsed into a single renderable credit row. All amounts are dollars.</summary>
 public record PurchasableProration

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/SecretsManagerInvoiceItems.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/SecretsManagerInvoiceItems.cs
@@ -1,6 +1,6 @@
 ﻿namespace Bit.Invoicing.InvoicePreviews.Models;
 
-/// <summary>Secrets Manager positions. Present only when the subscription carries Secrets Manager.</summary>
+/// <summary>Secrets Manager line items. Present only when the subscription carries Secrets Manager.</summary>
 public record SecretsManagerInvoiceItems
 {
     public required InvoicePreviewItem Seats { get; init; }

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/SecretsManagerInvoiceItems.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/SecretsManagerInvoiceItems.cs
@@ -1,0 +1,9 @@
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>Secrets Manager positions. Present only when the subscription carries Secrets Manager.</summary>
+public record SecretsManagerInvoiceItems
+{
+    public required InvoicePreviewItem Seats { get; init; }
+    public InvoicePreviewItem? AdditionalServiceAccounts { get; init; }
+    public PurchasableProration[]? Prorations { get; init; }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/SecretsManagerInvoiceItems.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/SecretsManagerInvoiceItems.cs
@@ -1,9 +1,10 @@
 ﻿namespace Bit.Invoicing.InvoicePreviews.Models;
 
-/// <summary>Secrets Manager line items. Present only when the subscription carries Secrets Manager.</summary>
+/// <summary>Secrets Manager line items. Present when the subscription carries Secrets Manager or the invoice includes a Secrets Manager proration.</summary>
 public record SecretsManagerInvoiceItems
 {
-    public required InvoicePreviewItem Seats { get; init; }
+    /// <summary>Null when the invoice carries only a Secrets Manager proration, such as a mid-cycle removal.</summary>
+    public InvoicePreviewItem? Seats { get; init; }
     public InvoicePreviewItem? AdditionalServiceAccounts { get; init; }
     public PurchasableProration[]? Prorations { get; init; }
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/SecretsManagerInvoiceItems.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/SecretsManagerInvoiceItems.cs
@@ -1,4 +1,4 @@
-namespace Bit.Invoicing.InvoicePreviews.Models;
+﻿namespace Bit.Invoicing.InvoicePreviews.Models;
 
 /// <summary>Secrets Manager positions. Present only when the subscription carries Secrets Manager.</summary>
 public record SecretsManagerInvoiceItems

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/SubscriptionPreview.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/SubscriptionPreview.cs
@@ -2,7 +2,7 @@
 
 namespace Bit.Invoicing.InvoicePreviews.Models;
 
-/// <summary>The subscription-level envelope around a preview. Consumers gate on Status, not on a null preview; the server always builds a complete one.</summary>
+/// <summary>The subscription-level envelope around a preview.</summary>
 public record SubscriptionPreview
 {
     /// <summary>A Stripe subscription status string. The client narrows it to a union.</summary>
@@ -18,6 +18,6 @@ public record SubscriptionPreview
     public DateTime? Suspension { get; init; }
     public int? GracePeriod { get; init; }
 
-    /// <summary>A scheduled future-phase change (e.g. an annual switch at renewal), when one is pending. Populated downstream, never by the projection.</summary>
+    /// <summary>A pending scheduled future-phase change (e.g. an annual switch at renewal). Set downstream, never by the projection.</summary>
     public PendingSubscriptionChange? PendingChange { get; init; }
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/SubscriptionPreview.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/SubscriptionPreview.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Subscriptions.Models;
+﻿using Bit.Core.Billing.Subscriptions.Models;
 
 namespace Bit.Invoicing.InvoicePreviews.Models;
 

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/SubscriptionPreview.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/SubscriptionPreview.cs
@@ -1,0 +1,23 @@
+using Bit.Core.Billing.Subscriptions.Models;
+
+namespace Bit.Invoicing.InvoicePreviews.Models;
+
+/// <summary>The subscription-level envelope around a preview. Consumers gate on Status, not on a null preview; the server always builds a complete one.</summary>
+public record SubscriptionPreview
+{
+    /// <summary>A Stripe subscription status string. The client narrows it to a union.</summary>
+    public required string Status { get; init; }
+
+    public required InvoicePreview InvoicePreview { get; init; }
+
+    /// <summary>Null for subscribers without max storage.</summary>
+    public Storage? Storage { get; init; }
+
+    public DateTime? CancelAt { get; init; }
+    public DateTime? Canceled { get; init; }
+    public DateTime? Suspension { get; init; }
+    public int? GracePeriod { get; init; }
+
+    /// <summary>A scheduled future-phase change (e.g. an annual switch at renewal), when one is pending. Populated downstream, never by the projection.</summary>
+    public PendingSubscriptionChange? PendingChange { get; init; }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Models/SubscriptionPreview.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Models/SubscriptionPreview.cs
@@ -5,7 +5,8 @@ namespace Bit.Invoicing.InvoicePreviews.Models;
 /// <summary>The subscription-level envelope around a preview.</summary>
 public record SubscriptionPreview
 {
-    /// <summary>A Stripe subscription status string. The client narrows it to a union.</summary>
+    /// <summary>A Stripe subscription status string. One of:
+    /// incomplete, incomplete_expired, trialing, active, past_due, canceled, unpaid.</summary>
     public required string Status { get; init; }
 
     public required InvoicePreview InvoicePreview { get; init; }
@@ -13,9 +14,16 @@ public record SubscriptionPreview
     /// <summary>Null for subscribers without max storage.</summary>
     public Storage? Storage { get; init; }
 
+    /// <summary>Scheduled cancellation date. Populated only for trialing/active, and optional even then.</summary>
     public DateTime? CancelAt { get; init; }
+
+    /// <summary>When the subscription was canceled. Required when Status is canceled; null otherwise.</summary>
     public DateTime? Canceled { get; init; }
+
+    /// <summary>When the subscription suspends. Required for incomplete/incomplete_expired; optional for past_due/unpaid; null otherwise.</summary>
     public DateTime? Suspension { get; init; }
+
+    /// <summary>Grace-period days before suspension. Required for incomplete/incomplete_expired; optional for past_due/unpaid; null otherwise. A value of zero means the subscription suspends today, not that no grace period is set.</summary>
     public int? GracePeriod { get; init; }
 
     /// <summary>A pending scheduled future-phase change (e.g. an annual switch at renewal). Set downstream, never by the projection.</summary>

--- a/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
@@ -22,17 +22,9 @@ internal static class ProrationMapper
             Charge = chargeCents / 100m,
             Credit = creditCents / 100m,
             Total = netCents / 100m,
-            Tax = AllocateTax(netCents, invoice),
+            Tax = lines.SelectMany(line => line.Taxes ?? []).Sum(tax => tax.Amount) / 100m,
             Months = MonthsRemaining(lines, invoice),
         };
-    }
-
-    private static decimal AllocateTax(long netCents, Invoice invoice)
-    {
-        var totalTaxCents = invoice.TotalTaxes?.Sum(tax => tax.Amount) ?? 0;
-        return totalTaxCents == 0 || invoice.Total == 0
-            ? 0m
-            : totalTaxCents * (netCents / (decimal)invoice.Total) / 100m;
     }
 
     private static int MonthsRemaining(IReadOnlyList<InvoiceLineItem> lines, Invoice invoice)

--- a/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
@@ -1,4 +1,4 @@
-using Bit.Invoicing.InvoicePreviews.Models;
+﻿using Bit.Invoicing.InvoicePreviews.Models;
 using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews;

--- a/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
@@ -6,7 +6,7 @@ namespace Bit.Invoicing.InvoicePreviews;
 /// <summary>Reduces one product's proration lines into a single renderable credit row.</summary>
 internal static class ProrationMapper
 {
-    internal static PurchasableProration? Summarize(IReadOnlyList<InvoiceLineItem> lines, Invoice invoice)
+    internal static PurchasableProration? Summarize(IReadOnlyList<InvoiceLineItem> lines)
     {
         if (lines.Count == 0)
         {
@@ -22,20 +22,20 @@ internal static class ProrationMapper
             Credit = creditCents / 100m,
             Total = (chargeCents - creditCents) / 100m,
             Tax = lines.SelectMany(line => line.Taxes ?? []).Sum(tax => tax.Amount) / 100m,
-            Months = MonthsRemaining(lines, invoice),
+            Months = MonthsRemaining(lines),
         };
     }
 
-    private static int MonthsRemaining(IReadOnlyList<InvoiceLineItem> lines, Invoice invoice)
+    private static int MonthsRemaining(IReadOnlyList<InvoiceLineItem> lines)
     {
-        var lineEnd = lines.Select(line => line.Period?.End).FirstOrDefault(end => end.HasValue);
-        if (lineEnd is null)
+        var period = lines.Select(line => line.Period).FirstOrDefault(p => p is not null);
+        if (period is null)
         {
             return 0;
         }
 
-        // 30-day months, minimum one, matching the legacy proration display.
-        var days = (lineEnd.Value - invoice.PeriodEnd).TotalDays;
+        // Calculate from the proration line's own span (End - Start); it is correct under any proration_behavior. (See README)
+        var days = (period.End - period.Start).TotalDays;
         return Math.Max(1, (int)Math.Round(days / 30, MidpointRounding.AwayFromZero));
     }
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
@@ -3,7 +3,7 @@ using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews;
 
-/// <summary>Reduces one product's proration lines into a single renderable credit row. Pure.</summary>
+/// <summary>Reduces one product's proration lines into a single renderable credit row.</summary>
 internal static class ProrationMapper
 {
     internal static PurchasableProration? Summarize(IReadOnlyList<InvoiceLineItem> lines, Invoice invoice)
@@ -15,13 +15,12 @@ internal static class ProrationMapper
 
         var chargeCents = lines.Where(line => line.Amount > 0).Sum(line => line.Amount);
         var creditCents = Math.Abs(lines.Where(line => line.Amount < 0).Sum(line => line.Amount));
-        var netCents = chargeCents - creditCents;
 
         return new PurchasableProration
         {
             Charge = chargeCents / 100m,
             Credit = creditCents / 100m,
-            Total = netCents / 100m,
+            Total = (chargeCents - creditCents) / 100m,
             Tax = lines.SelectMany(line => line.Taxes ?? []).Sum(tax => tax.Amount) / 100m,
             Months = MonthsRemaining(lines, invoice),
         };
@@ -35,7 +34,8 @@ internal static class ProrationMapper
             return 0;
         }
 
-        var months = ((invoice.PeriodEnd.Year - lineEnd.Value.Year) * 12) + invoice.PeriodEnd.Month - lineEnd.Value.Month;
-        return Math.Max(0, months);
+        // 30-day months, minimum one, matching the legacy proration display.
+        var days = (lineEnd.Value - invoice.PeriodEnd).TotalDays;
+        return Math.Max(1, (int)Math.Round(days / 30, MidpointRounding.AwayFromZero));
     }
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/ProrationMapper.cs
@@ -1,0 +1,49 @@
+using Bit.Invoicing.InvoicePreviews.Models;
+using Stripe;
+
+namespace Bit.Invoicing.InvoicePreviews;
+
+/// <summary>Reduces one product's proration lines into a single renderable credit row. Pure.</summary>
+internal static class ProrationMapper
+{
+    internal static PurchasableProration? Summarize(IReadOnlyList<InvoiceLineItem> lines, Invoice invoice)
+    {
+        if (lines.Count == 0)
+        {
+            return null;
+        }
+
+        var chargeCents = lines.Where(line => line.Amount > 0).Sum(line => line.Amount);
+        var creditCents = Math.Abs(lines.Where(line => line.Amount < 0).Sum(line => line.Amount));
+        var netCents = chargeCents - creditCents;
+
+        return new PurchasableProration
+        {
+            Charge = chargeCents / 100m,
+            Credit = creditCents / 100m,
+            Total = netCents / 100m,
+            Tax = AllocateTax(netCents, invoice),
+            Months = MonthsRemaining(lines, invoice),
+        };
+    }
+
+    private static decimal AllocateTax(long netCents, Invoice invoice)
+    {
+        var totalTaxCents = invoice.TotalTaxes?.Sum(tax => tax.Amount) ?? 0;
+        return totalTaxCents == 0 || invoice.Total == 0
+            ? 0m
+            : totalTaxCents * (netCents / (decimal)invoice.Total) / 100m;
+    }
+
+    private static int MonthsRemaining(IReadOnlyList<InvoiceLineItem> lines, Invoice invoice)
+    {
+        var lineEnd = lines.Select(line => line.Period?.End).FirstOrDefault(end => end.HasValue);
+        if (lineEnd is null)
+        {
+            return 0;
+        }
+
+        var months = ((invoice.PeriodEnd.Year - lineEnd.Value.Year) * 12) + invoice.PeriodEnd.Month - lineEnd.Value.Month;
+        return Math.Max(0, months);
+    }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/PurchasableReferences.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/PurchasableReferences.cs
@@ -1,8 +1,10 @@
-﻿using Bit.Core.Billing.Constants;
+﻿using System.Diagnostics.CodeAnalysis;
+using Bit.Core.Billing.Constants;
 using Bit.Core.Billing.Enums;
 
 namespace Bit.Invoicing.InvoicePreviews;
 
+/// <summary>Maps purchasable references to their product, and tells whether a reference is known.</summary>
 internal static class PurchasableReferences
 {
     private static readonly IReadOnlyDictionary<string, ProductType> ProductsByReference = new Dictionary<string, ProductType>
@@ -13,8 +15,11 @@ internal static class PurchasableReferences
         [StripeConstants.PurchasableReferences.SecretsManagerServiceAccount] = ProductType.SecretsManager,
     };
 
-    internal static bool IsKnown(string reference) => ProductsByReference.ContainsKey(reference);
+    /// <summary>True when the reference maps to a known product. Tolerates null/empty.</summary>
+    internal static bool IsKnown([NotNullWhen(true)] string? reference) =>
+        reference is not null && ProductsByReference.ContainsKey(reference);
 
+    /// <summary>The product a reference belongs to, or null when the reference is unknown.</summary>
     internal static ProductType? ProductOf(string reference) =>
         ProductsByReference.TryGetValue(reference, out var product) ? product : null;
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/PurchasableReferences.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/PurchasableReferences.cs
@@ -1,0 +1,19 @@
+﻿using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Enums;
+
+namespace Bit.Invoicing.InvoicePreviews;
+
+internal static class PurchasableReferences
+{
+    private static readonly IReadOnlyDictionary<string, ProductType> ProductsByReference = new Dictionary<string, ProductType>
+    {
+        [StripeConstants.PurchasableReferences.PasswordManagerSeat] = ProductType.PasswordManager,
+        [StripeConstants.PurchasableReferences.PasswordManagerStorage] = ProductType.PasswordManager,
+        [StripeConstants.PurchasableReferences.SecretsManagerSeat] = ProductType.SecretsManager,
+        [StripeConstants.PurchasableReferences.SecretsManagerServiceAccount] = ProductType.SecretsManager,
+    };
+
+    internal static bool IsKnown(string reference) => ProductsByReference.ContainsKey(reference);
+
+    internal static ProductType ProductOf(string reference) => ProductsByReference[reference];
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/PurchasableReferences.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/PurchasableReferences.cs
@@ -15,5 +15,6 @@ internal static class PurchasableReferences
 
     internal static bool IsKnown(string reference) => ProductsByReference.ContainsKey(reference);
 
-    internal static ProductType ProductOf(string reference) => ProductsByReference[reference];
+    internal static ProductType? ProductOf(string reference) =>
+        ProductsByReference.TryGetValue(reference, out var product) ? product : null;
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/IInvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/IInvoicePreviewClient.cs
@@ -1,4 +1,4 @@
-using Stripe;
+﻿using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews.Stripe;
 

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/IInvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/IInvoicePreviewClient.cs
@@ -1,0 +1,8 @@
+using Stripe;
+
+namespace Bit.Invoicing.InvoicePreviews.Stripe;
+
+internal interface IInvoicePreviewClient
+{
+    Task<Invoice> GetInvoiceForPreviewAsync(InvoiceCreatePreviewOptions options);
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
@@ -5,13 +5,25 @@ namespace Bit.Invoicing.InvoicePreviews.Stripe;
 
 internal sealed class InvoicePreviewClient(IStripeAdapter stripeAdapter) : IInvoicePreviewClient
 {
-    public Task<Invoice> GetInvoiceForPreviewAsync(InvoiceCreatePreviewOptions options)
+    public async Task<Invoice> GetInvoiceForPreviewAsync(InvoiceCreatePreviewOptions options)
     {
         options.Expand =
         [
             "lines.data.pricing.price_details.price",
             "total_discount_amounts.discount.source.coupon",
         ];
-        return stripeAdapter.CreateInvoicePreviewAsync(options);
+
+        var invoice = await stripeAdapter.CreateInvoicePreviewAsync(options);
+
+        // Stripe caps the preview's line sublist at 10 with has_more; fetch the rest so the builder sees every line.
+        if (invoice.Lines?.HasMore == true)
+        {
+            invoice.Lines.Data = await stripeAdapter.ListInvoiceLineItemsAsync(
+                invoice.Id,
+                new InvoiceLineItemListOptions { Expand = ["data.pricing.price_details.price"] });
+            invoice.Lines.HasMore = false;
+        }
+
+        return invoice;
     }
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
@@ -1,0 +1,18 @@
+using Bit.Core.Billing.Services;
+using Stripe;
+
+namespace Bit.Invoicing.InvoicePreviews.Stripe;
+
+internal sealed class InvoicePreviewClient(IStripeAdapter stripeAdapter) : IInvoicePreviewClient
+{
+    public Task<Invoice> GetInvoiceForPreviewAsync(InvoiceCreatePreviewOptions options)
+    {
+        // The line-level coupon path is six segments; resolving coupons only at the top level keeps the expand within reach.
+        options.Expand =
+        [
+            "lines.data.pricing.price_details.price",
+            "total_discount_amounts.discount.source.coupon",
+        ];
+        return stripeAdapter.CreateInvoicePreviewAsync(options);
+    }
+}

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
@@ -7,7 +7,6 @@ internal sealed class InvoicePreviewClient(IStripeAdapter stripeAdapter) : IInvo
 {
     public Task<Invoice> GetInvoiceForPreviewAsync(InvoiceCreatePreviewOptions options)
     {
-        // The line-level coupon path is six segments; resolving coupons only at the top level keeps the expand within reach.
         options.Expand =
         [
             "lines.data.pricing.price_details.price",

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Services;
+﻿using Bit.Core.Billing.Services;
 using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews.Stripe;

--- a/src/Libraries/Invoicing/Invoicing.csproj
+++ b/src/Libraries/Invoicing/Invoicing.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="..\..\Core\Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Stripe.net" Version="[52.1.0]" />
+  </ItemGroup>
+
 </Project>

--- a/src/Libraries/Invoicing/InvoicingServiceCollectionExtensions.cs
+++ b/src/Libraries/Invoicing/InvoicingServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Invoicing.InvoicePreviews;
 using Bit.Invoicing.InvoicePreviews.Stripe;
+using Bitwarden.Server.Sdk.Environment;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -8,12 +9,22 @@ namespace Bit.Invoicing;
 /// <summary>Registration entry point for the Invoicing library.</summary>
 public static class InvoicingServiceCollectionExtensions
 {
-    /// <summary>Registers everything <c>Bit.Invoicing</c> needs, including its owned feature flag keys.</summary>
+    /// <summary>Registers everything <c>Bit.Invoicing</c> needs, including its owned feature flag keys. Resolving <see cref="IInvoicePreviewService"/> in a self-hosted environment throws — the library is cloud-only.</summary>
     public static IServiceCollection AddInvoicing(this IServiceCollection services)
     {
-        services.TryAddSingleton<IInvoicePreviewService, InvoicePreviewService>();
+        services.TryAddSingleton<InvoicePreviewService>();
         services.TryAddSingleton<IInvoicePreviewClient, InvoicePreviewClient>();
         services.TryAddSingleton<InvoicePreviewBuilder>();
+        services.TryAddSingleton<IInvoicePreviewService>(sp =>
+        {
+            if (sp.GetRequiredService<IBitwardenEnvironment>().SelfHosted)
+            {
+                throw new InvalidOperationException(
+                    "Bit.Invoicing must never be resolved in a self-hosted environment.");
+            }
+
+            return sp.GetRequiredService<InvoicePreviewService>();
+        });
         services.AddKnownFeatureFlags(InvoicingFeatureFlags.GetKeys());
         return services;
     }

--- a/src/Libraries/Invoicing/InvoicingServiceCollectionExtensions.cs
+++ b/src/Libraries/Invoicing/InvoicingServiceCollectionExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Bit.Invoicing.InvoicePreviews;
+using Bit.Invoicing.InvoicePreviews.Stripe;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Bit.Invoicing;
 
@@ -8,6 +11,9 @@ public static class InvoicingServiceCollectionExtensions
     /// <summary>Registers everything <c>Bit.Invoicing</c> needs, including its owned feature flag keys.</summary>
     public static IServiceCollection AddInvoicing(this IServiceCollection services)
     {
+        services.TryAddSingleton<IInvoicePreviewService, InvoicePreviewService>();
+        services.TryAddSingleton<IInvoicePreviewClient, InvoicePreviewClient>();
+        services.TryAddSingleton<InvoicePreviewBuilder>();
         services.AddKnownFeatureFlags(InvoicingFeatureFlags.GetKeys());
         return services;
     }

--- a/src/Libraries/Invoicing/README.md
+++ b/src/Libraries/Invoicing/README.md
@@ -19,6 +19,17 @@ hydrate invoice and subscription data — and projects the results into the vend
 its public surface. Feature libraries above it never call Stripe themselves; they consume preview
 data through this surface, and reference Stripe SDK types only to pass data to and from it.
 
+### Proration months come from the line period
+
+`invoice.period_end` means different things depending on `proration_behavior`: under `always_invoice`
+it is the moment of change ("now"); under Stripe's default `create_prorations` it is the current
+period end. A proration line's own period is stable across both — it always spans
+`[change moment, period end]` (Stripe: "For prorations, this starts when the proration was calculated,
+and ends at the period end of the subscription"). So `ProrationMapper` measures the remaining term as
+`line.Period.End - line.Period.Start`, never against `invoice.period_end`. Confirmed against the Stripe
+docs and a live test-clock preview (annual plan: the line-span formula yields 12 months where
+`line.End - invoice.period_end` would yield 1).
+
 ## Core debt
 
 This library depends on `Core` as a documented deviation from the rule restricting Libraries from referencing Core, per ADR-0032:

--- a/src/Libraries/Invoicing/README.md
+++ b/src/Libraries/Invoicing/README.md
@@ -21,8 +21,7 @@ data through this surface, and reference Stripe SDK types only to pass data to a
 
 ## Core debt
 
-This library depends on `Core` as a documented deviation from the rule restricting Libraries from referencing Core, per ADR-0032, pending extraction into
-`Bit.Integrations.Billing`:
+This library depends on `Core` as a documented deviation from the rule restricting Libraries from referencing Core, per ADR-0032:
 
 | From Core | Used for |
 | --- | --- |

--- a/src/Libraries/Invoicing/README.md
+++ b/src/Libraries/Invoicing/README.md
@@ -32,6 +32,7 @@ This library depends on `Core` as a documented deviation from the rule restricti
 | `ProductType` | Routing a reference to its product family |
 | `BitwardenDiscountType` | The type of a projected discount |
 | `Storage` | Storage figures on the subscription preview |
+| `EnumMemberJsonConverter` | Serializing the projected enums (cadence, tier, discount type) as their EnumMember string values |
 
 Depending on `Core` for these is fine for now; this table exists so they're known, not because
 they're queued up for extraction.

--- a/src/Libraries/Invoicing/README.md
+++ b/src/Libraries/Invoicing/README.md
@@ -7,10 +7,11 @@ See [LIBRARY.md](../LIBRARY.md) for the shape all libraries under `src/Libraries
 
 ## Public surface
 
-`AddInvoicing()` registers everything the library needs, including the feature flag keys the library
-owns (`InvoicingFeatureFlags`) as known flags. The feature
-libraries above gate on those keys without depending on Core for them. The projection types land in
-a later change.
+`AddInvoicing()` registers the projection service and the feature flag keys the library owns
+(`InvoicingFeatureFlags`) as known flags. The public surface is `IInvoicePreviewService`, the
+`InvoicePreview` record family under `InvoicePreviews/Models/` (including `PlanTierType`), and
+`InvoicePreviewException`. The service, builder, mappers, reference table, and Stripe client are
+internal.
 
 ## Stripe boundary
 
@@ -25,11 +26,12 @@ This library depends on `Core` as a documented deviation from the rule restricti
 
 | From Core | Used for |
 | --- | --- |
-| `IStripeAdapter` | Hydrating Stripe invoice/subscription data |
-| `IPricingClient` | Resolving plan and price data |
-| `ISubscriptionDiscountService` | Applying discounts to the preview |
-| `SponsoredPlans` | Sponsorship pricing rules |
-| `ISubscriber` | The organization or user being billed |
+| `IStripeAdapter` | Fetching the preview invoice from Stripe |
+| `StripeConstants` | The `purchasable_reference` metadata key and reference values |
+| `PlanCadenceType` | The billing cadence carried on the preview |
+| `ProductType` | Routing a reference to its product family |
+| `BitwardenDiscountType` | The type of a projected discount |
+| `Storage` | Storage figures on the subscription preview |
 
 Depending on `Core` for these is fine for now; this table exists so they're known, not because
 they're queued up for extraction.

--- a/src/Libraries/Invoicing/README.md
+++ b/src/Libraries/Invoicing/README.md
@@ -8,10 +8,9 @@ See [LIBRARY.md](../LIBRARY.md) for the shape all libraries under `src/Libraries
 ## Public surface
 
 `AddInvoicing()` registers the projection service and the feature flag keys the library owns
-(`InvoicingFeatureFlags`) as known flags. The public surface is `IInvoicePreviewService`, the
-`InvoicePreview` record family under `InvoicePreviews/Models/` (including `PlanTierType`), and
-`InvoicePreviewException`. The service, builder, mappers, reference table, and Stripe client are
-internal.
+(`InvoicingFeatureFlags`) as known flags. The public surface is `IInvoicePreviewService` and the
+`InvoicePreview` record family under `InvoicePreviews/Models/` (including `PlanTierType`). The
+service, builder, mappers, reference table, and Stripe client are internal.
 
 ## Stripe boundary
 

--- a/src/Libraries/Invoicing/packages.lock.json
+++ b/src/Libraries/Invoicing/packages.lock.json
@@ -18,6 +18,16 @@
           "LaunchDarkly.ServerSdk": "8.14.1"
         }
       },
+      "Stripe.net": {
+        "type": "Direct",
+        "requested": "[52.1.0, 52.1.0]",
+        "resolved": "52.1.0",
+        "contentHash": "xzYOMenSrhR2UIgk+zBOjfzADSFe9NnCuhffs2FMpWSJst4M19m6QS7GAxq4cLeBdWvUoUo3RuHNc5uzI5eOFg==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "System.Configuration.ConfigurationManager": "9.0.0"
+        }
+      },
       "AdaptiveCards": {
         "type": "Transitive",
         "resolved": "3.1.0",
@@ -753,15 +763,6 @@
         "type": "Transitive",
         "resolved": "1.3.3",
         "contentHash": "OblOaKb1enXn+dSp7tsx9yjwV+/BEKM9jFhshIkZTwCk7LuTFTp+wSon6rFzuPiIiTGtvVWQNUw2slHjGktJog=="
-      },
-      "Stripe.net": {
-        "type": "Transitive",
-        "resolved": "52.1.0",
-        "contentHash": "xzYOMenSrhR2UIgk+zBOjfzADSFe9NnCuhffs2FMpWSJst4M19m6QS7GAxq4cLeBdWvUoUo3RuHNc5uzI5eOFg==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.3",
-          "System.Configuration.ConfigurationManager": "9.0.0"
-        }
       },
       "System.ClientModel": {
         "type": "Transitive",

--- a/src/Libraries/Subscriptions.Organization/OrganizationSubscriptionEndpointsExtensions.cs
+++ b/src/Libraries/Subscriptions.Organization/OrganizationSubscriptionEndpointsExtensions.cs
@@ -10,7 +10,11 @@ namespace Bit.Subscriptions.Organization;
 /// <summary>Maps the organization-scoped subscription HTTP surface as a Minimal API endpoint group.</summary>
 public static class OrganizationSubscriptionEndpointsExtensions
 {
-    /// <summary>Attaches the organization subscription group's shared cross-cutting chain to an empty group; the host owns the route prefix. Empty at this stage. Only an authenticated caller is required here; each handler performs its own organization billing authorization check.</summary>
+    /// <summary>
+    /// Attaches the organization subscription group's shared cross-cutting chain to an empty group;
+    /// the host owns the route prefix. Only an authenticated caller is required here; each handler
+    /// performs its own organization billing authorization check.
+    /// </summary>
     public static RouteGroupBuilder MapOrganizationSubscriptionEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("");

--- a/src/Libraries/Subscriptions.Organization/packages.lock.json
+++ b/src/Libraries/Subscriptions.Organization/packages.lock.json
@@ -915,7 +915,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "serilogfilelogging": {

--- a/src/Libraries/Subscriptions.User/UserSubscriptionEndpointsExtensions.cs
+++ b/src/Libraries/Subscriptions.User/UserSubscriptionEndpointsExtensions.cs
@@ -10,7 +10,7 @@ namespace Bit.Subscriptions.User;
 /// <summary>Maps the account-scoped subscription HTTP surface as a Minimal API endpoint group.</summary>
 public static class UserSubscriptionEndpointsExtensions
 {
-    /// <summary>Attaches the account subscription group's shared cross-cutting chain to an empty group; the host owns the route prefix. Empty at this stage; endpoints arrive with the individual screen slices.</summary>
+    /// <summary>Attaches the account subscription group's shared cross-cutting chain to an empty group; the host owns the route prefix.</summary>
     public static RouteGroupBuilder MapUserSubscriptionEndpoints(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup("");

--- a/src/Libraries/Subscriptions.User/packages.lock.json
+++ b/src/Libraries/Subscriptions.User/packages.lock.json
@@ -915,7 +915,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "serilogfilelogging": {

--- a/test/Api.IntegrationTest/packages.lock.json
+++ b/test/Api.IntegrationTest/packages.lock.json
@@ -1545,7 +1545,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "migrator": {

--- a/test/Api.Test/packages.lock.json
+++ b/test/Api.Test/packages.lock.json
@@ -1891,7 +1891,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "organizationauthorization": {

--- a/test/Billing.IntegrationTest/packages.lock.json
+++ b/test/Billing.IntegrationTest/packages.lock.json
@@ -2083,7 +2083,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "migrator": {

--- a/test/Libraries/Invoicing.Test/AddInvoicingTests.cs
+++ b/test/Libraries/Invoicing.Test/AddInvoicingTests.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.Billing.Services;
 using Bit.Invoicing.InvoicePreviews;
+using Bitwarden.Server.Sdk.Environment;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
@@ -13,6 +14,8 @@ public class AddInvoicingTests
     {
         var services = new ServiceCollection();
         services.AddSingleton(Substitute.For<IStripeAdapter>());
+        // SelfHosted defaults to false on the substitute, so this exercises the cloud path.
+        services.AddSingleton(Substitute.For<IBitwardenEnvironment>());
         services.AddLogging();
 
         services.AddInvoicing();
@@ -20,5 +23,24 @@ public class AddInvoicingTests
 
         Assert.NotNull(provider.GetService<IInvoicePreviewService>());
         Assert.NotNull(provider.GetService<InvoicePreviewBuilder>());
+    }
+
+    [Fact]
+    public void AddInvoicing_ResolvingInvoicePreviewServiceInSelfHost_Throws()
+    {
+        var services = new ServiceCollection();
+        var environment = Substitute.For<IBitwardenEnvironment>();
+        environment.SelfHosted.Returns(true);
+        services.AddSingleton(environment);
+        // Registered so the only reason resolution can fail is the self-host guard, not a missing dependency.
+        services.AddSingleton(Substitute.For<IStripeAdapter>());
+        services.AddLogging();
+
+        services.AddInvoicing();
+        var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => provider.GetRequiredService<IInvoicePreviewService>());
+        Assert.Contains("self-host", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/test/Libraries/Invoicing.Test/AddInvoicingTests.cs
+++ b/test/Libraries/Invoicing.Test/AddInvoicingTests.cs
@@ -1,0 +1,24 @@
+﻿using Bit.Core.Billing.Services;
+using Bit.Invoicing.InvoicePreviews;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class AddInvoicingTests
+{
+    [Fact]
+    public void AddInvoicing_RegistersTheServiceClientAndBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<IStripeAdapter>());
+        services.AddLogging();
+
+        services.AddInvoicing();
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IInvoicePreviewService>());
+        Assert.NotNull(provider.GetService<InvoicePreviewBuilder>());
+    }
+}

--- a/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
@@ -178,6 +178,29 @@ public class DiscountMapperTests
     }
 
     [Fact]
+    public void Partition_TotalDiscountWithoutDiscountId_LogsAndDrops()
+    {
+        // total_discount_amounts[].discount has a coupon but no id -> DiscountId is null; must log and drop, not throw.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "source": { "coupon": { "id": "cp_noid", "name": "NOID10", "percent_off": 10 } } } }
+          ],
+          "lines": { "data": [] }
+        }
+        """);
+
+        var logger = new RecordingLogger<DiscountMapperTests>();
+        var result = DiscountMapper.Partition(invoice, logger);
+
+        Assert.Empty(result.CartLevel);
+        Assert.Empty(result.ItemLevel);
+        Assert.Single(logger.Errors);
+    }
+
+    [Fact]
     public void Partition_ItemScopedCouponMatchingNoLine_LogsAndDrops()
     {
         // item-scoped coupon present in total_discount_amounts, but no line references it.

--- a/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
@@ -209,4 +209,35 @@ public class DiscountMapperTests
         Assert.Contains("di_orphan", error);
         Assert.Contains("ORPHAN10", error);
     }
+
+    [Fact]
+    public void Partition_ItemScopedDiscountOnUnknownReference_LogsAndDrops()
+    {
+        // line carries a non-empty but unknown purchasable_reference; its item-scoped discount must not attach.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_unknown", "source": { "coupon": { "id": "cp_u", "name": "MYSTERY10", "percent_off": 10, "applies_to": { "products": ["prod_x"] } } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 12790,
+                "pricing": { "price_details": { "price": { "id": "price_x", "metadata": { "purchasable_reference": "provider-seat" } } } },
+                "discount_amounts": [ { "amount": 1279, "discount": "di_unknown" } ]
+              }
+            ]
+          }
+        }
+        """);
+
+        var logger = new RecordingLogger<DiscountMapperTests>();
+        var result = DiscountMapper.Partition(invoice, logger);
+
+        Assert.Empty(result.ItemLevel);
+        var error = Assert.Single(logger.Errors);
+        Assert.Contains("di_unknown", error);
+    }
 }

--- a/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
@@ -1,0 +1,212 @@
+using Bit.Core.Billing.Subscriptions.Models;
+using Bit.Invoicing.InvoicePreviews;
+using Stripe;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class DiscountMapperTests
+{
+    private static Invoice Deserialize(string json) => Invoice.FromJson(json);
+
+    [Fact]
+    public void Partition_NoDiscounts_ReturnsEmptySets()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 12790,
+          "lines": { "data": [] }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        Assert.Empty(result.CartLevel);
+        Assert.Empty(result.ItemLevel);
+    }
+
+    [Fact]
+    public void Partition_CartWideCoupon_LandsInCartLevel_WithAggregateAmount()
+    {
+        // no applies_to on the coupon -> cart-wide, not item-scoped.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_cart", "source": { "coupon": { "id": "cp_cart", "name": "WELCOME10", "percent_off": 10 } } } }
+          ],
+          "lines": { "data": [] }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        Assert.Equal(12.79m, Assert.Single(result.CartLevel).Amount);
+        Assert.Empty(result.ItemLevel);
+    }
+
+    [Fact]
+    public void Partition_ItemScopedCoupon_MatchesByDiscountId_WhenLineDiscountUnexpanded()
+    {
+        // line-level discount is an unexpanded id; the coupon is only on total_discount_amounts.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_x", "source": { "coupon": { "id": "cp_x", "name": "SEATS10", "percent_off": 10, "applies_to": { "products": ["prod_pm"] } } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 12790,
+                "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } },
+                "discount_amounts": [ { "amount": 1279, "discount": "di_x" } ]
+              }
+            ]
+          }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        Assert.Empty(result.CartLevel);
+        Assert.Equal(12.79m, Assert.Single(result.ItemLevel["pm-seat"]).Amount);
+    }
+
+    [Fact]
+    public void Partition_MultiProductCoupon_AttachesUnderBothLines_WithoutDoubleCounting()
+    {
+        // one coupon scoped to two products; two lines each reference it via the same discount id.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 23964,
+          "total_discount_amounts": [
+            { "amount": 2558, "discount": { "id": "di_multi", "source": { "coupon": { "id": "cp_multi", "name": "BUNDLE10", "percent_off": 10, "applies_to": { "products": ["prod_pm", "prod_sm"] } } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 12790,
+                "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } },
+                "discount_amounts": [ { "amount": 1279, "discount": "di_multi" } ]
+              },
+              {
+                "amount": 11982,
+                "pricing": { "price_details": { "price": { "id": "price_sm", "metadata": { "purchasable_reference": "sm-seat" } } } },
+                "discount_amounts": [ { "amount": 1279, "discount": "di_multi" } ]
+              }
+            ]
+          }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        Assert.Empty(result.CartLevel);
+        Assert.Equal(12.79m, Assert.Single(result.ItemLevel["pm-seat"]).Amount);
+        Assert.Equal(12.79m, Assert.Single(result.ItemLevel["sm-seat"]).Amount);
+    }
+
+    [Fact]
+    public void Partition_PercentOffCoupon_MapsTypeAndValue()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_pct", "source": { "coupon": { "id": "cp_pct", "name": "TENOFF", "percent_off": 15.5 } } } }
+          ],
+          "lines": { "data": [] }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        var discount = Assert.Single(result.CartLevel);
+        Assert.Equal(BitwardenDiscountType.PercentOff, discount.Type);
+        Assert.Equal(15.5m, discount.Value);
+    }
+
+    [Fact]
+    public void Partition_AmountOffCoupon_MapsValueInDollars()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_amt", "source": { "coupon": { "id": "cp_amt", "name": "FIVEOFF", "amount_off": 1598 } } } }
+          ],
+          "lines": { "data": [] }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        var discount = Assert.Single(result.CartLevel);
+        Assert.Equal(BitwardenDiscountType.AmountOff, discount.Type);
+        Assert.Equal(15.98m, discount.Value);
+    }
+
+    [Fact]
+    public void Partition_CouponWithoutExpandedCoupon_LogsAndDrops()
+    {
+        // total_discount_amounts[].discount has no source.coupon -> can't resolve; must log and drop.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_unresolved" } }
+          ],
+          "lines": { "data": [] }
+        }
+        """);
+
+        var logger = new RecordingLogger<DiscountMapperTests>();
+        var result = DiscountMapper.Partition(invoice, logger);
+
+        Assert.Empty(result.CartLevel);
+        Assert.Empty(result.ItemLevel);
+        var error = Assert.Single(logger.Errors);
+        Assert.Contains("di_unresolved", error);
+    }
+
+    [Fact]
+    public void Partition_ItemScopedCouponMatchingNoLine_LogsAndDrops()
+    {
+        // item-scoped coupon present in total_discount_amounts, but no line references it.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_orphan", "source": { "coupon": { "id": "cp_orphan", "name": "ORPHAN10", "percent_off": 10, "applies_to": { "products": ["prod_pm"] } } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 12790,
+                "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } },
+                "discount_amounts": []
+              }
+            ]
+          }
+        }
+        """);
+
+        var logger = new RecordingLogger<DiscountMapperTests>();
+        var result = DiscountMapper.Partition(invoice, logger);
+
+        Assert.Empty(result.CartLevel);
+        Assert.Empty(result.ItemLevel);
+        var error = Assert.Single(logger.Errors);
+        Assert.Contains("di_orphan", error);
+        Assert.Contains("ORPHAN10", error);
+    }
+}

--- a/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
@@ -240,4 +240,40 @@ public class DiscountMapperTests
         var error = Assert.Single(logger.Errors);
         Assert.Contains("di_unknown", error);
     }
+
+    [Fact]
+    public void Partition_ItemScopedDiscountOnProrationLine_DoesNotAttachToBase()
+    {
+        // the same item-scoped coupon appears on both the base line and a proration line for pm-seat.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1479, "discount": { "id": "di_seat", "source": { "coupon": { "id": "cp_seat", "name": "SEATS10", "percent_off": 10, "applies_to": { "products": ["prod_pm"] } } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 12790,
+                "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } },
+                "discount_amounts": [ { "amount": 1279, "discount": "di_seat" } ]
+              },
+              {
+                "amount": 2000,
+                "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } },
+                "parent": { "subscription_item_details": { "proration": true } },
+                "discount_amounts": [ { "amount": 200, "discount": "di_seat" } ]
+              }
+            ]
+          }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        // only the base line's 12.79 attaches; the proration line's 2.00 must not appear on the base item.
+        var discount = Assert.Single(result.ItemLevel["pm-seat"]);
+        Assert.Equal(12.79m, discount.Amount);
+    }
 }

--- a/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
@@ -310,4 +310,34 @@ public class DiscountMapperTests
         Assert.Contains("di_seat", error);
         Assert.Contains("SEATS10", error);
     }
+
+    [Fact]
+    public void Partition_LineCarriesCartWideDiscountId_StaysCartLevel_NotAttachedToItem()
+    {
+        // Stripe echoes a cart-wide coupon (no applies_to) onto the line's discount_amounts.
+        // It must remain cart-level; the line loop must not pull it down to item-level.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_cart", "source": { "coupon": { "id": "cp_cart", "name": "WELCOME10", "percent_off": 10 } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 12790,
+                "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } },
+                "discount_amounts": [ { "amount": 1279, "discount": "di_cart" } ]
+              }
+            ]
+          }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        Assert.Equal(12.79m, Assert.Single(result.CartLevel).Amount);
+        Assert.Empty(result.ItemLevel);
+    }
 }

--- a/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
@@ -276,4 +276,38 @@ public class DiscountMapperTests
         var discount = Assert.Single(result.ItemLevel["pm-seat"]);
         Assert.Equal(12.79m, discount.Amount);
     }
+
+    [Fact]
+    public void Partition_ItemScopedCouponMatchingOnlyProrationLine_LogsAndDrops()
+    {
+        // the item-scoped coupon's only pm-seat line is a proration; the line loop skips it, so nothing attaches.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11982,
+          "total_discount_amounts": [
+            { "amount": 200, "discount": { "id": "di_seat", "source": { "coupon": { "id": "cp_seat", "name": "SEATS10", "percent_off": 10, "applies_to": { "products": ["prod_pm"] } } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 2000,
+                "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } },
+                "parent": { "subscription_item_details": { "proration": true } },
+                "discount_amounts": [ { "amount": 200, "discount": "di_seat" } ]
+              }
+            ]
+          }
+        }
+        """);
+
+        var logger = new RecordingLogger<DiscountMapperTests>();
+        var result = DiscountMapper.Partition(invoice, logger);
+
+        Assert.Empty(result.CartLevel);
+        Assert.Empty(result.ItemLevel);
+        var error = Assert.Single(logger.Errors);
+        Assert.Contains("di_seat", error);
+        Assert.Contains("SEATS10", error);
+    }
 }

--- a/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Subscriptions.Models;
+﻿using Bit.Core.Billing.Subscriptions.Models;
 using Bit.Invoicing.InvoicePreviews;
 using Stripe;
 using Xunit;

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderProrationMonthsTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderProrationMonthsTests.cs
@@ -1,0 +1,50 @@
+﻿using Bit.Core.Billing.Enums;
+using Bit.Invoicing.InvoicePreviews;
+using Bit.Invoicing.InvoicePreviews.Models;
+using Stripe;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class InvoicePreviewBuilderProrationMonthsTests
+{
+    private static InvoicePreviewBuilder Builder() => new(new RecordingLogger<InvoicePreviewBuilder>());
+
+    // Captured live from Stripe (test mode): an annual subscription (premium-annually-2026) on a test
+    // clock advanced 15 days into the term, previewed with proration_behavior=create_prorations.
+    // The proration line spans [now, period_end] = [1788901346, 1819141346] (~350 days), while the
+    // invoice's period_end is ALSO 1819141346 — so the old formula (line.End - invoice.PeriodEnd) gave
+    // 0 days -> Months = 1, when the true remaining term is 12 months. This fixture pins that real shape
+    // so the collapse can never come back. See the library README's Stripe boundary note.
+    [Fact]
+    public void BuildFromInvoice_AnnualProrationUnderCreateProrations_RendersTrueMonthsNotOne()
+    {
+        var invoice = Invoice.FromJson("""
+        {
+          "id": "in_preview_annual_proration_months", "total": 5858, "amount_due": 5858, "period_end": 1819141346,
+          "lines": { "data": [
+            { "amount": 3797, "quantity": 1,
+              "parent": { "subscription_item_details": { "proration": true }, "type": "subscription_item_details" },
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } },
+              "period": { "start": 1788901346, "end": 1819141346 } },
+            { "amount": -1899, "quantity": 1,
+              "parent": { "subscription_item_details": { "proration": true }, "type": "subscription_item_details" },
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } },
+              "period": { "start": 1788901346, "end": 1819141346 } },
+            { "amount": 3960, "quantity": 2,
+              "parent": { "subscription_item_details": { "proration": false }, "type": "subscription_item_details" },
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "unit_amount_decimal": "1980", "metadata": { "purchasable_reference": "pm-seat" } } } },
+              "period": { "start": 1819141346, "end": 1850677346 } }
+          ] }
+        }
+        """);
+
+        var preview = Builder().Build(invoice, PlanTierType.Premium, PlanCadenceType.Annually);
+
+        var proration = Assert.Single(preview.PasswordManager.Prorations!);
+        Assert.Equal(12, proration.Months);
+        Assert.Equal(37.97m, proration.Charge);
+        Assert.Equal(18.99m, proration.Credit);
+        Assert.Equal(18.98m, proration.Total);
+    }
+}

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderSmRemovalTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderSmRemovalTests.cs
@@ -25,7 +25,7 @@ public class InvoicePreviewBuilderSmRemovalTests
               "period": { "start": 1788387520, "end": 1789769920 } },
             { "amount": 5000, "quantity": 5,
               "parent": { "subscription_item_details": { "proration": false }, "type": "subscription_item_details" },
-              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } },
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "unit_amount_decimal": "1000", "metadata": { "purchasable_reference": "pm-seat" } } } },
               "period": { "start": 1789769920, "end": 1792361920 } }
           ] }
         }
@@ -33,7 +33,7 @@ public class InvoicePreviewBuilderSmRemovalTests
 
         var preview = Builder().Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Monthly);
 
-        Assert.Equal(50.00m, preview.PasswordManager.Seats.Cost);
+        Assert.Equal(10.00m, preview.PasswordManager.Seats.Cost);
         Assert.Equal(34.52m, preview.Total);
         Assert.Equal(34.52m, preview.AmountDue);
 
@@ -43,8 +43,10 @@ public class InvoicePreviewBuilderSmRemovalTests
         Assert.Equal(15.48m, proration.Credit);
         Assert.Equal(-15.48m, proration.Total);
 
-        // Visible rows now reconcile to the invoice total.
-        Assert.Equal(preview.Total, preview.PasswordManager.Seats.Cost + proration.Total);
+        // Visible rows now reconcile to the invoice total (unit cost × quantity, plus the proration).
+        Assert.Equal(
+            preview.Total,
+            preview.PasswordManager.Seats.Quantity * preview.PasswordManager.Seats.Cost + proration.Total);
     }
 
     // A plain Password Manager invoice with no Secrets Manager line and no Secrets Manager proration
@@ -79,10 +81,10 @@ public class InvoicePreviewBuilderSmRemovalTests
           "lines": { "data": [
             { "amount": 5000, "quantity": 5,
               "parent": { "subscription_item_details": { "proration": false }, "type": "subscription_item_details" },
-              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "unit_amount_decimal": "1000", "metadata": { "purchasable_reference": "pm-seat" } } } } },
             { "amount": 1000, "quantity": 2,
               "parent": { "subscription_item_details": { "proration": false }, "type": "subscription_item_details" },
-              "pricing": { "price_details": { "price": { "id": "price_sm_service_account", "metadata": { "purchasable_reference": "sm-service-account" } } } } }
+              "pricing": { "price_details": { "price": { "id": "price_sm_service_account", "unit_amount_decimal": "500", "metadata": { "purchasable_reference": "sm-service-account" } } } } }
           ] }
         }
         """);
@@ -94,9 +96,12 @@ public class InvoicePreviewBuilderSmRemovalTests
         Assert.Null(preview.SecretsManager.Prorations);
         var serviceAccounts = preview.SecretsManager.AdditionalServiceAccounts;
         Assert.NotNull(serviceAccounts);
-        Assert.Equal(10.00m, serviceAccounts!.Cost);
+        Assert.Equal(5.00m, serviceAccounts!.Cost);
 
-        // The service-account row reconciles into the total alongside Password Manager seats.
-        Assert.Equal(preview.Total, preview.PasswordManager.Seats.Cost + serviceAccounts.Cost);
+        // The service-account row reconciles into the total alongside Password Manager seats (unit cost × quantity).
+        Assert.Equal(
+            preview.Total,
+            preview.PasswordManager.Seats.Quantity * preview.PasswordManager.Seats.Cost
+                + serviceAccounts.Quantity * serviceAccounts.Cost);
     }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderSmRemovalTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderSmRemovalTests.cs
@@ -1,0 +1,70 @@
+﻿using Bit.Core.Billing.Enums;
+using Bit.Invoicing.InvoicePreviews;
+using Bit.Invoicing.InvoicePreviews.Models;
+using Stripe;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class InvoicePreviewBuilderSmRemovalTests
+{
+    private static InvoicePreviewBuilder Builder() => new(new RecordingLogger<InvoicePreviewBuilder>());
+
+    // Shape captured live from Stripe create_preview for a mid-cycle Secrets Manager removal:
+    // an sm-seat proration credit (proration = true) with no recurring sm-seat line; total already nets the credit.
+    [Fact]
+    public void BuildFromInvoice_SmRemovedMidCycle_RendersProrationOnlySectionAndReconciles()
+    {
+        var invoice = Invoice.FromJson("""
+        {
+          "id": "in_preview_sm_removal", "total": 3452, "amount_due": 3452, "period_end": 1789769920,
+          "lines": { "data": [
+            { "amount": -1548, "quantity": 3,
+              "parent": { "subscription_item_details": { "proration": true }, "type": "subscription_item_details" },
+              "pricing": { "price_details": { "price": { "id": "price_sm_seat", "metadata": { "purchasable_reference": "sm-seat" } } } },
+              "period": { "start": 1788387520, "end": 1789769920 } },
+            { "amount": 5000, "quantity": 5,
+              "parent": { "subscription_item_details": { "proration": false }, "type": "subscription_item_details" },
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } },
+              "period": { "start": 1789769920, "end": 1792361920 } }
+          ] }
+        }
+        """);
+
+        var preview = Builder().Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Monthly);
+
+        Assert.Equal(50.00m, preview.PasswordManager.Seats.Cost);
+        Assert.Equal(34.52m, preview.Total);
+        Assert.Equal(34.52m, preview.AmountDue);
+
+        Assert.NotNull(preview.SecretsManager);
+        Assert.Null(preview.SecretsManager!.Seats);
+        var proration = Assert.Single(preview.SecretsManager.Prorations!);
+        Assert.Equal(15.48m, proration.Credit);
+        Assert.Equal(-15.48m, proration.Total);
+
+        // Visible rows now reconcile to the invoice total.
+        Assert.Equal(preview.Total, preview.PasswordManager.Seats.Cost + proration.Total);
+    }
+
+    // A plain Password Manager invoice with no Secrets Manager line and no Secrets Manager proration
+    // must still yield no Secrets Manager section (the other half of the guard).
+    [Fact]
+    public void BuildFromInvoice_NoSecretsManagerActivity_LeavesSectionNull()
+    {
+        var invoice = Invoice.FromJson("""
+        {
+          "id": "in_pm_only", "total": 5000, "amount_due": 5000,
+          "lines": { "data": [
+            { "amount": 5000, "quantity": 5,
+              "parent": { "subscription_item_details": { "proration": false }, "type": "subscription_item_details" },
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } }
+          ] }
+        }
+        """);
+
+        var preview = Builder().Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Monthly);
+
+        Assert.Null(preview.SecretsManager);
+    }
+}

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderSmRemovalTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderSmRemovalTests.cs
@@ -67,4 +67,36 @@ public class InvoicePreviewBuilderSmRemovalTests
 
         Assert.Null(preview.SecretsManager);
     }
+
+    // A resolved sm-service-account line with no sm-seat line and no proration must keep the section,
+    // otherwise the service-account cost would silently drop out of the reconciled total.
+    [Fact]
+    public void BuildFromInvoice_ServiceAccountsWithoutSeatsLine_KeepsSectionAndReconciles()
+    {
+        var invoice = Invoice.FromJson("""
+        {
+          "id": "in_sm_service_accounts_only", "total": 6000, "amount_due": 6000,
+          "lines": { "data": [
+            { "amount": 5000, "quantity": 5,
+              "parent": { "subscription_item_details": { "proration": false }, "type": "subscription_item_details" },
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 1000, "quantity": 2,
+              "parent": { "subscription_item_details": { "proration": false }, "type": "subscription_item_details" },
+              "pricing": { "price_details": { "price": { "id": "price_sm_service_account", "metadata": { "purchasable_reference": "sm-service-account" } } } } }
+          ] }
+        }
+        """);
+
+        var preview = Builder().Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Monthly);
+
+        Assert.NotNull(preview.SecretsManager);
+        Assert.Null(preview.SecretsManager!.Seats);
+        Assert.Null(preview.SecretsManager.Prorations);
+        var serviceAccounts = preview.SecretsManager.AdditionalServiceAccounts;
+        Assert.NotNull(serviceAccounts);
+        Assert.Equal(10.00m, serviceAccounts!.Cost);
+
+        // The service-account row reconciles into the total alongside Password Manager seats.
+        Assert.Equal(preview.Total, preview.PasswordManager.Seats.Cost + serviceAccounts.Cost);
+    }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderSmRemovalTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderSmRemovalTests.cs
@@ -42,6 +42,7 @@ public class InvoicePreviewBuilderSmRemovalTests
         var proration = Assert.Single(preview.SecretsManager.Prorations!);
         Assert.Equal(15.48m, proration.Credit);
         Assert.Equal(-15.48m, proration.Total);
+        Assert.Equal(1, proration.Months);
 
         // Visible rows now reconcile to the invoice total (unit cost × quantity, plus the proration).
         Assert.Equal(

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Enums;
+﻿using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Subscriptions.Models;
 using Bit.Invoicing.InvoicePreviews;
 using Bit.Invoicing.InvoicePreviews.Models;

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
@@ -320,4 +320,53 @@ public class InvoicePreviewBuilderTests
 
         Assert.Throws<InvalidOperationException>(() => builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly));
     }
+
+    [Fact]
+    public void BuildFromSubscription_UnplaceableItem_CountsTowardTotalButIsSkipped()
+    {
+        var subscription = DeserializeSubscription("""
+        {
+          "id": "sub_test",
+          "items": { "data": [
+            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat", "unit_amount": 2558, "metadata": { "purchasable_reference": "pm-seat" } } },
+            { "id": "si_2", "quantity": 2, "price": { "id": "price_mystery", "unit_amount": 500, "metadata": {} } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out var logger);
+        var preview = builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly);
+
+        // Only the resolvable line is placed...
+        Assert.Equal("pm-seat", preview.PasswordManager.Seats.Reference);
+        Assert.Null(preview.PasswordManager.AdditionalStorage);
+        // ...but the unplaceable line still counts toward the total, so it is never understated (127.90 + 10.00).
+        Assert.Equal(137.90m, preview.Total);
+        Assert.Equal(137.90m, preview.AmountDue);
+        Assert.Contains(logger.Errors, e => e.Contains("price_mystery"));
+    }
+
+    [Fact]
+    public void BuildFromSubscription_DuplicateReference_KeepsFirstItemAndLogs()
+    {
+        var subscription = DeserializeSubscription("""
+        {
+          "id": "sub_test",
+          "items": { "data": [
+            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat_1", "unit_amount": 2558, "metadata": { "purchasable_reference": "pm-seat" } } },
+            { "id": "si_2", "quantity": 9, "price": { "id": "price_pm_seat_2", "unit_amount": 100, "metadata": { "purchasable_reference": "pm-seat" } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out var logger);
+        var preview = builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly);
+
+        // The first item wins the reference...
+        Assert.Equal(5, preview.PasswordManager.Seats.Quantity);
+        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
+        // ...yet both items still count toward the total (127.90 + 9.00).
+        Assert.Equal(136.90m, preview.Total);
+        Assert.Contains(logger.Errors, e => e.Contains("pm-seat"));
+    }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
@@ -110,7 +110,7 @@ public class InvoicePreviewBuilderTests
     }
 
     [Fact]
-    public void BuildFromInvoice_FoldsProrations_ByPrefix()
+    public void BuildFromInvoice_FoldsProrations_ByProductReference()
     {
         var invoice = Deserialize("""
         {

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
@@ -1,0 +1,323 @@
+using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Subscriptions.Models;
+using Bit.Invoicing.InvoicePreviews;
+using Bit.Invoicing.InvoicePreviews.Models;
+using Stripe;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class InvoicePreviewBuilderTests
+{
+    private static InvoicePreviewBuilder Builder(out RecordingLogger<InvoicePreviewBuilder> logger)
+    {
+        logger = new RecordingLogger<InvoicePreviewBuilder>();
+        return new InvoicePreviewBuilder(logger);
+    }
+
+    private static Invoice Deserialize(string json) => Invoice.FromJson(json);
+
+    private static Subscription DeserializeSubscription(string json) => Subscription.FromJson(json);
+
+    [Fact]
+    public void BuildFromInvoice_MissingReference_LogsAndSkips()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 12790, "amount_due": 12790,
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 500, "quantity": 1, "pricing": { "price_details": { "price": { "id": "price_mystery", "metadata": {} } } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out var logger);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Equal("pm-seat", preview.PasswordManager.Seats.Reference);
+        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
+        Assert.Contains(logger.Errors, e => e.Contains("price_mystery"));
+    }
+
+    [Fact]
+    public void BuildFromInvoice_RoutesEachReferenceToItsPosition()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 22218, "amount_due": 22218,
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 3582, "quantity": 2, "pricing": { "price_details": { "price": { "id": "price_pm_storage", "metadata": { "purchasable_reference": "pm-storage" } } } } },
+            { "amount": 4567, "quantity": 3, "pricing": { "price_details": { "price": { "id": "price_sm_seat", "metadata": { "purchasable_reference": "sm-seat" } } } } },
+            { "amount": 1279, "quantity": 1, "pricing": { "price_details": { "price": { "id": "price_sm_sa", "metadata": { "purchasable_reference": "sm-service-account" } } } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Equal(5, preview.PasswordManager.Seats.Quantity);
+        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
+        Assert.Equal(2, preview.PasswordManager.AdditionalStorage!.Quantity);
+        Assert.Equal(35.82m, preview.PasswordManager.AdditionalStorage.Cost);
+        Assert.Equal(3, preview.SecretsManager!.Seats.Quantity);
+        Assert.Equal(45.67m, preview.SecretsManager.Seats.Cost);
+        Assert.Equal(1, preview.SecretsManager.AdditionalServiceAccounts!.Quantity);
+        Assert.Equal(12.79m, preview.SecretsManager.AdditionalServiceAccounts.Cost);
+    }
+
+    [Fact]
+    public void BuildFromInvoice_MapsEnvelope()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 13997, "amount_due": 13997, "starting_balance": -1234,
+          "total_taxes": [ { "amount": 812 }, { "amount": 395 } ],
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Equal(12.07m, preview.EstimatedTax);
+        Assert.Equal(139.97m, preview.Total);
+        Assert.Equal(139.97m, preview.AmountDue);
+        Assert.Equal(-12.34m, preview.StartingBalance);
+        Assert.Null(preview.NextPaymentAttempt);
+    }
+
+    [Fact]
+    public void BuildFromInvoice_PositiveStartingBalance_IsNotCarried()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 12790, "amount_due": 12790, "starting_balance": 1234,
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Null(preview.StartingBalance);
+    }
+
+    [Fact]
+    public void BuildFromInvoice_FoldsProrations_ByPrefix()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 17856, "amount_due": 17856,
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 4567, "quantity": 3, "pricing": { "price_details": { "price": { "id": "price_sm_seat", "metadata": { "purchasable_reference": "sm-seat" } } } } },
+            { "amount": 2007, "pricing": { "price_details": { "price": { "id": "price_pm_prorate", "metadata": { "purchasable_reference": "pm-storage" } } } }, "parent": { "subscription_item_details": { "proration": true } } },
+            { "amount": -1508, "pricing": { "price_details": { "price": { "id": "price_sm_prorate", "metadata": { "purchasable_reference": "sm-service-account" } } } }, "parent": { "subscription_item_details": { "proration": true } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Null(preview.PasswordManager.AdditionalStorage);
+        Assert.Null(preview.SecretsManager!.AdditionalServiceAccounts);
+
+        var pmProration = Assert.Single(preview.PasswordManager.Prorations!);
+        Assert.Equal(20.07m, pmProration.Charge);
+        Assert.Equal(0m, pmProration.Credit);
+        Assert.Equal(20.07m, pmProration.Total);
+
+        var smProration = Assert.Single(preview.SecretsManager.Prorations!);
+        Assert.Equal(0m, smProration.Charge);
+        Assert.Equal(15.08m, smProration.Credit);
+        Assert.Equal(-15.08m, smProration.Total);
+    }
+
+    [Fact]
+    public void BuildFromInvoice_ReadsReferenceBeforeProrationCheck()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 13290, "amount_due": 13290,
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 500, "pricing": { "price_details": { "price": { "id": "price_orphan", "metadata": {} } } }, "parent": { "subscription_item_details": { "proration": true } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out var logger);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Null(preview.PasswordManager.Prorations);
+        Assert.Contains(logger.Errors, e => e.Contains("price_orphan"));
+    }
+
+    [Fact]
+    public void BuildFromInvoice_UsesParentSubscriptionItemDetailsProration_NotTopLevel()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 17606, "amount_due": 17606,
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 3582, "quantity": 2, "proration": true, "pricing": { "price_details": { "price": { "id": "price_pm_storage_pos", "metadata": { "purchasable_reference": "pm-storage" } } } }, "parent": { "subscription_item_details": { "proration": false } } },
+            { "amount": 1234, "proration": false, "pricing": { "price_details": { "price": { "id": "price_pm_storage_prorate", "metadata": { "purchasable_reference": "pm-storage" } } } }, "parent": { "subscription_item_details": { "proration": true } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        // Top-level "proration": true on this line is a no-op (unmapped field); nested false wins -> it's a position.
+        Assert.NotNull(preview.PasswordManager.AdditionalStorage);
+        Assert.Equal(2, preview.PasswordManager.AdditionalStorage!.Quantity);
+        Assert.Equal(35.82m, preview.PasswordManager.AdditionalStorage.Cost);
+
+        // Top-level "proration": false is a no-op; nested true wins -> it's a proration, not a second position.
+        var proration = Assert.Single(preview.PasswordManager.Prorations!);
+        Assert.Equal(12.34m, proration.Charge);
+        Assert.Equal(0m, proration.Credit);
+        Assert.Equal(12.34m, proration.Total);
+    }
+
+    [Fact]
+    public void BuildFromInvoice_UnknownReference_LogsAndSkips()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 13290, "amount_due": 13290,
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 500, "quantity": 1, "pricing": { "price_details": { "price": { "id": "price_weird", "metadata": { "purchasable_reference": "pm-unknown" } } } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out var logger);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Null(preview.PasswordManager.AdditionalStorage);
+        Assert.Contains(logger.Errors, e => e.Contains("pm-unknown"));
+    }
+
+    [Fact]
+    public void BuildFromInvoice_DuplicateReference_KeepsFirstAndLogs()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 13789, "amount_due": 13789,
+          "lines": { "data": [
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat_1", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 999, "quantity": 9, "pricing": { "price_details": { "price": { "id": "price_pm_seat_2", "metadata": { "purchasable_reference": "pm-seat" } } } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out var logger);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Equal(5, preview.PasswordManager.Seats.Quantity);
+        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
+        Assert.Contains(logger.Errors, e => e.Contains("pm-seat"));
+    }
+
+    [Fact]
+    public void BuildFromInvoice_NoPasswordManagerSeats_Throws()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 4567, "amount_due": 4567,
+          "lines": { "data": [
+            { "amount": 4567, "quantity": 3, "pricing": { "price_details": { "price": { "id": "price_sm_seat", "metadata": { "purchasable_reference": "sm-seat" } } } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+
+        Assert.Throws<InvoicePreviewException>(() => builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually));
+    }
+
+    [Fact]
+    public void BuildFromInvoice_AttachesItemLevelDiscountsToTheRightItem()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test", "total": 11511, "amount_due": 11511,
+          "total_discount_amounts": [
+            { "amount": 1279, "discount": { "id": "di_x", "source": { "coupon": { "id": "cp_x", "name": "SEATS10", "percent_off": 10, "applies_to": { "products": ["prod_pm"] } } } } }
+          ],
+          "lines": { "data": [
+            {
+              "amount": 12790, "quantity": 5,
+              "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } },
+              "discount_amounts": [ { "amount": 1279, "discount": "di_x" } ]
+            }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        var discount = Assert.Single(preview.PasswordManager.Seats.Discounts!);
+        Assert.Equal(BitwardenDiscountType.PercentOff, discount.Type);
+        Assert.Equal(10m, discount.Value);
+        Assert.Equal(12.79m, discount.Amount);
+        Assert.Equal("SEATS10", discount.Label);
+    }
+
+    [Fact]
+    public void BuildFromSubscription_SumsCurrentItems_ZeroTax_NoProrationsNoDiscounts()
+    {
+        var subscription = DeserializeSubscription("""
+        {
+          "id": "sub_test",
+          "items": { "data": [
+            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat", "unit_amount": 2558, "metadata": { "purchasable_reference": "pm-seat" } } },
+            { "id": "si_2", "quantity": 2, "price": { "id": "price_pm_storage", "unit_amount": 599, "metadata": { "purchasable_reference": "pm-storage" } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+        var preview = builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly);
+
+        Assert.Equal(5, preview.PasswordManager.Seats.Quantity);
+        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
+        Assert.Equal(2, preview.PasswordManager.AdditionalStorage!.Quantity);
+        Assert.Equal(11.98m, preview.PasswordManager.AdditionalStorage.Cost);
+        Assert.Equal(139.88m, preview.Total);
+        Assert.Equal(139.88m, preview.AmountDue);
+        Assert.Equal(0m, preview.EstimatedTax);
+        Assert.Null(preview.PasswordManager.Prorations);
+        Assert.Null(preview.Discounts);
+    }
+
+    [Fact]
+    public void BuildFromSubscription_NoPasswordManagerSeats_Throws()
+    {
+        var subscription = DeserializeSubscription("""
+        {
+          "id": "sub_test",
+          "items": { "data": [
+            { "id": "si_1", "quantity": 3, "price": { "id": "price_sm_seat", "unit_amount": 4567, "metadata": { "purchasable_reference": "sm-seat" } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+
+        Assert.Throws<InvoicePreviewException>(() => builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly));
+    }
+}

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
@@ -245,7 +245,7 @@ public class InvoicePreviewBuilderTests
 
         var builder = Builder(out _);
 
-        Assert.Throws<InvoicePreviewException>(() => builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually));
+        Assert.Throws<InvalidOperationException>(() => builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually));
     }
 
     [Fact]
@@ -318,6 +318,6 @@ public class InvoicePreviewBuilderTests
 
         var builder = Builder(out _);
 
-        Assert.Throws<InvoicePreviewException>(() => builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly));
+        Assert.Throws<InvalidOperationException>(() => builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly));
     }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
@@ -211,7 +211,7 @@ public class InvoicePreviewBuilderTests
     }
 
     [Fact]
-    public void BuildFromInvoice_DuplicateReference_KeepsFirstAndLogs()
+    public void BuildFromInvoice_DuplicateReference_Throws()
     {
         var invoice = Deserialize("""
         {
@@ -223,12 +223,9 @@ public class InvoicePreviewBuilderTests
         }
         """);
 
-        var builder = Builder(out var logger);
-        var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
+        var builder = Builder(out _);
 
-        Assert.Equal(5, preview.PasswordManager.Seats.Quantity);
-        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
-        Assert.Contains(logger.Errors, e => e.Contains("pm-seat"));
+        Assert.Throws<InvalidOperationException>(() => builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually));
     }
 
     [Fact]
@@ -347,7 +344,7 @@ public class InvoicePreviewBuilderTests
     }
 
     [Fact]
-    public void BuildFromSubscription_DuplicateReference_KeepsFirstItemAndLogs()
+    public void BuildFromSubscription_DuplicateReference_Throws()
     {
         var subscription = DeserializeSubscription("""
         {
@@ -359,14 +356,8 @@ public class InvoicePreviewBuilderTests
         }
         """);
 
-        var builder = Builder(out var logger);
-        var preview = builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly);
+        var builder = Builder(out _);
 
-        // The first item wins the reference...
-        Assert.Equal(5, preview.PasswordManager.Seats.Quantity);
-        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
-        // ...yet both items still count toward the total (127.90 + 9.00).
-        Assert.Equal(136.90m, preview.Total);
-        Assert.Contains(logger.Errors, e => e.Contains("pm-seat"));
+        Assert.Throws<InvalidOperationException>(() => builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly));
     }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
@@ -26,7 +26,7 @@ public class InvoicePreviewBuilderTests
         {
           "id": "in_test", "total": 12790, "amount_due": 12790,
           "lines": { "data": [
-            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm", "unit_amount_decimal": "2558", "metadata": { "purchasable_reference": "pm-seat" } } } } },
             { "amount": 500, "quantity": 1, "pricing": { "price_details": { "price": { "id": "price_mystery", "metadata": {} } } } }
           ] }
         }
@@ -36,7 +36,7 @@ public class InvoicePreviewBuilderTests
         var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
 
         Assert.Equal("pm-seat", preview.PasswordManager.Seats.Reference);
-        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
+        Assert.Equal(25.58m, preview.PasswordManager.Seats.Cost);
         Assert.Contains(logger.Errors, e => e.Contains("price_mystery"));
     }
 
@@ -47,10 +47,10 @@ public class InvoicePreviewBuilderTests
         {
           "id": "in_test", "total": 22218, "amount_due": 22218,
           "lines": { "data": [
-            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
-            { "amount": 3582, "quantity": 2, "pricing": { "price_details": { "price": { "id": "price_pm_storage", "metadata": { "purchasable_reference": "pm-storage" } } } } },
-            { "amount": 4567, "quantity": 3, "pricing": { "price_details": { "price": { "id": "price_sm_seat", "metadata": { "purchasable_reference": "sm-seat" } } } } },
-            { "amount": 1279, "quantity": 1, "pricing": { "price_details": { "price": { "id": "price_sm_sa", "metadata": { "purchasable_reference": "sm-service-account" } } } } }
+            { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "unit_amount_decimal": "2558", "metadata": { "purchasable_reference": "pm-seat" } } } } },
+            { "amount": 3582, "quantity": 2, "pricing": { "price_details": { "price": { "id": "price_pm_storage", "unit_amount_decimal": "1791", "metadata": { "purchasable_reference": "pm-storage" } } } } },
+            { "amount": 4500, "quantity": 3, "pricing": { "price_details": { "price": { "id": "price_sm_seat", "unit_amount_decimal": "1500", "metadata": { "purchasable_reference": "sm-seat" } } } } },
+            { "amount": 1279, "quantity": 1, "pricing": { "price_details": { "price": { "id": "price_sm_sa", "unit_amount_decimal": "1279", "metadata": { "purchasable_reference": "sm-service-account" } } } } }
           ] }
         }
         """);
@@ -59,11 +59,11 @@ public class InvoicePreviewBuilderTests
         var preview = builder.Build(invoice, PlanTierType.Enterprise, PlanCadenceType.Annually);
 
         Assert.Equal(5, preview.PasswordManager.Seats.Quantity);
-        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
+        Assert.Equal(25.58m, preview.PasswordManager.Seats.Cost);
         Assert.Equal(2, preview.PasswordManager.AdditionalStorage!.Quantity);
-        Assert.Equal(35.82m, preview.PasswordManager.AdditionalStorage.Cost);
+        Assert.Equal(17.91m, preview.PasswordManager.AdditionalStorage.Cost);
         Assert.Equal(3, preview.SecretsManager!.Seats.Quantity);
-        Assert.Equal(45.67m, preview.SecretsManager.Seats.Cost);
+        Assert.Equal(15.00m, preview.SecretsManager.Seats.Cost);
         Assert.Equal(1, preview.SecretsManager.AdditionalServiceAccounts!.Quantity);
         Assert.Equal(12.79m, preview.SecretsManager.AdditionalServiceAccounts.Cost);
     }
@@ -169,7 +169,7 @@ public class InvoicePreviewBuilderTests
           "id": "in_test", "total": 17606, "amount_due": 17606,
           "lines": { "data": [
             { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm_seat", "metadata": { "purchasable_reference": "pm-seat" } } } } },
-            { "amount": 3582, "quantity": 2, "proration": true, "pricing": { "price_details": { "price": { "id": "price_pm_storage_pos", "metadata": { "purchasable_reference": "pm-storage" } } } }, "parent": { "subscription_item_details": { "proration": false } } },
+            { "amount": 3582, "quantity": 2, "proration": true, "pricing": { "price_details": { "price": { "id": "price_pm_storage_pos", "unit_amount_decimal": "1791", "metadata": { "purchasable_reference": "pm-storage" } } } }, "parent": { "subscription_item_details": { "proration": false } } },
             { "amount": 1234, "proration": false, "pricing": { "price_details": { "price": { "id": "price_pm_storage_prorate", "metadata": { "purchasable_reference": "pm-storage" } } } }, "parent": { "subscription_item_details": { "proration": true } } }
           ] }
         }
@@ -181,7 +181,7 @@ public class InvoicePreviewBuilderTests
         // Top-level "proration": true on this line is a no-op (unmapped field); nested false wins -> it's a position.
         Assert.NotNull(preview.PasswordManager.AdditionalStorage);
         Assert.Equal(2, preview.PasswordManager.AdditionalStorage!.Quantity);
-        Assert.Equal(35.82m, preview.PasswordManager.AdditionalStorage.Cost);
+        Assert.Equal(17.91m, preview.PasswordManager.AdditionalStorage.Cost);
 
         // Top-level "proration": false is a no-op; nested true wins -> it's a proration, not a second position.
         var proration = Assert.Single(preview.PasswordManager.Prorations!);
@@ -291,9 +291,9 @@ public class InvoicePreviewBuilderTests
         var preview = builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly);
 
         Assert.Equal(5, preview.PasswordManager.Seats.Quantity);
-        Assert.Equal(127.90m, preview.PasswordManager.Seats.Cost);
+        Assert.Equal(25.58m, preview.PasswordManager.Seats.Cost);
         Assert.Equal(2, preview.PasswordManager.AdditionalStorage!.Quantity);
-        Assert.Equal(11.98m, preview.PasswordManager.AdditionalStorage.Cost);
+        Assert.Equal(5.99m, preview.PasswordManager.AdditionalStorage.Cost);
         Assert.Equal(139.88m, preview.Total);
         Assert.Equal(139.88m, preview.AmountDue);
         Assert.Equal(0m, preview.EstimatedTax);
@@ -378,7 +378,7 @@ public class InvoicePreviewBuilderTests
         var preview = builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly);
 
         Assert.Equal(300, preview.PasswordManager.Seats.Quantity);
-        Assert.Equal(1.50m, preview.PasswordManager.Seats.Cost); // 300 × 0.5¢ ÷ 100 — would be 0 under the old UnitAmount read
-        Assert.Equal(1.50m, preview.Total);
+        Assert.Equal(0.005m, preview.PasswordManager.Seats.Cost); // 0.5¢ unit price ÷ 100 — UnitAmountDecimal avoids the old truncate-to-0
+        Assert.Equal(1.50m, preview.Total); // 300 × 0.5¢ ÷ 100
     }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewBuilderTests.cs
@@ -281,8 +281,8 @@ public class InvoicePreviewBuilderTests
         {
           "id": "sub_test",
           "items": { "data": [
-            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat", "unit_amount": 2558, "metadata": { "purchasable_reference": "pm-seat" } } },
-            { "id": "si_2", "quantity": 2, "price": { "id": "price_pm_storage", "unit_amount": 599, "metadata": { "purchasable_reference": "pm-storage" } } }
+            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat", "unit_amount": 2558, "unit_amount_decimal": "2558", "metadata": { "purchasable_reference": "pm-seat" } } },
+            { "id": "si_2", "quantity": 2, "price": { "id": "price_pm_storage", "unit_amount": 599, "unit_amount_decimal": "599", "metadata": { "purchasable_reference": "pm-storage" } } }
           ] }
         }
         """);
@@ -308,7 +308,7 @@ public class InvoicePreviewBuilderTests
         {
           "id": "sub_test",
           "items": { "data": [
-            { "id": "si_1", "quantity": 3, "price": { "id": "price_sm_seat", "unit_amount": 4567, "metadata": { "purchasable_reference": "sm-seat" } } }
+            { "id": "si_1", "quantity": 3, "price": { "id": "price_sm_seat", "unit_amount": 4567, "unit_amount_decimal": "4567", "metadata": { "purchasable_reference": "sm-seat" } } }
           ] }
         }
         """);
@@ -325,8 +325,8 @@ public class InvoicePreviewBuilderTests
         {
           "id": "sub_test",
           "items": { "data": [
-            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat", "unit_amount": 2558, "metadata": { "purchasable_reference": "pm-seat" } } },
-            { "id": "si_2", "quantity": 2, "price": { "id": "price_mystery", "unit_amount": 500, "metadata": {} } }
+            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat", "unit_amount": 2558, "unit_amount_decimal": "2558", "metadata": { "purchasable_reference": "pm-seat" } } },
+            { "id": "si_2", "quantity": 2, "price": { "id": "price_mystery", "unit_amount": 500, "unit_amount_decimal": "500", "metadata": {} } }
           ] }
         }
         """);
@@ -350,8 +350,8 @@ public class InvoicePreviewBuilderTests
         {
           "id": "sub_test",
           "items": { "data": [
-            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat_1", "unit_amount": 2558, "metadata": { "purchasable_reference": "pm-seat" } } },
-            { "id": "si_2", "quantity": 9, "price": { "id": "price_pm_seat_2", "unit_amount": 100, "metadata": { "purchasable_reference": "pm-seat" } } }
+            { "id": "si_1", "quantity": 5, "price": { "id": "price_pm_seat_1", "unit_amount": 2558, "unit_amount_decimal": "2558", "metadata": { "purchasable_reference": "pm-seat" } } },
+            { "id": "si_2", "quantity": 9, "price": { "id": "price_pm_seat_2", "unit_amount": 100, "unit_amount_decimal": "100", "metadata": { "purchasable_reference": "pm-seat" } } }
           ] }
         }
         """);
@@ -359,5 +359,26 @@ public class InvoicePreviewBuilderTests
         var builder = Builder(out _);
 
         Assert.Throws<InvalidOperationException>(() => builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly));
+    }
+
+    [Fact]
+    public void BuildFromSubscription_FractionalCentPrice_UsesDecimalAmount_NotZero()
+    {
+        // Stripe omits unit_amount for fractional-cent per-unit prices; only unit_amount_decimal is set.
+        var subscription = DeserializeSubscription("""
+        {
+          "id": "sub_test",
+          "items": { "data": [
+            { "id": "si_1", "quantity": 300, "price": { "id": "price_pm_seat", "unit_amount_decimal": "0.5", "metadata": { "purchasable_reference": "pm-seat" } } }
+          ] }
+        }
+        """);
+
+        var builder = Builder(out _);
+        var preview = builder.Build(subscription, PlanTierType.Teams, PlanCadenceType.Monthly);
+
+        Assert.Equal(300, preview.PasswordManager.Seats.Quantity);
+        Assert.Equal(1.50m, preview.PasswordManager.Seats.Cost); // 300 × 0.5¢ ÷ 100 — would be 0 under the old UnitAmount read
+        Assert.Equal(1.50m, preview.Total);
     }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
@@ -1,0 +1,25 @@
+using Bit.Core.Billing.Services;
+using Bit.Invoicing.InvoicePreviews.Stripe;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class InvoicePreviewClientTests
+{
+    [Fact]
+    public async Task GetInvoiceForPreviewAsync_SetsBothExpandsAndOmitsLineLevelCouponPath()
+    {
+        var adapter = Substitute.For<IStripeAdapter>();
+        adapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>()).Returns(new Invoice());
+        var client = new InvoicePreviewClient(adapter);
+
+        var options = new InvoiceCreatePreviewOptions();
+        await client.GetInvoiceForPreviewAsync(options);
+
+        Assert.Contains("lines.data.pricing.price_details.price", options.Expand);
+        Assert.Contains("total_discount_amounts.discount.source.coupon", options.Expand);
+        Assert.DoesNotContain("lines.data.discount_amounts.discount.source.coupon", options.Expand);
+    }
+}

--- a/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
@@ -22,4 +22,63 @@ public class InvoicePreviewClientTests
         Assert.Contains("total_discount_amounts.discount.source.coupon", options.Expand);
         Assert.DoesNotContain("lines.data.discount_amounts.discount.source.coupon", options.Expand);
     }
+
+    [Fact]
+    public async Task GetInvoiceForPreviewAsync_LinesTruncated_FetchesFullSetByInvoiceIdAndSplices()
+    {
+        var adapter = Substitute.For<IStripeAdapter>();
+
+        var truncated = new Invoice
+        {
+            Id = "upcoming_in_test",
+            Lines = new StripeList<InvoiceLineItem>
+            {
+                Data = [new InvoiceLineItem { Id = "il_1" }],
+                HasMore = true,
+            },
+        };
+        adapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>()).Returns(truncated);
+
+        var fullSet = new List<InvoiceLineItem>
+        {
+            new() { Id = "il_1" }, new() { Id = "il_2" }, new() { Id = "il_3" },
+        };
+        adapter.ListInvoiceLineItemsAsync(Arg.Any<string>(), Arg.Any<InvoiceLineItemListOptions>())
+            .Returns(fullSet);
+
+        var client = new InvoicePreviewClient(adapter);
+
+        var result = await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
+
+        // Fetched by the preview's ephemeral id, carrying only the line-level price expand.
+        await adapter.Received(1).ListInvoiceLineItemsAsync(
+            "upcoming_in_test",
+            Arg.Is<InvoiceLineItemListOptions>(o => o.Expand.Contains("data.pricing.price_details.price")));
+
+        Assert.Same(fullSet, result.Lines.Data);
+        Assert.Equal(3, result.Lines.Data.Count);
+        Assert.False(result.Lines.HasMore);
+    }
+
+    [Fact]
+    public async Task GetInvoiceForPreviewAsync_LinesNotTruncated_DoesNotFetchAndLeavesLinesUntouched()
+    {
+        var adapter = Substitute.For<IStripeAdapter>();
+
+        var lines = new List<InvoiceLineItem> { new() { Id = "il_1" } };
+        var invoice = new Invoice
+        {
+            Id = "upcoming_in_test",
+            Lines = new StripeList<InvoiceLineItem> { Data = lines, HasMore = false },
+        };
+        adapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>()).Returns(invoice);
+
+        var client = new InvoicePreviewClient(adapter);
+
+        var result = await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
+
+        await adapter.DidNotReceive()
+            .ListInvoiceLineItemsAsync(Arg.Any<string>(), Arg.Any<InvoiceLineItemListOptions>());
+        Assert.Same(lines, result.Lines.Data);
+    }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Services;
+﻿using Bit.Core.Billing.Services;
 using Bit.Invoicing.InvoicePreviews.Stripe;
 using NSubstitute;
 using Stripe;

--- a/test/Libraries/Invoicing.Test/InvoicePreviewServiceTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewServiceTests.cs
@@ -1,0 +1,47 @@
+﻿using Bit.Core.Billing.Enums;
+using Bit.Invoicing.InvoicePreviews;
+using Bit.Invoicing.InvoicePreviews.Models;
+using Bit.Invoicing.InvoicePreviews.Stripe;
+using Stripe;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class InvoicePreviewServiceTests
+{
+    [Fact]
+    public async Task GetInvoicePreviewAsync_FromOptions_FetchesThroughClientThenProjects()
+    {
+        var client = new FakeInvoicePreviewClient(StripeFixtures.SampleInvoiceWithPmSeat());
+        var service = new InvoicePreviewService(client, new InvoicePreviewBuilder(new RecordingLogger<InvoicePreviewBuilder>()));
+
+        var preview = await service.GetInvoicePreviewAsync(new InvoiceCreatePreviewOptions(), PlanTierType.Enterprise, PlanCadenceType.Annually);
+
+        Assert.Equal("pm-seat", preview.PasswordManager.Seats.Reference);
+        Assert.Equal(1, client.CallCount);
+    }
+
+    [Fact]
+    public async Task GetInvoicePreviewAsync_FromSubscription_ProjectsWithoutFetching()
+    {
+        var client = new FakeInvoicePreviewClient(new Invoice());
+        var service = new InvoicePreviewService(client, new InvoicePreviewBuilder(new RecordingLogger<InvoicePreviewBuilder>()));
+
+        var preview = await service.GetInvoicePreviewAsync(StripeFixtures.SampleSubscriptionWithPmSeat(), PlanTierType.Premium, PlanCadenceType.Annually);
+
+        Assert.Equal(0m, preview.EstimatedTax);
+        Assert.Equal(0, client.CallCount);
+    }
+
+    // IInvoicePreviewClient is internal, so it is hand-faked via Invoicing.Test's InternalsVisibleTo grant rather than mocked — NSubstitute's proxy assembly cannot see it. Same reasoning as RecordingLogger.
+    private sealed class FakeInvoicePreviewClient(Invoice invoice) : IInvoicePreviewClient
+    {
+        public int CallCount { get; private set; }
+
+        public Task<Invoice> GetInvoiceForPreviewAsync(InvoiceCreatePreviewOptions options)
+        {
+            CallCount++;
+            return Task.FromResult(invoice);
+        }
+    }
+}

--- a/test/Libraries/Invoicing.Test/Models/InvoicePreviewSerializationTests.cs
+++ b/test/Libraries/Invoicing.Test/Models/InvoicePreviewSerializationTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Bit.Core.Billing.Enums;
 using Bit.Core.Billing.Subscriptions.Models;
 using Bit.Invoicing.InvoicePreviews.Models;

--- a/test/Libraries/Invoicing.Test/Models/InvoicePreviewSerializationTests.cs
+++ b/test/Libraries/Invoicing.Test/Models/InvoicePreviewSerializationTests.cs
@@ -50,4 +50,31 @@ public class InvoicePreviewSerializationTests
         Assert.Contains("\"discounts\":null", json);
         Assert.Contains("\"startingBalance\":null", json);
     }
+
+    private static SubscriptionPreview SampleSubscriptionPreview() => new()
+    {
+        Status = "active",
+        InvoicePreview = Sample(),
+        Storage = new Storage { Available = 10, Used = 2.5, ReadableUsed = "2.5 GB" },
+        CancelAt = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        Canceled = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+        Suspension = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+        GracePeriod = 7,
+        PendingChange = new PendingSubscriptionChange
+        {
+            InvoicePreview = Sample(),
+            EffectiveDate = new DateTime(2027, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+        },
+    };
+
+    [Fact]
+    public void SubscriptionPreview_SerializesEnvelopeFields()
+    {
+        var json = JsonSerializer.Serialize(SampleSubscriptionPreview(), Options);
+        Assert.Contains("\"status\":\"active\"", json);
+        Assert.Contains("\"gracePeriod\":7", json);
+        Assert.Contains("\"available\":10", json);
+        Assert.Contains("\"pendingChange\":{", json);
+        Assert.Contains("\"effectiveDate\":", json);
+    }
 }

--- a/test/Libraries/Invoicing.Test/Models/InvoicePreviewSerializationTests.cs
+++ b/test/Libraries/Invoicing.Test/Models/InvoicePreviewSerializationTests.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Billing.Subscriptions.Models;
+using Bit.Invoicing.InvoicePreviews.Models;
+using Xunit;
+
+namespace Bit.Invoicing.Test.Models;
+
+public class InvoicePreviewSerializationTests
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    private static InvoicePreview Sample() => new()
+    {
+        PasswordManager = new PasswordManagerInvoiceItems
+        {
+            Seats = new InvoicePreviewItem { Reference = "pm-seat", Quantity = 5, Cost = 35.82m },
+        },
+        Cadence = PlanCadenceType.Annually,
+        PlanTier = PlanTierType.Enterprise,
+        EstimatedTax = 2.11m,
+        Total = 37.93m,
+        AmountDue = 37.93m,
+    };
+
+    [Fact]
+    public void Serializes_TierAndCadence_AsEnumMemberStrings()
+    {
+        var json = JsonSerializer.Serialize(Sample(), Options);
+        Assert.Contains("\"planTier\":\"enterprise\"", json);
+        Assert.Contains("\"cadence\":\"annually\"", json);
+    }
+
+    [Fact]
+    public void Serializes_DiscountType_AsEnumMemberString()
+    {
+        var preview = Sample() with
+        {
+            Discounts = [new InvoicePreviewDiscount { Type = BitwardenDiscountType.PercentOff, Value = 10m, Amount = 3.79m, Label = "LAUNCH" }],
+        };
+        var json = JsonSerializer.Serialize(preview, Options);
+        Assert.Contains("\"type\":\"percent-off\"", json);
+    }
+
+    [Fact]
+    public void Serializes_NullOptionalFields_AsNull()
+    {
+        var json = JsonSerializer.Serialize(Sample(), Options);
+        Assert.Contains("\"secretsManager\":null", json);
+        Assert.Contains("\"discounts\":null", json);
+        Assert.Contains("\"startingBalance\":null", json);
+    }
+}

--- a/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
@@ -1,4 +1,4 @@
-using Bit.Invoicing.InvoicePreviews;
+﻿using Bit.Invoicing.InvoicePreviews;
 using Stripe;
 using Xunit;
 

--- a/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
@@ -63,14 +63,22 @@ public class ProrationMapperTests
     }
 
     [Fact]
-    public void Summarize_Months_FromLinePeriodEndToInvoicePeriodEnd_FlooredAtZero()
+    public void Summarize_Months_RoundsProratedDaysToNearestMonth_MinimumOne()
     {
-        var invoice = InvoiceWith(3_582, 0, periodEnd: new DateTime(2027, 1, 1));
-        Assert.Equal(11, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2026, 2, 1))], invoice)!.Months);
-        // line end after invoice end -> floored to 0
-        Assert.Equal(0, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2027, 6, 1))], invoice)!.Months);
-        // no period -> 0
-        Assert.Equal(0, ProrationMapper.Summarize([Line(3_582)], invoice)!.Months);
+        // Real proration shape: line end is LATER than invoice end. ~365 days -> 12 months.
+        var yearOut = InvoiceWith(3_582, 0, periodEnd: new DateTime(2026, 8, 13));
+        Assert.Equal(12, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2027, 8, 13))], yearOut)!.Months);
+
+        // 59-day gap rounds to 2 (day-based, not calendar months, which would give 1).
+        var partial = InvoiceWith(3_582, 0, periodEnd: new DateTime(2026, 8, 2));
+        Assert.Equal(2, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2026, 9, 30))], partial)!.Months);
+
+        // Sub-month gap floors to 1, never 0.
+        var tiny = InvoiceWith(3_582, 0, periodEnd: new DateTime(2026, 8, 13));
+        Assert.Equal(1, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2026, 8, 20))], tiny)!.Months);
+
+        // No line period -> 0.
+        Assert.Equal(0, ProrationMapper.Summarize([Line(3_582)], tiny)!.Months);
     }
 
     [Fact]

--- a/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
@@ -6,29 +6,21 @@ namespace Bit.Invoicing.Test;
 
 public class ProrationMapperTests
 {
-    private static InvoiceLineItem Line(long amountCents, DateTime? periodEnd = null, long taxCents = 0) => new()
+    private static InvoiceLineItem Line(long amountCents, DateTime? periodStart = null, DateTime? periodEnd = null, long taxCents = 0) => new()
     {
         Amount = amountCents,
-        Period = periodEnd is null ? null : new InvoiceLineItemPeriod { End = periodEnd.Value },
+        Period = periodEnd is null ? null : new InvoiceLineItemPeriod { Start = periodStart ?? default, End = periodEnd.Value },
         Taxes = taxCents == 0 ? null : [new InvoiceLineItemTax { Amount = taxCents }],
-    };
-
-    private static Invoice InvoiceWith(long totalCents, long totalTaxCents, DateTime periodEnd) => new()
-    {
-        Total = totalCents,
-        TotalTaxes = [new InvoiceTotalTax { Amount = totalTaxCents }],
-        PeriodEnd = periodEnd,
     };
 
     [Fact]
     public void Summarize_EmptyBucket_ReturnsNull()
-        => Assert.Null(ProrationMapper.Summarize([], InvoiceWith(0, 0, new DateTime(2027, 1, 1))));
+        => Assert.Null(ProrationMapper.Summarize([]));
 
     [Fact]
     public void Summarize_SplitsChargeCreditAndNet_InDollars()
     {
-        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 0, periodEnd: new DateTime(2027, 1, 1));
-        var result = ProrationMapper.Summarize([Line(7_355), Line(-3_773)], invoice)!;
+        var result = ProrationMapper.Summarize([Line(7_355), Line(-3_773)])!;
         Assert.Equal(73.55m, result.Charge);
         Assert.Equal(37.73m, result.Credit);
         Assert.Equal(35.82m, result.Total);
@@ -37,8 +29,7 @@ public class ProrationMapperTests
     [Fact]
     public void Summarize_EntirelyNegativeBucket_IsAllCredit()
     {
-        var invoice = InvoiceWith(11_982, 0, new DateTime(2027, 1, 1));
-        var result = ProrationMapper.Summarize([Line(-2_507), Line(-1_275)], invoice)!;
+        var result = ProrationMapper.Summarize([Line(-2_507), Line(-1_275)])!;
         Assert.Equal(0m, result.Charge);
         Assert.Equal(37.82m, result.Credit);
         Assert.Equal(-37.82m, result.Total);
@@ -48,49 +39,46 @@ public class ProrationMapperTests
     public void Summarize_Tax_SumsPerLineTaxes_InDollars()
     {
         // charge line tax 736, credit line tax -377 -> (736 + -377) / 100 = 3.59
-        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 0, periodEnd: new DateTime(2027, 1, 1));
-        var result = ProrationMapper.Summarize([Line(7_355, taxCents: 736), Line(-3_773, taxCents: -377)], invoice)!;
+        var result = ProrationMapper.Summarize([Line(7_355, taxCents: 736), Line(-3_773, taxCents: -377)])!;
         Assert.Equal(3.59m, result.Tax);
     }
 
     [Fact]
     public void Summarize_LinesWithoutPerLineTaxes_YieldZeroTax()
     {
-        // invoice carries tax, but the proration lines have none -> bucket tax is 0 (no allocation from the invoice total)
-        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 1_207, periodEnd: new DateTime(2027, 1, 1));
-        var result = ProrationMapper.Summarize([Line(3_582)], invoice)!;
+        // proration lines carry no per-line taxes -> bucket tax is 0
+        var result = ProrationMapper.Summarize([Line(3_582)])!;
         Assert.Equal(0m, result.Tax);
     }
 
     [Fact]
     public void Summarize_Months_RoundsProratedDaysToNearestMonth_MinimumOne()
     {
-        // Real proration shape: line end is LATER than invoice end. ~365 days -> 12 months.
-        var yearOut = InvoiceWith(3_582, 0, periodEnd: new DateTime(2026, 8, 13));
-        Assert.Equal(12, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2027, 8, 13))], yearOut)!.Months);
+        // ~365-day span -> 12 months.
+        Assert.Equal(12, ProrationMapper.Summarize(
+            [Line(3_582, periodStart: new DateTime(2026, 8, 13), periodEnd: new DateTime(2027, 8, 13))])!.Months);
 
-        // 59-day gap rounds to 2 (day-based, not calendar months, which would give 1).
-        var partial = InvoiceWith(3_582, 0, periodEnd: new DateTime(2026, 8, 2));
-        Assert.Equal(2, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2026, 9, 30))], partial)!.Months);
+        // 59-day span rounds to 2 (day-based, not calendar months, which would give 1).
+        Assert.Equal(2, ProrationMapper.Summarize(
+            [Line(3_582, periodStart: new DateTime(2026, 8, 2), periodEnd: new DateTime(2026, 9, 30))])!.Months);
 
-        // Sub-month gap floors to 1, never 0.
-        var tiny = InvoiceWith(3_582, 0, periodEnd: new DateTime(2026, 8, 13));
-        Assert.Equal(1, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2026, 8, 20))], tiny)!.Months);
+        // Sub-month span floors to 1, never 0.
+        Assert.Equal(1, ProrationMapper.Summarize(
+            [Line(3_582, periodStart: new DateTime(2026, 8, 13), periodEnd: new DateTime(2026, 8, 20))])!.Months);
 
         // No line period -> 0.
-        Assert.Equal(0, ProrationMapper.Summarize([Line(3_582)], tiny)!.Months);
+        Assert.Equal(0, ProrationMapper.Summarize([Line(3_582)])!.Months);
     }
 
     [Fact]
     public void Summarize_MultipleTaxesOnOneLine_SumsThem()
     {
-        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 0, periodEnd: new DateTime(2027, 1, 1));
         var line = new InvoiceLineItem
         {
             Amount = 7_355,
             Taxes = [new InvoiceLineItemTax { Amount = 500 }, new InvoiceLineItemTax { Amount = 236 }],
         };
-        var result = ProrationMapper.Summarize([line], invoice)!;
+        var result = ProrationMapper.Summarize([line])!;
         Assert.Equal(7.36m, result.Tax);
     }
 }

--- a/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
@@ -6,10 +6,11 @@ namespace Bit.Invoicing.Test;
 
 public class ProrationMapperTests
 {
-    private static InvoiceLineItem Line(long amountCents, DateTime? periodEnd = null) => new()
+    private static InvoiceLineItem Line(long amountCents, DateTime? periodEnd = null, long taxCents = 0) => new()
     {
         Amount = amountCents,
         Period = periodEnd is null ? null : new InvoiceLineItemPeriod { End = periodEnd.Value },
+        Taxes = taxCents == 0 ? null : [new InvoiceLineItemTax { Amount = taxCents }],
     };
 
     private static Invoice InvoiceWith(long totalCents, long totalTaxCents, DateTime periodEnd) => new()
@@ -44,18 +45,19 @@ public class ProrationMapperTests
     }
 
     [Fact]
-    public void Summarize_AllocatesTax_ProportionalToNetOverInvoiceTotal()
+    public void Summarize_Tax_SumsPerLineTaxes_InDollars()
     {
-        // net 3_582 of total 11_982; tax 1_207 -> 1207 * (3582/11982) / 100 = 3.6086...
-        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 1_207, periodEnd: new DateTime(2027, 1, 1));
-        var result = ProrationMapper.Summarize([Line(7_355), Line(-3_773)], invoice)!;
-        Assert.Equal(1207m * (3582m / 11982m) / 100m, result.Tax);
+        // charge line tax 736, credit line tax -377 -> (736 + -377) / 100 = 3.59
+        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 0, periodEnd: new DateTime(2027, 1, 1));
+        var result = ProrationMapper.Summarize([Line(7_355, taxCents: 736), Line(-3_773, taxCents: -377)], invoice)!;
+        Assert.Equal(3.59m, result.Tax);
     }
 
     [Fact]
-    public void Summarize_ZeroInvoiceTotal_YieldsZeroTax()
+    public void Summarize_LinesWithoutPerLineTaxes_YieldZeroTax()
     {
-        var invoice = InvoiceWith(totalCents: 0, totalTaxCents: 1_207, periodEnd: new DateTime(2027, 1, 1));
+        // invoice carries tax, but the proration lines have none -> bucket tax is 0 (no allocation from the invoice total)
+        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 1_207, periodEnd: new DateTime(2027, 1, 1));
         var result = ProrationMapper.Summarize([Line(3_582)], invoice)!;
         Assert.Equal(0m, result.Tax);
     }

--- a/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
@@ -1,0 +1,73 @@
+using Bit.Invoicing.InvoicePreviews;
+using Stripe;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class ProrationMapperTests
+{
+    private static InvoiceLineItem Line(long amountCents, DateTime? periodEnd = null) => new()
+    {
+        Amount = amountCents,
+        Period = periodEnd is null ? null : new InvoiceLineItemPeriod { End = periodEnd.Value },
+    };
+
+    private static Invoice InvoiceWith(long totalCents, long totalTaxCents, DateTime periodEnd) => new()
+    {
+        Total = totalCents,
+        TotalTaxes = [new InvoiceTotalTax { Amount = totalTaxCents }],
+        PeriodEnd = periodEnd,
+    };
+
+    [Fact]
+    public void Summarize_EmptyBucket_ReturnsNull()
+        => Assert.Null(ProrationMapper.Summarize([], InvoiceWith(0, 0, new DateTime(2027, 1, 1))));
+
+    [Fact]
+    public void Summarize_SplitsChargeCreditAndNet_InDollars()
+    {
+        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 0, periodEnd: new DateTime(2027, 1, 1));
+        var result = ProrationMapper.Summarize([Line(7_355), Line(-3_773)], invoice)!;
+        Assert.Equal(73.55m, result.Charge);
+        Assert.Equal(37.73m, result.Credit);
+        Assert.Equal(35.82m, result.Total);
+    }
+
+    [Fact]
+    public void Summarize_EntirelyNegativeBucket_IsAllCredit()
+    {
+        var invoice = InvoiceWith(11_982, 0, new DateTime(2027, 1, 1));
+        var result = ProrationMapper.Summarize([Line(-2_507), Line(-1_275)], invoice)!;
+        Assert.Equal(0m, result.Charge);
+        Assert.Equal(37.82m, result.Credit);
+        Assert.Equal(-37.82m, result.Total);
+    }
+
+    [Fact]
+    public void Summarize_AllocatesTax_ProportionalToNetOverInvoiceTotal()
+    {
+        // net 3_582 of total 11_982; tax 1_207 -> 1207 * (3582/11982) / 100 = 3.6086...
+        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 1_207, periodEnd: new DateTime(2027, 1, 1));
+        var result = ProrationMapper.Summarize([Line(7_355), Line(-3_773)], invoice)!;
+        Assert.Equal(1207m * (3582m / 11982m) / 100m, result.Tax);
+    }
+
+    [Fact]
+    public void Summarize_ZeroInvoiceTotal_YieldsZeroTax()
+    {
+        var invoice = InvoiceWith(totalCents: 0, totalTaxCents: 1_207, periodEnd: new DateTime(2027, 1, 1));
+        var result = ProrationMapper.Summarize([Line(3_582)], invoice)!;
+        Assert.Equal(0m, result.Tax);
+    }
+
+    [Fact]
+    public void Summarize_Months_FromLinePeriodEndToInvoicePeriodEnd_FlooredAtZero()
+    {
+        var invoice = InvoiceWith(3_582, 0, periodEnd: new DateTime(2027, 1, 1));
+        Assert.Equal(11, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2026, 2, 1))], invoice)!.Months);
+        // line end after invoice end -> floored to 0
+        Assert.Equal(0, ProrationMapper.Summarize([Line(3_582, periodEnd: new DateTime(2027, 6, 1))], invoice)!.Months);
+        // no period -> 0
+        Assert.Equal(0, ProrationMapper.Summarize([Line(3_582)], invoice)!.Months);
+    }
+}

--- a/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/ProrationMapperTests.cs
@@ -72,4 +72,17 @@ public class ProrationMapperTests
         // no period -> 0
         Assert.Equal(0, ProrationMapper.Summarize([Line(3_582)], invoice)!.Months);
     }
+
+    [Fact]
+    public void Summarize_MultipleTaxesOnOneLine_SumsThem()
+    {
+        var invoice = InvoiceWith(totalCents: 11_982, totalTaxCents: 0, periodEnd: new DateTime(2027, 1, 1));
+        var line = new InvoiceLineItem
+        {
+            Amount = 7_355,
+            Taxes = [new InvoiceLineItemTax { Amount = 500 }, new InvoiceLineItemTax { Amount = 236 }],
+        };
+        var result = ProrationMapper.Summarize([line], invoice)!;
+        Assert.Equal(7.36m, result.Tax);
+    }
 }

--- a/test/Libraries/Invoicing.Test/PurchasableReferencesTests.cs
+++ b/test/Libraries/Invoicing.Test/PurchasableReferencesTests.cs
@@ -30,4 +30,8 @@ public class PurchasableReferencesTests
     [InlineData(StripeConstants.PurchasableReferences.SecretsManagerServiceAccount, ProductType.SecretsManager)]
     public void ProductOf_MapsReferenceToProduct(string reference, ProductType expected)
         => Assert.Equal(expected, PurchasableReferences.ProductOf(reference));
+
+    [Fact]
+    public void ProductOf_UnknownReference_ReturnsNull()
+        => Assert.Null(PurchasableReferences.ProductOf("fake-reference"));
 }

--- a/test/Libraries/Invoicing.Test/PurchasableReferencesTests.cs
+++ b/test/Libraries/Invoicing.Test/PurchasableReferencesTests.cs
@@ -1,0 +1,32 @@
+﻿using Bit.Core.Billing.Constants;
+using Bit.Core.Billing.Enums;
+using Bit.Invoicing.InvoicePreviews;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class PurchasableReferencesTests
+{
+    [Theory]
+    [InlineData(StripeConstants.PurchasableReferences.PasswordManagerSeat)]
+    [InlineData(StripeConstants.PurchasableReferences.PasswordManagerStorage)]
+    [InlineData(StripeConstants.PurchasableReferences.SecretsManagerSeat)]
+    [InlineData(StripeConstants.PurchasableReferences.SecretsManagerServiceAccount)]
+    public void IsKnown_TrueForKnownReference(string reference)
+        => Assert.True(PurchasableReferences.IsKnown(reference));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("provider-seat")]
+    [InlineData("PM-SEAT")]
+    public void IsKnown_FalseForUnknownReference(string reference)
+        => Assert.False(PurchasableReferences.IsKnown(reference));
+
+    [Theory]
+    [InlineData(StripeConstants.PurchasableReferences.PasswordManagerSeat, ProductType.PasswordManager)]
+    [InlineData(StripeConstants.PurchasableReferences.PasswordManagerStorage, ProductType.PasswordManager)]
+    [InlineData(StripeConstants.PurchasableReferences.SecretsManagerSeat, ProductType.SecretsManager)]
+    [InlineData(StripeConstants.PurchasableReferences.SecretsManagerServiceAccount, ProductType.SecretsManager)]
+    public void ProductOf_MapsReferenceToProduct(string reference, ProductType expected)
+        => Assert.Equal(expected, PurchasableReferences.ProductOf(reference));
+}

--- a/test/Libraries/Invoicing.Test/PurchasableReferencesTests.cs
+++ b/test/Libraries/Invoicing.Test/PurchasableReferencesTests.cs
@@ -17,9 +17,10 @@ public class PurchasableReferencesTests
 
     [Theory]
     [InlineData("")]
+    [InlineData(null)]
     [InlineData("provider-seat")]
     [InlineData("PM-SEAT")]
-    public void IsKnown_FalseForUnknownReference(string reference)
+    public void IsKnown_FalseForUnknownReference(string? reference)
         => Assert.False(PurchasableReferences.IsKnown(reference));
 
     [Theory]

--- a/test/Libraries/Invoicing.Test/RecordingLogger.cs
+++ b/test/Libraries/Invoicing.Test/RecordingLogger.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 
 namespace Bit.Invoicing.Test;
 

--- a/test/Libraries/Invoicing.Test/RecordingLogger.cs
+++ b/test/Libraries/Invoicing.Test/RecordingLogger.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+namespace Bit.Invoicing.Test;
+
+internal sealed class RecordingLogger<T> : ILogger<T>
+{
+    private readonly List<string> _errors = [];
+    public IReadOnlyList<string> Errors => _errors;
+
+    IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (logLevel == LogLevel.Error)
+        {
+            _errors.Add(formatter(state, exception));
+        }
+    }
+}

--- a/test/Libraries/Invoicing.Test/StripeConstantsPurchasableReferenceTests.cs
+++ b/test/Libraries/Invoicing.Test/StripeConstantsPurchasableReferenceTests.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Constants;
+﻿using Bit.Core.Billing.Constants;
 using Xunit;
 
 namespace Bit.Invoicing.Test;

--- a/test/Libraries/Invoicing.Test/StripeConstantsPurchasableReferenceTests.cs
+++ b/test/Libraries/Invoicing.Test/StripeConstantsPurchasableReferenceTests.cs
@@ -1,0 +1,13 @@
+using Bit.Core.Billing.Constants;
+using Xunit;
+
+namespace Bit.Invoicing.Test;
+
+public class StripeConstantsPurchasableReferenceTests
+{
+    [Fact] public void MetadataKey_IsPurchasableReference() => Assert.Equal("purchasable_reference", StripeConstants.MetadataKeys.PurchasableReference);
+    [Fact] public void PasswordManagerSeat_IsPmSeat() => Assert.Equal("pm-seat", StripeConstants.PurchasableReferences.PasswordManagerSeat);
+    [Fact] public void PasswordManagerStorage_IsPmStorage() => Assert.Equal("pm-storage", StripeConstants.PurchasableReferences.PasswordManagerStorage);
+    [Fact] public void SecretsManagerSeat_IsSmSeat() => Assert.Equal("sm-seat", StripeConstants.PurchasableReferences.SecretsManagerSeat);
+    [Fact] public void SecretsManagerServiceAccount_IsSmServiceAccount() => Assert.Equal("sm-service-account", StripeConstants.PurchasableReferences.SecretsManagerServiceAccount);
+}

--- a/test/Libraries/Invoicing.Test/StripeFixtures.cs
+++ b/test/Libraries/Invoicing.Test/StripeFixtures.cs
@@ -1,0 +1,24 @@
+﻿using Stripe;
+
+namespace Bit.Invoicing.Test;
+
+internal static class StripeFixtures
+{
+    internal static Invoice SampleInvoiceWithPmSeat() => Invoice.FromJson("""
+    {
+      "id": "in_test", "total": 12790, "amount_due": 12790,
+      "lines": { "data": [
+        { "amount": 12790, "quantity": 5, "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } } }
+      ] }
+    }
+    """);
+
+    internal static Subscription SampleSubscriptionWithPmSeat() => Subscription.FromJson("""
+    {
+      "id": "sub_test",
+      "items": { "data": [
+        { "quantity": 5, "price": { "id": "price_pm", "unit_amount": 2558, "metadata": { "purchasable_reference": "pm-seat" } } }
+      ] }
+    }
+    """);
+}

--- a/test/Libraries/Invoicing.Test/packages.lock.json
+++ b/test/Libraries/Invoicing.Test/packages.lock.json
@@ -1345,7 +1345,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "serilogfilelogging": {

--- a/test/Libraries/Subscriptions.Organization.Test/packages.lock.json
+++ b/test/Libraries/Subscriptions.Organization.Test/packages.lock.json
@@ -1021,7 +1021,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "serilogfilelogging": {

--- a/test/Libraries/Subscriptions.User.Test/packages.lock.json
+++ b/test/Libraries/Subscriptions.User.Test/packages.lock.json
@@ -1021,7 +1021,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "serilogfilelogging": {

--- a/util/SqlServerEFScaffold/packages.lock.json
+++ b/util/SqlServerEFScaffold/packages.lock.json
@@ -1788,7 +1788,8 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.1, )"
+          "Core": "[2026.8.1, )",
+          "Stripe.net": "[52.1.0, 52.1.0]"
         }
       },
       "organizationauthorization": {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39925

## 📔 Objective

Fills in `Bit.Invoicing` with the invoice-preview projection: it fetches an upcoming Stripe invoice (or reads a subscription's current items when there is no upcoming invoice, such as a canceled or suspended subscription) and projects it into a vendor-neutral `InvoicePreview` record family for the cart screens to render.

- The public surface is `IInvoicePreviewService`; the builder, mappers, reference table, and Stripe client are internal, registered with `TryAddSingleton`.
- Each line resolves by a stable `purchasable_reference` value on the Stripe price metadata (`pm-seat`, `pm-storage`, `sm-seat`, `sm-service-account`), routed through a central reference-to-product table. There is deliberately no fallback to `Stripe.Price.Id`: an unresolved or unknown reference is logged and skipped, and a missing required Password Manager seats line throws before the preview is built.
- `DiscountMapper` splits coupons into cart-level and item-level buckets, matching item-scoped coupons onto their lines by `DiscountId` (the line-level discount object is unexpanded on real Stripe responses, so only the id is reliable). Unresolved or unattached coupons are logged rather than dropped silently.
- `ProrationMapper` folds each product's proration lines into a single credit, charge, and total row.
- All monetary values on the projection are dollars: Stripe integer cents are divided by decimal `100m`, never integer `100`.
- Adds the `purchasable_reference` metadata key and its reference values to Core's `StripeConstants`, and covers the projection with tests built on deserialized, production-shaped Stripe JSON rather than hand-built object graphs.

**Deliberate divergences from the technical breakdown:**

- **Proration bucket tax.** The breakdown specified the proration bucket's tax as a proportional allocation of the invoice tax total (the bucket's share of `invoice.TotalTaxes`). This projection instead sums Stripe's own per-line tax (`InvoiceLineItem.Taxes`) for the bucket. The proportional formula divided a pre-tax numerator (the line amount, which excludes tax) by a tax-inclusive denominator (`invoice.Total`), so it understated the tax whenever the invoice carried any; summing the tax Stripe has already computed also honors the breakdown's own rule that totals, tax, and discounts come straight from Stripe with no manual server-side tax calculation.
- **Distinct `InvoicePreviewDiscount` record** rather than extending Core's `BitwardenDiscount`. A required applied `Amount` would break `BitwardenDiscount`'s two implicit Stripe operators and its existing assignment sites, the projection never uses those operators, and the two paths disagree on units (the legacy value is cents, the projection's is dollars).
- **No domain `InvoicePreviewOptions`.** The public `IInvoicePreviewService` takes Stripe types (`InvoiceCreatePreviewOptions`, `Subscription`) directly. `Bit.Invoicing` is itself the Stripe boundary and is permitted to reference Stripe types, so a domain-options wrapper would protect no boundary (the breakdown contradicts itself on this point). The boundary the READMEs enforce is behavioral: consumers must not call Stripe, but passing Stripe types across the surface is allowed.
- **`StripeException` is not wrapped in this library.** Vendor-exception-to-domain translation belongs to the future `Bit.Integrations.Billing`; the endpoint groups' exception handling already logs server-side and returns a generic 500, so no raw Stripe detail leaks.

**Note on the 5-level expand.** `lines.data.pricing.price_details.price` looks like it exceeds Stripe's documented 4-level expand limit, but it doesn't: `.data` list accessors and inline sub-hashes (`pricing`, `price_details`) don't count as levels. Verified live against `create_preview` API  — the expand returns the full price object, and Stripe only rejects at 7 segments (`…price.product.default_price`).

This branch is stacked on the scaffolding PR; its base is `billing/PM-39925/invoice-preview-scaffolding`, which should be reviewed and merged first.



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>