### PR TITLE
[PM-42157] fix: register separate memory caches for icons and change-password URIs

### DIFF
--- a/src/Icons/Controllers/ChangePasswordUriController.cs
+++ b/src/Icons/Controllers/ChangePasswordUriController.cs
@@ -16,7 +16,7 @@ public class ChangePasswordUriController : Controller
     private readonly ILogger<ChangePasswordUriController> _logger;
 
     public ChangePasswordUriController(
-        IMemoryCache memoryCache,
+        [FromKeyedServices(IconsCacheConstants.ChangePasswordUriCacheName)] IMemoryCache memoryCache,
         IDomainMappingService domainMappingService,
         IChangePasswordUriService changePasswordService,
         ChangePasswordUriSettings changePasswordUriSettings,

--- a/src/Icons/Controllers/IconsController.cs
+++ b/src/Icons/Controllers/IconsController.cs
@@ -28,7 +28,7 @@ public class IconsController : Controller
     private readonly IconsSettings _iconsSettings;
 
     public IconsController(
-        IMemoryCache memoryCache,
+        [FromKeyedServices(IconsCacheConstants.IconsCacheName)] IMemoryCache memoryCache,
         IDomainMappingService domainMappingService,
         IIconFetchingService iconFetchingService,
         ILogger<IconsController> logger,

--- a/src/Icons/IconsCacheConstants.cs
+++ b/src/Icons/IconsCacheConstants.cs
@@ -1,0 +1,19 @@
+namespace Bit.Icons;
+
+/// <summary>
+/// Service keys for the memory caches used by the Icons service. Each cache is registered as a
+/// separate keyed <see cref="Microsoft.Extensions.Caching.Memory.IMemoryCache"/> so that the icon
+/// and change-password-URI caches are sized and evicted independently of one another.
+/// </summary>
+public static class IconsCacheConstants
+{
+    /// <summary>
+    /// The cache used by the icons endpoint to store fetched favicons.
+    /// </summary>
+    public const string IconsCacheName = "Icons";
+
+    /// <summary>
+    /// The cache used by the change-password-URI endpoint to store resolved URIs.
+    /// </summary>
+    public const string ChangePasswordUriCacheName = "ChangePasswordUri";
+}

--- a/src/Icons/Startup.cs
+++ b/src/Icons/Startup.cs
@@ -37,14 +37,7 @@ public class Startup
         services.AddHtmlParsing();
 
         // Cache
-        services.AddMemoryCache(options =>
-        {
-            options.SizeLimit = iconsSettings.CacheSizeLimit;
-        });
-        services.AddMemoryCache(options =>
-        {
-            options.SizeLimit = changePasswordUriSettings.CacheSizeLimit;
-        });
+        services.AddCaches(iconsSettings, changePasswordUriSettings);
 
         // Services
         services.AddServices();

--- a/src/Icons/Util/ServiceCollectionExtension.cs
+++ b/src/Icons/Util/ServiceCollectionExtension.cs
@@ -3,7 +3,11 @@
 using System.Net;
 using AngleSharp.Html.Parser;
 using Bit.Core.Utilities;
+using Bit.Icons.Models;
 using Bit.Icons.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Bit.Icons.Extensions;
 
@@ -52,6 +56,28 @@ public static class ServiceCollectionExtension
     public static void AddHtmlParsing(this IServiceCollection services)
     {
         services.AddSingleton<IHtmlParser, HtmlParser>();
+    }
+
+    /// <summary>
+    /// Registers a separate <see cref="IMemoryCache"/> for each consumer, keyed by the names in
+    /// <see cref="IconsCacheConstants"/>. Two calls to <c>AddMemoryCache</c> would not do this:
+    /// it registers <see cref="IMemoryCache"/> with <c>TryAdd</c>, so the second call adds no
+    /// second cache and only appends another options callback, leaving both consumers sharing one
+    /// cache sized by whichever limit was configured last.
+    /// </summary>
+    public static void AddCaches(this IServiceCollection services, IconsSettings iconsSettings,
+        ChangePasswordUriSettings changePasswordUriSettings)
+    {
+        services.TryAddKeyedSingleton<IMemoryCache>(IconsCacheConstants.IconsCacheName, (_, _) =>
+            new MemoryCache(Options.Create(new MemoryCacheOptions
+            {
+                SizeLimit = iconsSettings.CacheSizeLimit
+            })));
+        services.TryAddKeyedSingleton<IMemoryCache>(IconsCacheConstants.ChangePasswordUriCacheName, (_, _) =>
+            new MemoryCache(Options.Create(new MemoryCacheOptions
+            {
+                SizeLimit = changePasswordUriSettings.CacheSizeLimit
+            })));
     }
 
     public static void AddServices(this IServiceCollection services)

--- a/test/Icons.Test/Util/ServiceCollectionExtensionTests.cs
+++ b/test/Icons.Test/Util/ServiceCollectionExtensionTests.cs
@@ -1,0 +1,72 @@
+using Bit.Icons.Extensions;
+using Bit.Icons.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Bit.Icons.Test.Util;
+
+public class ServiceCollectionExtensionTests
+{
+    private const long _iconsCacheSizeLimit = 100;
+    private const long _changePasswordUriCacheSizeLimit = 10_000;
+
+    /// <summary>
+    /// Builds a provider with deliberately different size limits for the two caches, so that a
+    /// single shared cache cannot satisfy both.
+    /// </summary>
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddCaches(
+            new IconsSettings { CacheSizeLimit = _iconsCacheSizeLimit },
+            new ChangePasswordUriSettings { CacheSizeLimit = _changePasswordUriCacheSizeLimit });
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void AddCaches_RegistersTwoDistinctCaches()
+    {
+        using var provider = BuildProvider();
+
+        var iconsCache = provider.GetRequiredKeyedService<IMemoryCache>(IconsCacheConstants.IconsCacheName);
+        var changePasswordUriCache =
+            provider.GetRequiredKeyedService<IMemoryCache>(IconsCacheConstants.ChangePasswordUriCacheName);
+
+        Assert.NotSame(iconsCache, changePasswordUriCache);
+    }
+
+    [Fact]
+    public void AddCaches_CachesDoNotShareEntries()
+    {
+        using var provider = BuildProvider();
+        var iconsCache = provider.GetRequiredKeyedService<IMemoryCache>(IconsCacheConstants.IconsCacheName);
+        var changePasswordUriCache =
+            provider.GetRequiredKeyedService<IMemoryCache>(IconsCacheConstants.ChangePasswordUriCacheName);
+
+        iconsCache.Set("example.com", "icons-value", new MemoryCacheEntryOptions { Size = 1 });
+
+        Assert.False(changePasswordUriCache.TryGetValue("example.com", out _));
+    }
+
+    [Fact]
+    public void AddCaches_EachCacheUsesItsOwnSizeLimit()
+    {
+        // An entry larger than a cache's SizeLimit is rejected outright, so an entry sized between
+        // the two limits is accepted by one cache and refused by the other only if each cache is
+        // using its own configured limit.
+        const int entrySize = 500;
+
+        using var provider = BuildProvider();
+        var iconsCache = provider.GetRequiredKeyedService<IMemoryCache>(IconsCacheConstants.IconsCacheName);
+        var changePasswordUriCache =
+            provider.GetRequiredKeyedService<IMemoryCache>(IconsCacheConstants.ChangePasswordUriCacheName);
+
+        iconsCache.Set("example.com", "icons-value", new MemoryCacheEntryOptions { Size = entrySize });
+        changePasswordUriCache.Set("example.com", "change-password-value",
+            new MemoryCacheEntryOptions { Size = entrySize });
+
+        Assert.False(iconsCache.TryGetValue("example.com", out _));
+        Assert.True(changePasswordUriCache.TryGetValue("example.com", out _));
+    }
+}


### PR DESCRIPTION
AddMemoryCache registers IMemoryCache with TryAdd, so calling it twice created one shared cache rather than two. The second options callback also won, silently discarding IconsSettings.CacheSizeLimit. Register each cache as its own keyed singleton so both honour their configured size limits independently.

Fixes #7701

## 🎟️ Tracking

#7701 (PM-37996)
https://github.com/bitwarden/server/issues/7701

## 📔 Objective

`Startup.ConfigureServices` called `services.AddMemoryCache(...)` twice, intending one cache for
`IconsController` and one for `ChangePasswordUriController`. Because `AddMemoryCache` registers
`IMemoryCache` via `TryAdd`, the second call registers no second cache — it only appends another
options callback. Both controllers therefore shared a single cache whose `SizeLimit` came from
whichever value was configured last (`ChangePasswordUriSettings.CacheSizeLimit`), silently
discarding `IconsSettings.CacheSizeLimit`. Cached icons were then evicted under a size budget
never intended for them, matching the reported symptom of icons disappearing.

This registers the two caches as separate keyed singletons, so each honours its own configured
`CacheSizeLimit` and neither evicts the other's entries. Keyed registration follows the existing
pattern in the codebase (e.g. `[FromKeyedServices(OrganizationReportCacheConstants.CacheName)]`).

The registration moved into an `AddCaches` extension method alongside the existing
`ConfigureHttpClients` / `AddHtmlParsing` / `AddServices`, which also makes it directly testable.
Added tests cover that the two caches are distinct instances, do not share entries, and each
applies its own size limit.

**Note for reviewers:** deployments that configured only `IconsSettings.CacheSizeLimit`
previously ended up with no effective limit at all; that limit now takes effect, so their icon
cache will begin evicting. The default configuration (`null` for both) is unchanged.
