### PR TITLE
[PM-40350] ManagePolicies should allow read-only access to claimed organization domains

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
@@ -48,7 +48,18 @@ public class OrganizationDomainController : Controller
     [HttpGet("{orgId}/domain")]
     public async Task<ListResponseModel<OrganizationDomainResponseModel>> GetAll(Guid orgId)
     {
-        await ValidateOrganizationAccessAsync(orgId);
+        // The Send Policy edit dialog will call this endpoint to read all claimed domains
+        // The validation used elsewhere in this controller gates on ManageSso policy alone
+        if (!await _currentContext.ManageSso(orgId) && !await _currentContext.ManagePolicies(orgId))
+        {
+            throw new UnauthorizedAccessException();
+        }
+
+        var organization = await _organizationRepository.GetByIdAsync(orgId);
+        if (organization == null)
+        {
+            throw new NotFoundException();
+        }
 
         var domains = await _getOrganizationDomainByOrganizationIdQuery
             .GetDomainsByOrganizationIdAsync(orgId);

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationDomainControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationDomainControllerTests.cs
@@ -34,6 +34,21 @@ public class OrganizationDomainControllerTests
     }
 
     [Theory, BitAutoData]
+    public async Task Get_ShouldReturnOrganizationDomainList_WhenOrgIdCanManagePoliciesOnly(Guid orgId,
+        SutProvider<OrganizationDomainController> sutProvider)
+    {
+        sutProvider.GetDependency<ICurrentContext>().ManageSso(orgId).Returns(false);
+        sutProvider.GetDependency<ICurrentContext>().ManagePolicies(orgId).Returns(true);
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(orgId).Returns(new Organization());
+        sutProvider.GetDependency<IGetOrganizationDomainByOrganizationIdQuery>()
+            .GetDomainsByOrganizationIdAsync(orgId).Returns(new List<OrganizationDomain>());
+
+        var result = await sutProvider.Sut.GetAll(orgId);
+
+        Assert.IsType<ListResponseModel<OrganizationDomainResponseModel>>(result);
+    }
+
+    [Theory, BitAutoData]
     public async Task Get_ShouldNotFound_WhenOrganizationDoesNotExist(Guid orgId,
         SutProvider<OrganizationDomainController> sutProvider)
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40350

## 📔 Objective

This PR modifies policy gated logic to allow users having the `ManagePolicies` role to access a read-only endpoint and enumerate claimed domains for organizations they belong to and have been granted this role on behalf of. 

This is necessary so that the Send Policy edit dialog populates domains claimed by an organization, and is a proper fix compared to the [previous bandaid](https://github.com/bitwarden/clients/pull/21836/changes). 