### PR TITLE
fix(vault): skip key id validation for organization

### DIFF
--- a/src/Api/Vault/Controllers/CiphersController.cs
+++ b/src/Api/Vault/Controllers/CiphersController.cs
@@ -166,7 +166,7 @@ public class CiphersController : Controller
         var user = await _userService.GetUserByPrincipalAsync(User);
 
         // Validate the model was encrypted by the posting user
-        ValidateCipherEncryptedByUser(model, user);
+        ValidateCipherEncryptedByUser(model, user, model.IsOrganizationCipher);
 
         var cipher = model.ToCipherDetails(user.Id);
         if (cipher.OrganizationId.HasValue && !await _currentContext.OrganizationUser(cipher.OrganizationId.Value))
@@ -185,7 +185,7 @@ public class CiphersController : Controller
         var user = await _userService.GetUserByPrincipalAsync(User);
 
         // Validate the model was encrypted by the posting user
-        ValidateCipherEncryptedByUser(model.Cipher, user);
+        ValidateCipherEncryptedByUser(model.Cipher, user, model.Cipher.IsOrganizationCipher);
 
         var cipher = model.Cipher.ToCipherDetails(user.Id);
         if (cipher.OrganizationId.HasValue && !await _currentContext.OrganizationUser(cipher.OrganizationId.Value))
@@ -229,8 +229,9 @@ public class CiphersController : Controller
             throw new NotFoundException();
         }
 
-        // Validate the model was encrypted by the posting user
-        ValidateCipherEncryptedByUser(model, user, id);
+        // Validate the model was encrypted by the posting user, against the cipher we hold rather than
+        // the organization the client claims.
+        ValidateCipherEncryptedByUser(model, user, cipher.OrganizationId.HasValue, id);
 
         ValidateClientVersionForFido2CredentialSupport(cipher);
 
@@ -697,8 +698,9 @@ public class CiphersController : Controller
             throw new NotFoundException();
         }
 
-        // Validate the model was encrypted by the posting user
-        ValidateCipherEncryptedByUser(model.Cipher, user, id);
+        // Validate the model was encrypted by the posting user. Sharing always re-encrypts under the
+        // organization key, so there is no user key id to compare against.
+        ValidateCipherEncryptedByUser(model.Cipher, user, isOrganizationCipher: true, id);
 
         ValidateClientVersionForFido2CredentialSupport(cipher);
 
@@ -1638,17 +1640,28 @@ public class CiphersController : Controller
     }
 
     /// <summary>
-    /// Validates that the cipher in <paramref name="model"/> was encrypted by the acting user, with that
-    /// user's current user key.
+    /// Validates that the cipher in <paramref name="model"/> was encrypted by the acting user, with the
+    /// key that owns it.
     /// <para>
-    /// The key id is only compared when both sides are present: the client may predate the field, and the
-    /// user may not have a key id recorded yet. This mirrors
+    /// The key id check only applies to user-owned ciphers. An organization cipher is encrypted with the
+    /// organization key, and organizations carry no key id yet, so there is nothing to compare against.
+    /// Once organizations have a key id, compare against it here.
+    /// </para>
+    /// <para>
+    /// Even for a user-owned cipher the key id is only compared when both sides are present: the client
+    /// may predate the field, and the user may not have a key id recorded yet. This mirrors
     /// <see cref="Core.KeyManagement.Models.Data.MasterPasswordUnlockData.ValidateKeyIdUnchangedForUser"/>.
     /// </para>
     /// </summary>
