### PR TITLE
Tell clients which collections a PAM access rule governs

### DIFF
--- a/src/Api/AdminConsole/Models/Response/CollectionResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/CollectionResponseModel.cs
@@ -51,11 +51,18 @@ public class CollectionDetailsResponseModel : CollectionResponseModel
         HidePasswords = collectionDetails.HidePasswords;
         Manage = collectionDetails.Manage;
         DefaultUserCollectionEmail = collectionDetails.DefaultUserCollectionEmail;
+        HasEnabledAccessRule = collectionDetails.HasEnabledAccessRule;
     }
 
     public bool ReadOnly { get; set; }
     public bool HidePasswords { get; set; }
     public bool Manage { get; set; }
+
+    /// <summary>
+    /// True if the collection is governed by an access rule that is currently enabled. Lets a client
+    /// mark the collection as privileged without reading the organization's access rules.
+    /// </summary>
+    public bool HasEnabledAccessRule { get; set; }
 }
 
 public class CollectionAccessDetailsResponseModel : CollectionResponseModel
@@ -100,6 +107,7 @@ public class CollectionAccessDetailsResponseModel : CollectionResponseModel
         HidePasswords = collection.HidePasswords;
         Manage = collection.Manage;
         Unmanaged = collection.Unmanaged;
+        HasEnabledAccessRule = collection.HasEnabledAccessRule;
         Groups = collection.Groups?.Select(g => new SelectionReadOnlyResponseModel(g)) ?? Enumerable.Empty<SelectionReadOnlyResponseModel>();
         Users = collection.Users?.Select(g => new SelectionReadOnlyResponseModel(g)) ?? Enumerable.Empty<SelectionReadOnlyResponseModel>();
     }
@@ -116,4 +124,16 @@ public class CollectionAccessDetailsResponseModel : CollectionResponseModel
     public bool HidePasswords { get; set; }
     public bool Manage { get; set; }
     public bool Unmanaged { get; set; }
+
+    /// <summary>
+    /// True if the collection is governed by an access rule that is currently enabled. Lets a client
+    /// mark the collection as privileged without reading the organization's access rules.
+    /// </summary>
+    /// <remarks>
+    /// Only the <see cref="CollectionAdminDetails"/> constructor can populate this — it is computed by
+    /// the collection read paths. The bare <see cref="Collection"/> constructors are used for the
+    /// create/update responses and the provider fallbacks, which have no rule state to report and so
+    /// leave it false.
+    /// </remarks>
+    public bool HasEnabledAccessRule { get; set; }
 }

--- a/src/Core/AdminConsole/Models/Data/CollectionDetails.cs
+++ b/src/Core/AdminConsole/Models/Data/CollectionDetails.cs
@@ -21,4 +21,15 @@ public class CollectionDetails : Collection
     /// deleting it, and assigning access for other users and groups.
     /// </summary>
     public bool Manage { get; set; }
+    /// <summary>
+    /// If true, the collection is governed by an <c>AccessRule</c> that is currently enabled, so
+    /// items in it are gated behind PAM leasing.
+    /// </summary>
+    /// <remarks>
+    /// Derived, not stored: <see cref="Collection.AccessRuleId"/> records the association, but a
+    /// disabled rule gates nothing, so the read paths join the rule and report whether it is switched
+    /// on. Computed by the collection read procedures and their Entity Framework equivalents; a
+    /// <see cref="Collection"/> loaded outside those paths cannot tell you this.
+    /// </remarks>
+    public bool HasEnabledAccessRule { get; set; }
 }

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
@@ -260,7 +260,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         c.CreationDate,
                         c.RevisionDate,
                         c.ExternalId,
-                        c.Type
+                        c.Type,
+                        c.HasEnabledAccessRule
                     })
                     .Select(collectionGroup => new CollectionDetails
                     {
@@ -274,6 +275,7 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         HidePasswords = Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                         Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
                         Type = collectionGroup.Key.Type,
+                        HasEnabledAccessRule = collectionGroup.Key.HasEnabledAccessRule,
                     })
                     .ToList();
             }
@@ -287,7 +289,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                               c.CreationDate,
                               c.RevisionDate,
                               c.ExternalId,
-                              c.Type
+                              c.Type,
+                              c.HasEnabledAccessRule
                           } into collectionGroup
                           select new CollectionDetails
                           {
@@ -301,6 +304,7 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                               HidePasswords = Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                               Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
                               Type = collectionGroup.Key.Type,
+                              HasEnabledAccessRule = collectionGroup.Key.HasEnabledAccessRule,
                           }).ToListAsync();
         }
     }
