### PR TITLE
PM-42152 - Open Org Invite Status Endpoint - Decode org name 

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkStatusQuery.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/GetOrganizationInviteLinkStatusQuery.cs
@@ -33,7 +33,7 @@ public class GetOrganizationInviteLinkStatusQuery(
         if (!organization.UseInviteLinks)
         {
             return new OrganizationInviteLinkStatus(
-                organization.Name, LinksEnabled: false, SeatsAvailable: false, SupportsConfirmation: false, Sso: null);
+                organization.DisplayName(), LinksEnabled: false, SeatsAvailable: false, SupportsConfirmation: false, Sso: null);
         }
 
         var occupied = (await organizationRepository
@@ -43,7 +43,7 @@ public class GetOrganizationInviteLinkStatusQuery(
         var sso = seatsAvailable ? await GetSsoStatusAsync(organization) : null;
 
         return new OrganizationInviteLinkStatus(
-            organization.Name, LinksEnabled: true, seatsAvailable, inviteLink.SupportsConfirmation, sso);
+            organization.DisplayName(), LinksEnabled: true, seatsAvailable, inviteLink.SupportsConfirmation, sso);
     }
 
     private async Task<OrganizationInviteLinkSsoStatus?> GetSsoStatusAsync(Organization organization)

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationInviteLinksControllerTests.cs
@@ -464,6 +464,44 @@ public class OrganizationInviteLinksControllerTests : IClassFixture<ApiApplicati
     }
 
     [Fact]
+    public async Task GetStatus_WithHtmlEncodedOrgName_ReturnsDecodedName()
+    {
+        // Organization.Name is stored HTML-encoded at write time (legacy XSS defense — see
+        // Admin OrganizationsController), so read paths must call Organization.DisplayName() to
+        // return a human-readable value. This test locks in that contract for the invite-link
+        // status endpoint so a raw Organization.Name regression can't ship literal entities
+        // (&amp;, &#39;, &quot;) to the client.
+        const string encodedName = "Acme &amp; &#39; &quot; Co.";
+        const string decodedName = "Acme & ' \" Co.";
+
+        var organizationRepository = _factory.Services.GetRequiredService<IOrganizationRepository>();
+        _organization.Name = encodedName;
+        await organizationRepository.ReplaceAsync(_organization);
+
+        var createRequest = new CreateOrganizationInviteLinkRequestModel
+        {
+            AllowedDomains = ["acme.com"],
+            Invite = _invite,
+            SupportsConfirmation = false,
+        };
+        var createResponse = await _client.PostAsJsonAsync(
+            $"/organizations/{_organization.Id}/invite-link", createRequest);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var created = await createResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkResponseModel>();
+        Assert.NotNull(created);
+
+        var anonClient = _factory.CreateClient();
+        var statusResponse = await anonClient.PostAsJsonAsync(
+            "/organizations/invite-link/status",
+            new GetOrganizationInviteLinkStatusRequestModel { OrganizationId = _organization.Id, Code = created.Code });
+
+        Assert.Equal(HttpStatusCode.OK, statusResponse.StatusCode);
+        var status = await statusResponse.Content.ReadFromJsonAsync<OrganizationInviteLinkStatusResponseModel>();
+        Assert.NotNull(status);
+        Assert.Equal(decodedName, status.OrganizationName);
+    }
+
+    [Fact]
     public async Task GetPolicies_WithExistingLink_ReturnsListResponseModel()
     {
         var createRequest = new CreateOrganizationInviteLinkRequestModel


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-42152

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
`Organization.Name` is stored HTML-encoded, so callers must invoke `DisplayName()` to return a human-readable value. The open org invite link status query was returning the raw encoded value, causing clients to render literal entities (`&amp;`, `&#39;`, `&quot;`) in the invite landing UI.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Before:

<img width="450" height="250" alt="image" src="https://github.com/user-attachments/assets/2938b9b1-97f7-425d-8996-c392a995f84f" />

After:

https://github.com/user-attachments/assets/b58474d3-3281-4523-b1c8-525d5f298312