-    private void ValidateCipherEncryptedByUser(CipherRequestModel model, User user, Guid? cipherId = null)
+    private void ValidateCipherEncryptedByUser(CipherRequestModel model, User user, bool isOrganizationCipher,
+        Guid? cipherId = null)
     {
         ValidateCipherEncryptedForUser(model, user.Id, cipherId);
+
+        if (isOrganizationCipher)
+        {
+            return;
+        }
 
         var currentUserKeyId = user.GetUserKeyId();
         var encryptedByKeyId = model.GetEncryptedByKeyId();

--- a/src/Api/Vault/Models/Request/CipherRequestModel.cs
+++ b/src/Api/Vault/Models/Request/CipherRequestModel.cs
@@ -20,8 +20,10 @@ public class CipherRequestModel
     public Guid? EncryptedFor { get; set; }
 
     /// <summary>
-    /// Hex-encoded key id of the user key the client held when it encrypted this cipher. Absent for
-    /// clients that predate the field. When present, it must match the acting user's current user key id.
+    /// Hex-encoded key id of the key the client held when it encrypted this cipher: the user key for a
+    /// user-owned cipher, the organization key for an organization cipher. Absent for clients that
+    /// predate the field. For a user-owned cipher it must match the acting user's current user key id;
+    /// for an organization cipher it is not validated, because organizations carry no key id yet.
     /// </summary>
     [KeyId]
     public string EncryptedByKeyId { get; set; }
@@ -83,9 +85,15 @@ public class CipherRequestModel
     public KeyId GetEncryptedByKeyId() =>
         KeyId.FromHexEncodedString(string.IsNullOrEmpty(EncryptedByKeyId) ? null : EncryptedByKeyId);
 
+    /// <summary>
+    /// True when this cipher is owned by an organization, and so is encrypted with the organization
+    /// key rather than the acting user's key.
+    /// </summary>
+    public bool IsOrganizationCipher => !string.IsNullOrWhiteSpace(OrganizationId);
+
     public CipherDetails ToCipherDetails(Guid userId, bool allowOrgIdSet = true)
     {
-        var hasOrgId = !string.IsNullOrWhiteSpace(OrganizationId);
+        var hasOrgId = IsOrganizationCipher;
         var cipher = new CipherDetails
         {
             Type = Type,

--- a/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
+++ b/test/Api.Test/Vault/Controllers/CiphersControllerTests.cs
@@ -2680,17 +2680,18 @@ public class CiphersControllerTests
     }
 
     [Theory, BitAutoData]
-    public async Task PutShare_EncryptedByKeyIdDoesNotMatchUserKeyId_ThrowsBadRequestException(
+    public async Task PutShare_DoesNotValidateEncryptedByKeyId(
         User user,
         Guid cipherId,
         Guid organizationId,
         SutProvider<CiphersController> sutProvider)
     {
+        // Sharing re-encrypts the cipher under the organization key, so the key id the client sends is
+        // the organization's, not the user's, and there is nothing to compare it against.
         user.UserKeyId = KeyIdBuilder.HexEncodedKeyId;
         sutProvider.GetDependency<IUserService>()
             .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
             .Returns(user);
-        // Ownership and organization membership are checked before validation.
         sutProvider.GetDependency<ICipherRepository>()
             .GetByIdAsync(cipherId)
             .Returns(new Cipher
@@ -2700,9 +2701,21 @@ public class CiphersControllerTests
                 Type = CipherType.Login,
                 Data = "{}"
             });
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId, user.Id)
+            .Returns(new CipherDetails
+            {
+                Id = cipherId,
+                OrganizationId = organizationId,
+                Type = CipherType.Login,
+                Data = "{}"
+            });
         sutProvider.GetDependency<ICurrentContext>()
             .OrganizationUser(organizationId)
             .Returns(true);
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { Id = organizationId });
 
         var cipherModel = SecureNoteRequestModel(MismatchedKeyId);
         cipherModel.OrganizationId = organizationId.ToString();
@@ -2712,11 +2725,137 @@ public class CiphersControllerTests
             CollectionIds = [Guid.NewGuid().ToString()]
         };
 