@@ -328,7 +332,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         c.RevisionDate,
                         c.ExternalId,
                         c.Unmanaged,
-                        c.DefaultUserCollectionEmail
+                        c.DefaultUserCollectionEmail,
+                        c.HasEnabledAccessRule
                     }).Select(collectionGroup => new CollectionAdminDetails
                     {
                         Id = collectionGroup.Key.Id,
@@ -343,7 +348,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
                         Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned))),
                         Unmanaged = collectionGroup.Key.Unmanaged,
-                        DefaultUserCollectionEmail = collectionGroup.Key.DefaultUserCollectionEmail
+                        DefaultUserCollectionEmail = collectionGroup.Key.DefaultUserCollectionEmail,
+                        HasEnabledAccessRule = collectionGroup.Key.HasEnabledAccessRule
                     }).ToList();
             }
             else
@@ -358,7 +364,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                          c.RevisionDate,
                                          c.ExternalId,
                                          c.Unmanaged,
-                                         c.DefaultUserCollectionEmail
+                                         c.DefaultUserCollectionEmail,
+                                         c.HasEnabledAccessRule
                                      }
                     into collectionGroup
                                      select new CollectionAdminDetails
@@ -375,7 +382,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                          Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
                                          Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned))),
                                          Unmanaged = collectionGroup.Key.Unmanaged,
-                                         DefaultUserCollectionEmail = collectionGroup.Key.DefaultUserCollectionEmail
+                                         DefaultUserCollectionEmail = collectionGroup.Key.DefaultUserCollectionEmail,
+                                         HasEnabledAccessRule = collectionGroup.Key.HasEnabledAccessRule
                                      }).ToListAsync();
             }
 
@@ -441,7 +449,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                         c.Name,
                         c.CreationDate,
                         c.RevisionDate,
-                        c.ExternalId
+                        c.ExternalId,
+                        c.HasEnabledAccessRule
                     }).Select(collectionGroup => new CollectionAdminDetails
                     {
                         Id = collectionGroup.Key.Id,
@@ -455,7 +464,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                             Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                         Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
                         Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned))),
-                        Unmanaged = collectionGroup.Select(c => c.Unmanaged).FirstOrDefault()
+                        Unmanaged = collectionGroup.Select(c => c.Unmanaged).FirstOrDefault(),
+                        HasEnabledAccessRule = collectionGroup.Key.HasEnabledAccessRule
                     }).FirstOrDefault();
             }
             else
@@ -468,7 +478,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                                c.Name,
                                                c.CreationDate,
                                                c.RevisionDate,
-                                               c.ExternalId
+                                               c.ExternalId,
+                                               c.HasEnabledAccessRule
                                            }
                     into collectionGroup
                                            select new CollectionAdminDetails
@@ -484,7 +495,8 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                                                    Convert.ToBoolean(collectionGroup.Min(c => Convert.ToInt32(c.HidePasswords))),
                                                Manage = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Manage))),
                                                Assigned = Convert.ToBoolean(collectionGroup.Max(c => Convert.ToInt32(c.Assigned))),
-                                               Unmanaged = collectionGroup.Select(c => c.Unmanaged).FirstOrDefault()
+                                               Unmanaged = collectionGroup.Select(c => c.Unmanaged).FirstOrDefault(),
+                                               HasEnabledAccessRule = collectionGroup.Key.HasEnabledAccessRule
                                            }).FirstOrDefaultAsync();
             }
 

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/CollectionAdminDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/CollectionAdminDetailsQuery.cs
@@ -90,6 +90,8 @@ public class CollectionAdminDetailsQuery : IQuery<CollectionAdminDetails>
             Manage = (bool?)x.cu.Manage ?? (bool?)x.cg.Manage ?? false,
             Assigned = x.cu != null || x.cg != null,
             Unmanaged = !activeUserManageRights.Contains(x.c.Id) && !activeGroupManageRights.Contains(x.c.Id),
+            // A disabled rule gates nothing, so the association alone is not enough.
+            HasEnabledAccessRule = dbContext.AccessRules.Any(ar => ar.Id == x.c.AccessRuleId && ar.Enabled),
         });
     }
 

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/UserCollectionDetailsQuery.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/Queries/UserCollectionDetailsQuery.cs
@@ -61,7 +61,9 @@ public class UserCollectionDetailsQuery : IQuery<CollectionDetails>
             ReadOnly = (bool?)row.cu.ReadOnly ?? (bool?)row.cg.ReadOnly ?? false,
             HidePasswords = (bool?)row.cu.HidePasswords ?? (bool?)row.cg.HidePasswords ?? false,
             Manage = (bool?)row.cu.Manage ?? (bool?)row.cg.Manage ?? false,
