### PR TITLE
Ensure seeder appsettings.{env}.json can be found

### DIFF
--- a/util/SeederUtility/Commands/IndividualArgs.cs
+++ b/util/SeederUtility/Commands/IndividualArgs.cs
@@ -34,7 +34,7 @@ public class IndividualArgs : IArgumentModel
     public bool SelfHosted { get; set; }
 
     [Option("account-age-days", Description = "Backdate the account's CreationDate by N days (default: 0 = today)")]
-    public int AccountAgeDays { get; set; }
+    public int? AccountAgeDays { get; set; }
 
     [Option("mangle", Description = "Enable ID mangling for test isolation")]
     public bool Mangle { get; set; }
@@ -82,6 +82,6 @@ public class IndividualArgs : IArgumentModel
         Password = Password,
         KdfIterations = KdfIterations,
         SelfHosted = SelfHosted,
-        AccountAgeDays = AccountAgeDays
+        AccountAgeDays = AccountAgeDays ?? 0
     };
 }

--- a/util/SeederUtility/Configuration/GlobalSettingsFactory.cs
+++ b/util/SeederUtility/Configuration/GlobalSettingsFactory.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Core.Settings;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace Bit.SeederUtility.Configuration;
 
@@ -14,18 +15,22 @@ public static class GlobalSettingsFactory
 
     private static GlobalSettings LoadGlobalSettings()
     {
-        var configBuilder = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
-            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true, reloadOnChange: true)
-            .AddUserSecrets("bitwarden-seeder-utility")
-            .AddEnvironmentVariables();
+        // The generic host only reads DOTNET_ENVIRONMENT, while the rest of the repo keys off
+        // ASPNETCORE_ENVIRONMENT; honor both. The seeder is a local development tool, so fall
+        // back to Development rather than Production so appsettings.Development.json applies.
+        var environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+                          ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
+                          ?? Environments.Development;
 
-        var configuration = configBuilder.Build();
-        var globalSettingsSection = configuration.GetSection("globalSettings");
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            // Resolve appsettings files next to the binary, not the caller's working directory.
+            ContentRootPath = AppContext.BaseDirectory,
+            EnvironmentName = environment,
+        });
 
         var settings = new GlobalSettings();
-        globalSettingsSection.Bind(settings);
+        builder.Configuration.GetSection("globalSettings").Bind(settings);
 
         return settings;
     }

--- a/util/SeederUtility/SeederUtility.csproj
+++ b/util/SeederUtility/SeederUtility.csproj
@@ -19,4 +19,13 @@
     <PackageReference Include="Spectre.Console" Version="[0.55.2]" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## 🎟️ Tracking

No Jira issue. Supersedes #8154 (thanks @patriksvensson — your commit is carried over with authorship intact), reworked per the feedback there from @Hinton and @justindbaur.

## 📔 Objective

Make the seeder find its `appsettings.{env}.json` files again, without requiring everyone to hand-set connection strings in user secrets.

`GlobalSettingsFactory` resolved configuration from the caller's working directory, so the appsettings files were never found when launching via `dev/seed.ps1` (cwd is `dev/`) — and they were not copied to the build output at all. This became a real problem with #7953, which made the seeder read attachment storage settings from configuration: with the appsettings never loading, storage resolved to Noop and attachment fixtures failed unless the connection string was manually added to user secrets.

Changes:

- Copy `appsettings.json` / `appsettings.Development.json` to the output directory (from #8154).
- Replace the hand-rolled `ConfigurationBuilder` with `Host.CreateApplicationBuilder` conventions (the modern equivalent of `Host.CreateDefaultBuilder`, without building a throwaway host), anchored at `AppContext.BaseDirectory`.
- The environment honors `ASPNETCORE_ENVIRONMENT`, then `DOTNET_ENVIRONMENT`, then falls back to **Development** instead of Production — the seeder is a dev-only tool, so `appsettings.Development.json` (Azurite connection strings) applies out of the box. User secrets now load via the project's existing `UserSecretsId` (`bitwarden-seeder-utility`), the same store `dev/setup_secrets.ps1` populates.

Verified end to end: from `dev/` with no environment variables set, `preset --name individual.encryption-modes` (the attachments fixture) seeds successfully against a local SqlServer + Azurite — previously it failed fast with Noop attachment storage.


---

Also includes a one-commit fix for #8201: `--account-age-days` was declared as a bare `int`, which CommandDotNet treats as required (0 is indistinguishable from "no default"), breaking every `individual` seed — including `dev/seed.ps1`. Declared as `int?` with the documented default of 0 applied in `ToOptions()`.