-        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.PutShare(cipherId, model));
-        Assert.Contains("current user key", exception.Message);
+        await sutProvider.Sut.PutShare(cipherId, model);
+
+        await sutProvider.GetDependency<ICipherService>().Received(1)
+            .ShareAsync(Arg.Any<Cipher>(), Arg.Any<Cipher>(), organizationId, Arg.Any<IEnumerable<Guid>>(), user.Id,
+                Arg.Any<DateTime?>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task Post_OrganizationCipher_DoesNotValidateEncryptedByKeyId(
+        User user,
+        Guid organizationId,
+        SutProvider<CiphersController> sutProvider)
+    {
+        // An organization cipher is encrypted with the organization key, which has no key id yet.
+        user.UserKeyId = KeyIdBuilder.HexEncodedKeyId;
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationUser(organizationId)
+            .Returns(true);
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { Id = organizationId });
+
+        var model = SecureNoteRequestModel(MismatchedKeyId);
+        model.OrganizationId = organizationId.ToString();
+
+        await sutProvider.Sut.Post(model);
+
+        await sutProvider.GetDependency<ICipherService>().Received(1)
+            .SaveDetailsAsync(Arg.Any<CipherDetails>(), user.Id, Arg.Any<DateTime?>(), Arg.Any<IEnumerable<Guid>>(), Arg.Any<bool>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task Post_OrganizationCipher_EncryptedForOtherUser_ThrowsBadRequestException(
+        User user,
+        Guid organizationId,
+        SutProvider<CiphersController> sutProvider)
+    {
+        // The legacy EncryptedFor check identifies the posting user, not a key, so it still applies.
+        user.UserKeyId = KeyIdBuilder.HexEncodedKeyId;
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+
+        var model = SecureNoteRequestModel(null);
+        model.OrganizationId = organizationId.ToString();
+#pragma warning disable CS0618
+        model.EncryptedFor = Guid.NewGuid(); // not equal to user.Id
+#pragma warning restore CS0618
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => sutProvider.Sut.Post(model));
+        Assert.Contains("encrypted for the current user", exception.Message);
 
         await sutProvider.GetDependency<ICipherService>().DidNotReceiveWithAnyArgs()
-            .ShareAsync(default, default, default, default, default, default);
+            .SaveDetailsAsync(default, default, default, default, default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task PostCreate_OrganizationCipher_DoesNotValidateEncryptedByKeyId(
+        User user,
+        Guid organizationId,
+        SutProvider<CiphersController> sutProvider)
+    {
+        user.UserKeyId = KeyIdBuilder.HexEncodedKeyId;
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+        sutProvider.GetDependency<ICurrentContext>()
+            .OrganizationUser(organizationId)
+            .Returns(true);
+        // PostCreate re-reads the saved cipher to build its response.
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(Arg.Any<Guid>(), user.Id)
+            .Returns(new CipherDetails
+            {
+                OrganizationId = organizationId,
+                Type = CipherType.SecureNote,
+                Data = "{}"
+            });
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { Id = organizationId });
+
+        var cipherModel = SecureNoteRequestModel(MismatchedKeyId);
+        cipherModel.OrganizationId = organizationId.ToString();
+        var model = new CipherCreateRequestModel
+        {
+            Cipher = cipherModel,
+            CollectionIds = []
+        };
+
+        await sutProvider.Sut.PostCreate(model);
+
+        await sutProvider.GetDependency<ICipherService>().Received(1)
+            .SaveDetailsAsync(Arg.Any<CipherDetails>(), user.Id, Arg.Any<DateTime?>(), Arg.Any<IEnumerable<Guid>>(), Arg.Any<bool>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task Put_OrganizationCipher_DoesNotValidateEncryptedByKeyId(
+        User user,
+        Guid cipherId,
+        Guid organizationId,
+        SutProvider<CiphersController> sutProvider)
+    {
+        user.UserKeyId = KeyIdBuilder.HexEncodedKeyId;
+        sutProvider.GetDependency<IUserService>()
+            .GetUserByPrincipalAsync(Arg.Any<ClaimsPrincipal>())
+            .Returns(user);
+        // Organization ownership is read off the cipher we hold, not off the model.
+        sutProvider.GetDependency<ICipherRepository>()
+            .GetByIdAsync(cipherId, user.Id)
+            .Returns(new CipherDetails
+            {
+                Id = cipherId,
+                OrganizationId = organizationId,
+                Type = CipherType.SecureNote,
+                Data = "{}"
+            });
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility { Id = organizationId });
+
+        var model = SecureNoteRequestModel(MismatchedKeyId);
+        model.OrganizationId = organizationId.ToString();
+
+        await sutProvider.Sut.Put(cipherId, model);
+
+        await sutProvider.GetDependency<ICipherService>().Received(1)
+            .SaveDetailsAsync(Arg.Any<CipherDetails>(), user.Id, Arg.Any<DateTime?>(), Arg.Any<IEnumerable<Guid>>(), Arg.Any<bool>());
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
https://bitwarden.atlassian.net/browse/PM-40814

Accidentally, we check the user-key-id for all cipher updates including organization cipher updates. We have follow-up work to post and check the organization key id, but this is not currently the case. We should ignore it, otherwise cipher updates will fail.