-            Type = row.c.Type
+            Type = row.c.Type,
+            // A disabled rule gates nothing, so the association alone is not enough.
+            HasEnabledAccessRule = dbContext.AccessRules.Any(ar => ar.Id == row.c.AccessRuleId && ar.Enabled)
         });
     }
 }

--- a/src/Sql/dbo/AdminConsole/Stored Procedures/Collection_ReadByIdWithPermissions.sql
+++ b/src/Sql/dbo/AdminConsole/Stored Procedures/Collection_ReadByIdWithPermissions.sql
@@ -52,7 +52,11 @@ BEGIN
                 )
             THEN 1
             ELSE 0
-        END AS [Unmanaged]
+        END AS [Unmanaged],
+        -- Whether the collection is governed by an access rule that is currently switched on.
+        -- The rule row is functionally determined by C.[AccessRuleId], which is in the GROUP BY,
+        -- so MAX() picks the one value the group has rather than aggregating across rules.
+        MAX(CASE WHEN AR.[Enabled] = 1 THEN 1 ELSE 0 END) AS [HasEnabledAccessRule]
 	FROM
 	    [dbo].[CollectionView] C
 	LEFT JOIN
@@ -65,6 +69,8 @@ BEGIN
 	    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
 	LEFT JOIN
 	    [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+	LEFT JOIN
+	    [dbo].[AccessRule] AR ON AR.[Id] = C.[AccessRuleId]
 	WHERE
 	    C.[Id] = @CollectionId
     GROUP BY

--- a/src/Sql/dbo/AdminConsole/Stored Procedures/Collection_ReadByUserId.sql
+++ b/src/Sql/dbo/AdminConsole/Stored Procedures/Collection_ReadByUserId.sql
@@ -4,29 +4,37 @@ AS
 BEGIN
     SET NOCOUNT ON
 
+    -- Columns are qualified with UCD because the [AccessRule] join below also has [Id],
+    -- [OrganizationId] and [Name].
     SELECT
-        Id,
-        OrganizationId,
-        [Name],
-        CreationDate,
-        RevisionDate,
-        ExternalId,
-        MIN([ReadOnly]) AS [ReadOnly],
-        MIN([HidePasswords]) AS [HidePasswords],
-        MAX([Manage]) AS [Manage],
-        [DefaultUserCollectionEmail],
-        [Type],
-        [AccessRuleId]
+        UCD.[Id],
+        UCD.[OrganizationId],
+        UCD.[Name],
+        UCD.[CreationDate],
+        UCD.[RevisionDate],
+        UCD.[ExternalId],
+        MIN(UCD.[ReadOnly]) AS [ReadOnly],
+        MIN(UCD.[HidePasswords]) AS [HidePasswords],
+        MAX(UCD.[Manage]) AS [Manage],
+        UCD.[DefaultUserCollectionEmail],
+        UCD.[Type],
+        UCD.[AccessRuleId],
+        -- Whether the collection is governed by an access rule that is currently switched on.
+        -- The rule row is functionally determined by [AccessRuleId], which is in the GROUP BY, so
+        -- MAX() picks the one value the group has rather than aggregating across rules.
+        MAX(CASE WHEN AR.[Enabled] = 1 THEN 1 ELSE 0 END) AS [HasEnabledAccessRule]
     FROM
-        [dbo].[UserCollectionDetails](@UserId)
+        [dbo].[UserCollectionDetails](@UserId) UCD
+    LEFT JOIN
+        [dbo].[AccessRule] AR ON AR.[Id] = UCD.[AccessRuleId]
     GROUP BY
-        Id,
-        OrganizationId,
-        [Name],
-        CreationDate,
-        RevisionDate,
-        ExternalId,
-        [DefaultUserCollectionEmail],
-        [Type],
-        [AccessRuleId]
+        UCD.[Id],
+        UCD.[OrganizationId],
+        UCD.[Name],
+        UCD.[CreationDate],
+        UCD.[RevisionDate],
+        UCD.[ExternalId],
+        UCD.[DefaultUserCollectionEmail],
+        UCD.[Type],
+        UCD.[AccessRuleId]
 END

--- a/src/Sql/dbo/AdminConsole/Stored Procedures/Collection_ReadSharedCollectionsByOrganizationIdWithPermissions.sql
+++ b/src/Sql/dbo/AdminConsole/Stored Procedures/Collection_ReadSharedCollectionsByOrganizationIdWithPermissions.sql
@@ -52,7 +52,11 @@ BEGIN
                 )
             THEN 1
             ELSE 0
-        END AS [Unmanaged]
+        END AS [Unmanaged],
+        -- Whether the collection is governed by an access rule that is currently switched on.
+        -- The rule row is functionally determined by C.[AccessRuleId], which is in the GROUP BY,
+        -- so MAX() picks the one value the group has rather than aggregating across rules.
+        MAX(CASE WHEN AR.[Enabled] = 1 THEN 1 ELSE 0 END) AS [HasEnabledAccessRule]
     FROM
         [dbo].[CollectionView] C
     LEFT JOIN
@@ -65,6 +69,8 @@ BEGIN
         [dbo].[Group] G ON G.[Id] = GU.[GroupId]
     LEFT JOIN
         [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+    LEFT JOIN
+        [dbo].[AccessRule] AR ON AR.[Id] = C.[AccessRuleId]
     WHERE
         C.[OrganizationId] = @OrganizationId AND
         C.[Type] = 0 -- Only SharedCollection

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryHasEnabledAccessRuleTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryHasEnabledAccessRuleTests.cs
@@ -1,0 +1,201 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Entities;
+using Bit.Core.Models.Data;
+using Bit.Core.Repositories;
+using Bit.Pam.Entities;
+using Bit.Pam.Repositories;
+using Xunit;
+
+namespace Bit.Infrastructure.IntegrationTest.AdminConsole.Repositories.CollectionRepository;
+
+/// <summary>
+/// Covers <see cref="CollectionDetails.HasEnabledAccessRule"/> on the three collection read paths that feed a
+/// client: the sync read, the organization listing behind the Admin Console vault, and the single-collection read.
+///
+/// The flag is derived rather than stored — <see cref="Collection.AccessRuleId"/> records the association, but a
+/// rule that is switched off gates nothing, so each read joins the rule and reports whether it is enabled. MSSQL
+/// computes this in the stored procedures and Entity Framework reimplements it in LINQ, so every test here runs the
+/// same truth table against both: ungoverned, governed by an enabled rule, governed by a disabled rule.
+/// </summary>
+public class CollectionRepositoryHasEnabledAccessRuleTests
+{
+    private const string _conditions = """{"kind":"human_approval"}""";
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManyByUserIdAsync_ReportsWhetherTheGoverningRuleIsEnabled(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        ICollectionRepository collectionRepository,
+        IAccessRuleRepository accessRuleRepository)
+    {
+        // Arrange
+        var (organization, orgUser, user) = await CreateMemberAsync(
+            userRepository, organizationRepository, organizationUserRepository);
+        var (ungoverned, enabled, disabled) = await CreateThreeCollectionsAsync(
+            collectionRepository, accessRuleRepository, organization, orgUser);
+
+        // Act
+        var actual = await collectionRepository.GetManyByUserIdAsync(user.Id);
+
+        // Assert
+        Assert.False(Single(actual, ungoverned.Id).HasEnabledAccessRule);
+        Assert.True(Single(actual, enabled.Id).HasEnabledAccessRule);
+        Assert.False(Single(actual, disabled.Id).HasEnabledAccessRule);
+    }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManySharedByOrganizationIdWithPermissionsAsync_ReportsWhetherTheGoverningRuleIsEnabled(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        ICollectionRepository collectionRepository,
+        IAccessRuleRepository accessRuleRepository)
+    {
+        // Arrange
+        var (organization, orgUser, user) = await CreateMemberAsync(
+            userRepository, organizationRepository, organizationUserRepository);
+        var (ungoverned, enabled, disabled) = await CreateThreeCollectionsAsync(
+            collectionRepository, accessRuleRepository, organization, orgUser);
+
+        // Act
+        var actual = await collectionRepository.GetManySharedByOrganizationIdWithPermissionsAsync(
+            organization.Id, user.Id, false);
+
+        // Assert
+        Assert.False(Single(actual, ungoverned.Id).HasEnabledAccessRule);
+        Assert.True(Single(actual, enabled.Id).HasEnabledAccessRule);
+        Assert.False(Single(actual, disabled.Id).HasEnabledAccessRule);
+    }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task GetByIdWithPermissionsAsync_ReportsWhetherTheGoverningRuleIsEnabled(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        ICollectionRepository collectionRepository,
+        IAccessRuleRepository accessRuleRepository)
+    {
+        // Arrange
+        var (organization, orgUser, user) = await CreateMemberAsync(
+            userRepository, organizationRepository, organizationUserRepository);
+        var (ungoverned, enabled, disabled) = await CreateThreeCollectionsAsync(
+            collectionRepository, accessRuleRepository, organization, orgUser);
+
+        // Act + Assert
+        Assert.False((await ReadAsync(ungoverned)).HasEnabledAccessRule);
+        Assert.True((await ReadAsync(enabled)).HasEnabledAccessRule);
+        Assert.False((await ReadAsync(disabled)).HasEnabledAccessRule);
+
+        async Task<CollectionAdminDetails> ReadAsync(Collection collection)
+        {
+            var actual = await collectionRepository.GetByIdWithPermissionsAsync(collection.Id, user.Id, false);
+            Assert.NotNull(actual);
+            return actual;
+        }
+    }
+
+    /// <summary>
+    /// Switching a rule off ungoverns its collections for badge purposes without touching the association, so the
+    /// flag has to follow the rule's state rather than the collection's row.
+    /// </summary>
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManyByUserIdAsync_AfterTheRuleIsDisabled_StopsReportingTheCollectionAsGoverned(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        ICollectionRepository collectionRepository,
+        IAccessRuleRepository accessRuleRepository)
+    {
+        // Arrange
+        var (organization, orgUser, user) = await CreateMemberAsync(
+            userRepository, organizationRepository, organizationUserRepository);
+        var rule = await CreateRuleAsync(accessRuleRepository, organization.Id, "Toggled", enabled: true);
+        var collection = await CreateAssignedCollectionAsync(collectionRepository, organization, orgUser);
+        await collectionRepository.SetAccessRuleAssociationsAsync(
+            organization.Id, rule.Id, [collection.Id], []);
+
+        var before = await collectionRepository.GetManyByUserIdAsync(user.Id);
+        Assert.True(Single(before, collection.Id).HasEnabledAccessRule);
+
+        // Act
+        rule.Enabled = false;
+        await accessRuleRepository.ReplaceAsync(rule);
+
+        // Assert: still associated, no longer gating.
+        var after = await collectionRepository.GetManyByUserIdAsync(user.Id);
+        Assert.False(Single(after, collection.Id).HasEnabledAccessRule);
+
+        var stored = await collectionRepository.GetByIdAsync(collection.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(rule.Id, stored.AccessRuleId);
+    }
+
+    private static T Single<T>(IEnumerable<T> collections, Guid collectionId) where T : Collection
+        => Assert.Single(collections, c => c.Id == collectionId);
+
+    private static async Task<(Organization, OrganizationUser, User)> CreateMemberAsync(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository)
+    {
+        var user = await userRepository.CreateTestUserAsync();
+        var organization = await organizationRepository.CreateTestOrganizationAsync();
+        var orgUser = await organizationUserRepository.CreateTestOrganizationUserAsync(organization, user);
+        return (organization, orgUser, user);
+    }
+
+    private static async Task<(Collection Ungoverned, Collection Enabled, Collection Disabled)>
+        CreateThreeCollectionsAsync(
+            ICollectionRepository collectionRepository,
+            IAccessRuleRepository accessRuleRepository,
+            Organization organization,
+            OrganizationUser orgUser)
+    {
+        var enabledRule = await CreateRuleAsync(accessRuleRepository, organization.Id, "Enabled", enabled: true);
+        var disabledRule = await CreateRuleAsync(accessRuleRepository, organization.Id, "Disabled", enabled: false);
+
+        var ungoverned = await CreateAssignedCollectionAsync(collectionRepository, organization, orgUser);
+        var governedByEnabled = await CreateAssignedCollectionAsync(collectionRepository, organization, orgUser);
+        var governedByDisabled = await CreateAssignedCollectionAsync(collectionRepository, organization, orgUser);
+
+        await collectionRepository.SetAccessRuleAssociationsAsync(
+            organization.Id, enabledRule.Id, [governedByEnabled.Id], []);
+        await collectionRepository.SetAccessRuleAssociationsAsync(
+            organization.Id, disabledRule.Id, [governedByDisabled.Id], []);
+
+        return (ungoverned, governedByEnabled, governedByDisabled);
+    }
+
+    /// <summary>
+    /// The collection must be assigned to the member, otherwise the user-scoped read paths do not return it at all.
+    /// </summary>
+    private static async Task<Collection> CreateAssignedCollectionAsync(
+        ICollectionRepository collectionRepository,
+        Organization organization,
+        OrganizationUser orgUser)
+    {
+        var collection = new Collection
+        {
+            OrganizationId = organization.Id,
+            Name = $"Test Collection {Guid.NewGuid()}"
+        };
+
+        await collectionRepository.CreateAsync(collection, groups: [], users:
+        [
+            new CollectionAccessSelection { Id = orgUser.Id, ReadOnly = false, HidePasswords = false, Manage = true }
+        ]);
+
+        return collection;
+    }
+
+    private static Task<AccessRule> CreateRuleAsync(
+        IAccessRuleRepository accessRuleRepository, Guid organizationId, string name, bool enabled)
+        => accessRuleRepository.CreateAsync(new AccessRule
+        {
+            OrganizationId = organizationId,
+            Name = $"{name} {Guid.NewGuid()}",
+            Conditions = _conditions,
+            Enabled = enabled,
+        });
+}

--- a/util/Migrator/DbScripts/2026-08-20_00_CollectionHasEnabledAccessRule.sql
+++ b/util/Migrator/DbScripts/2026-08-20_00_CollectionHasEnabledAccessRule.sql
@@ -1,0 +1,239 @@
+-- Surface [HasEnabledAccessRule] on the collection read paths that feed sync, the org collection
+-- listing and the single-collection read. The Collection.AccessRuleId association was already
+-- selected by these procedures, but "governed" only means "gated" while the rule itself is
+-- switched on, so each now LEFT JOINs [dbo].[AccessRule] and reports whether the governing rule
+-- is enabled rather than merely present.
+
+-- Collection_ReadByUserId
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadByUserId]
+    @UserId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    -- Columns are qualified with UCD because the [AccessRule] join below also has [Id],
+    -- [OrganizationId] and [Name].
+    SELECT
+        UCD.[Id],
+        UCD.[OrganizationId],
+        UCD.[Name],
+        UCD.[CreationDate],
+        UCD.[RevisionDate],
+        UCD.[ExternalId],
+        MIN(UCD.[ReadOnly]) AS [ReadOnly],
+        MIN(UCD.[HidePasswords]) AS [HidePasswords],
+        MAX(UCD.[Manage]) AS [Manage],
+        UCD.[DefaultUserCollectionEmail],
+        UCD.[Type],
+        UCD.[AccessRuleId],
+        -- Whether the collection is governed by an access rule that is currently switched on.
+        -- The rule row is functionally determined by [AccessRuleId], which is in the GROUP BY, so
+        -- MAX() picks the one value the group has rather than aggregating across rules.
+        MAX(CASE WHEN AR.[Enabled] = 1 THEN 1 ELSE 0 END) AS [HasEnabledAccessRule]
+    FROM
+        [dbo].[UserCollectionDetails](@UserId) UCD
+    LEFT JOIN
+        [dbo].[AccessRule] AR ON AR.[Id] = UCD.[AccessRuleId]
+    GROUP BY
+        UCD.[Id],
+        UCD.[OrganizationId],
+        UCD.[Name],
+        UCD.[CreationDate],
+        UCD.[RevisionDate],
+        UCD.[ExternalId],
+        UCD.[DefaultUserCollectionEmail],
+        UCD.[Type],
+        UCD.[AccessRuleId]
+END
+GO
+
+-- Collection_ReadByIdWithPermissions
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadByIdWithPermissions]
+    @CollectionId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+	SELECT
+	    C.*,
+	    MIN(CASE
+	        WHEN
+	            COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END) AS [ReadOnly],
+	    MIN (CASE
+	        WHEN
+	            COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END) AS [HidePasswords],
+	    MAX(CASE
+	        WHEN
+	            COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+	        THEN 0
+	        ELSE 1
+	    END) AS [Manage],
+	    MAX(CASE
+	    	WHEN
+	    	    CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+	    	THEN 0
+	    	ELSE 1
+	    END) AS [Assigned],
+	    CASE
+            WHEN
+                -- No user or group has manage rights
+                 NOT EXISTS(
+                    SELECT 1
+                    FROM [dbo].[CollectionUser] CU2
+                             JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
+                    WHERE
+                        CU2.[CollectionId] = C.[Id] AND
+                        CU2.[Manage] = 1
+                )
+                    AND NOT EXISTS (
+                    SELECT 1
+                    FROM [dbo].[CollectionGroup] CG2
+                    WHERE
+                        CG2.[CollectionId] = C.[Id] AND
+                        CG2.[Manage] = 1
+                )
+            THEN 1
+            ELSE 0
+        END AS [Unmanaged],
+        -- Whether the collection is governed by an access rule that is currently switched on.
+        -- The rule row is functionally determined by C.[AccessRuleId], which is in the GROUP BY,
+        -- so MAX() picks the one value the group has rather than aggregating across rules.
+        MAX(CASE WHEN AR.[Enabled] = 1 THEN 1 ELSE 0 END) AS [HasEnabledAccessRule]
+	FROM
+	    [dbo].[CollectionView] C
+	LEFT JOIN
+	    [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+	LEFT JOIN
+	    [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+	LEFT JOIN
+	    [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+	LEFT JOIN
+	    [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+	LEFT JOIN
+	    [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+	LEFT JOIN
+	    [dbo].[AccessRule] AR ON AR.[Id] = C.[AccessRuleId]
+	WHERE
+	    C.[Id] = @CollectionId
+    GROUP BY
+    	C.[Id],
+    	C.[OrganizationId],
+    	C.[Name],
+    	C.[CreationDate],
+    	C.[RevisionDate],
+    	C.[ExternalId],
+        C.[DefaultUserCollectionEmail],
+        C.[Type],
+        C.[AccessRuleId]
+
+   IF (@IncludeAccessRelationships = 1)
+    BEGIN
+        EXEC [dbo].[CollectionGroup_ReadByCollectionId] @CollectionId
+        EXEC [dbo].[CollectionUser_ReadByCollectionId] @CollectionId
+	END
+END
+GO
+
+-- Collection_ReadSharedCollectionsByOrganizationIdWithPermissions
+CREATE OR ALTER PROCEDURE [dbo].[Collection_ReadSharedCollectionsByOrganizationIdWithPermissions]
+    @OrganizationId UNIQUEIDENTIFIER,
+    @UserId UNIQUEIDENTIFIER,
+    @IncludeAccessRelationships BIT
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    SELECT
+        C.*,
+        MIN(CASE
+            WHEN
+                COALESCE(CU.[ReadOnly], CG.[ReadOnly], 0) = 0
+            THEN 0
+            ELSE 1
+        END) AS [ReadOnly],
+        MIN(CASE
+            WHEN
+                COALESCE(CU.[HidePasswords], CG.[HidePasswords], 0) = 0
+            THEN 0
+            ELSE 1
+        END) AS [HidePasswords],
+        MAX(CASE
+            WHEN
+                COALESCE(CU.[Manage], CG.[Manage], 0) = 0
+            THEN 0
+            ELSE 1
+        END) AS [Manage],
+        MAX(CASE
+            WHEN
+                CU.[CollectionId] IS NULL AND CG.[CollectionId] IS NULL
+            THEN 0
+            ELSE 1
+        END) AS [Assigned],
+        CASE
+            WHEN
+                -- No user or group has manage rights
+                NOT EXISTS(
+                    SELECT 1
+                    FROM [dbo].[CollectionUser] CU2
+                    JOIN [dbo].[OrganizationUser] OU2 ON CU2.[OrganizationUserId] = OU2.[Id]
+                    WHERE
+                        CU2.[CollectionId] = C.[Id] AND
+                        CU2.[Manage] = 1
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM [dbo].[CollectionGroup] CG2
+                    WHERE
+                        CG2.[CollectionId] = C.[Id] AND
+                        CG2.[Manage] = 1
+                )
+            THEN 1
+            ELSE 0
+        END AS [Unmanaged],
+        -- Whether the collection is governed by an access rule that is currently switched on.
+        -- The rule row is functionally determined by C.[AccessRuleId], which is in the GROUP BY,
+        -- so MAX() picks the one value the group has rather than aggregating across rules.
+        MAX(CASE WHEN AR.[Enabled] = 1 THEN 1 ELSE 0 END) AS [HasEnabledAccessRule]
+    FROM
+        [dbo].[CollectionView] C
+    LEFT JOIN
+        [dbo].[OrganizationUser] OU ON C.[OrganizationId] = OU.[OrganizationId] AND OU.[UserId] = @UserId
+    LEFT JOIN
+        [dbo].[CollectionUser] CU ON CU.[CollectionId] = C.[Id] AND CU.[OrganizationUserId] = [OU].[Id]
+    LEFT JOIN
+        [dbo].[GroupUser] GU ON CU.[CollectionId] IS NULL AND GU.[OrganizationUserId] = OU.[Id]
+    LEFT JOIN
+        [dbo].[Group] G ON G.[Id] = GU.[GroupId]
+    LEFT JOIN
+        [dbo].[CollectionGroup] CG ON CG.[CollectionId] = C.[Id] AND CG.[GroupId] = GU.[GroupId]
+    LEFT JOIN
+        [dbo].[AccessRule] AR ON AR.[Id] = C.[AccessRuleId]
+    WHERE
+        C.[OrganizationId] = @OrganizationId AND
+        C.[Type] = 0 -- Only SharedCollection
+    GROUP BY
+        C.[Id],
+        C.[OrganizationId],
+        C.[Name],
+        C.[CreationDate],
+        C.[RevisionDate],
+        C.[ExternalId],
+        C.[DefaultUserCollectionEmail],
+        C.[Type],
+        C.[AccessRuleId]
+
+    IF (@IncludeAccessRelationships = 1)
+    BEGIN
+        EXEC [dbo].[CollectionGroup_ReadByOrganizationId] @OrganizationId
+        EXEC [dbo].[CollectionUser_ReadByOrganizationId] @OrganizationId
+    END
+END
+GO


### PR DESCRIPTION
Part of [PM-42246](https://bitwarden.atlassian.net/browse/PM-42246). Paired with the clients half — neither is useful alone.

## The problem

The collection browser renders a **Controlled access** column, but a collection row has nothing to put in it. No collection response model carries the PAM association, so a client can only learn that a collection is governed by reading the organization's access rules itself.

A member can do that. A **provider cannot**: `GET organizations/{orgId}/access-rules` requires `MemberRequirement`, deliberately —

> providers manage an organization's billing and configuration, but access rules gate who can lease credentials out of it, which is not theirs to read or change.

Providers do browse the client organization's collection list (`CollectionsController.GetManyWithDetails` handles them explicitly). So their column renders and every cell stays empty, however the client is written.

## The change

Surface the fact on the collection: `HasEnabledAccessRule` on the responses that feed sync and the organization listing.

**It is derived, not the stored association.** `Collection.AccessRuleId` records which rule governs a collection, but a rule that is switched off gates nothing — returning the association alone would *start* badging collections whose rule is disabled, which is a regression dressed as a fix. Each read path joins `AccessRule` and reports whether it is enabled:

| | Where |
|---|---|
| MSSQL | `Collection_ReadByUserId`, `Collection_ReadByIdWithPermissions`, `Collection_ReadSharedCollectionsByOrganizationIdWithPermissions` — `LEFT JOIN [dbo].[AccessRule]` + `MAX(CASE WHEN AR.[Enabled] = 1 …)` |
| EF | `EXISTS` subquery in `UserCollectionDetailsQuery` / `CollectionAdminDetailsQuery` — `Collection` has no `AccessRule` navigation to traverse — carried through the `GROUP BY` key and projection of all three repository reads, both branches |

`Collection_ReadByUserId` needed its columns qualified (`UCD.`): joining `AccessRule` makes `Id`, `OrganizationId` and `Name` ambiguous against the `UserCollectionDetails` table function.

A boolean rather than the rule id, deliberately: the id is useless to a client (the badge needs only "governed"; the collection dialog's callout names rules and fetches them anyway), and it avoids handing providers the rule identity the access-rules endpoint withholds from them.

**Nothing writes the column and no request model gains a field** — `SetAccessRuleAssociationsAsync` remains the single writer of the association.

## Testing

`CollectionRepositoryHasEnabledAccessRuleTests` runs the same truth table — ungoverned / governed by an enabled rule / governed by a disabled rule — against all three read paths, plus a case that flips a rule off and checks the collection stops reporting as governed while keeping its association.

- Passing on **SQL Server**, **SQLite** and **Postgres**. Postgres earns its place: SQLite takes the client-side `.GroupBy` branch, so only Postgres exercises grouping by the `EXISTS` subquery in translated SQL.
- All 276 `~Collection` integration tests pass on those three providers; `Api.Test` 1921, `Core.Test` 6516, `Pam.Test` 414.
- **Not run:** MySQL/MariaDB (no local instance).

## Reviewer notes

- The two bare-`Collection` `CollectionAccessDetailsResponseModel` constructors — create/update responses and their provider fallbacks — cannot compute the flag and leave it `false`. Documented on the property; no vault list reads those responses.
- `Collection_ReadByIdWithPermissions` and the shared-collections procedure select `C.*` and group by each column explicitly, so the new value is an aggregate (`MAX`) rather than a `GROUP BY` addition.
- The migrator script is generated from the three procedure files so the two cannot drift.

[PM-42246]: https://bitwarden.atlassian.net/browse/PM-42246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