### PR TITLE
[PM-39513] chore: Pin library project versions to 0.0.1

### DIFF
--- a/bitwarden_license/src/Commercial.Core/Commercial.Core.csproj
+++ b/bitwarden_license/src/Commercial.Core/Commercial.Core.csproj
@@ -1,5 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Core\Core.csproj" />
   </ItemGroup>

--- a/bitwarden_license/src/Commercial.Core/packages.lock.json
+++ b/bitwarden_license/src/Commercial.Core/packages.lock.json
@@ -1226,7 +1226,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/Commercial.Infrastructure.EntityFramework.csproj
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/Commercial.Infrastructure.EntityFramework.csproj
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="[14.0.0]" />

--- a/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/packages.lock.json
+++ b/bitwarden_license/src/Commercial.Infrastructure.EntityFramework/packages.lock.json
@@ -1382,7 +1382,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1392,12 +1392,12 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"

--- a/bitwarden_license/src/Scim/packages.lock.json
+++ b/bitwarden_license/src/Scim/packages.lock.json
@@ -1169,7 +1169,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1178,21 +1178,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1215,9 +1215,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/bitwarden_license/src/Services/Pam/packages.lock.json
+++ b/bitwarden_license/src/Services/Pam/packages.lock.json
@@ -904,7 +904,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -913,7 +913,7 @@
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "pam.domain": {

--- a/bitwarden_license/src/Sso/packages.lock.json
+++ b/bitwarden_license/src/Sso/packages.lock.json
@@ -1208,7 +1208,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1217,21 +1217,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1254,9 +1254,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/bitwarden_license/test/Commercial.Core.Test/packages.lock.json
+++ b/bitwarden_license/test/Commercial.Core.Test/packages.lock.json
@@ -1361,7 +1361,7 @@
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1370,7 +1370,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1440,8 +1440,8 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Common": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.Diagnostics.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1455,7 +1455,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/bitwarden_license/test/SSO.Test/packages.lock.json
+++ b/bitwarden_license/test/SSO.Test/packages.lock.json
@@ -1661,7 +1661,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1732,7 +1732,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1741,21 +1741,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1778,9 +1778,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }
@@ -1791,7 +1791,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1799,7 +1799,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Sustainsys.Saml2.AspNetCore2": "[2.11.0, 2.11.0]"
         }
       },

--- a/bitwarden_license/test/Scim.IntegrationTest/packages.lock.json
+++ b/bitwarden_license/test/Scim.IntegrationTest/packages.lock.json
@@ -1300,7 +1300,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1371,7 +1371,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1383,7 +1383,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1391,27 +1391,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1420,17 +1420,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1450,7 +1450,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1458,17 +1458,17 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "seeder": {
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1482,9 +1482,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/bitwarden_license/test/Scim.Test/packages.lock.json
+++ b/bitwarden_license/test/Scim.Test/packages.lock.json
@@ -1621,7 +1621,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1692,7 +1692,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1701,21 +1701,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1733,7 +1733,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1741,7 +1741,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1755,9 +1755,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/bitwarden_license/test/Services/Pam.IntegrationTest/packages.lock.json
+++ b/bitwarden_license/test/Services/Pam.IntegrationTest/packages.lock.json
@@ -1853,10 +1853,10 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Commercial.Infrastructure.EntityFramework": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Commercial.Infrastructure.EntityFramework": "[0.0.1, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1866,7 +1866,7 @@
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
           "OrganizationAuthorization": "[0.0.1, )",
           "Pam": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Swashbuckle.AspNetCore": "[10.1.7, 10.1.7]"
         }
       },
@@ -1877,14 +1877,14 @@
           "IntegrationTestCommon": "[2026.8.0, )",
           "Microsoft.Extensions.Diagnostics.Testing": "[9.10.0, 9.10.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
-          "Seeder": "[2026.8.0, )",
+          "Seeder": "[0.0.1, )",
           "xunit": "[2.6.6, )"
         }
       },
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1892,8 +1892,8 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "common": {
@@ -1901,7 +1901,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1972,7 +1972,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1984,7 +1984,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1992,27 +1992,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -2021,17 +2021,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -2039,16 +2039,16 @@
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "pam": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OrganizationAuthorization": "[0.0.1, )",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -2064,10 +2064,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -2081,9 +2081,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/bitwarden_license/test/Services/Pam.Test/packages.lock.json
+++ b/bitwarden_license/test/Services/Pam.Test/packages.lock.json
@@ -1363,7 +1363,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1433,8 +1433,8 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Common": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.Diagnostics.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1448,7 +1448,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1457,16 +1457,16 @@
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "pam": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OrganizationAuthorization": "[0.0.1, )",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "pam.domain": {

--- a/bitwarden_license/test/Sso.IntegrationTest/packages.lock.json
+++ b/bitwarden_license/test/Sso.IntegrationTest/packages.lock.json
@@ -1338,7 +1338,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1409,7 +1409,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1421,7 +1421,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1429,27 +1429,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1458,17 +1458,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1486,10 +1486,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1503,9 +1503,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }
@@ -1516,7 +1516,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1524,7 +1524,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Sustainsys.Saml2.AspNetCore2": "[2.11.0, 2.11.0]"
         }
       },

--- a/perf/MicroBenchmarks/packages.lock.json
+++ b/perf/MicroBenchmarks/packages.lock.json
@@ -1630,7 +1630,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1642,7 +1642,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1650,27 +1650,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1693,9 +1693,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/src/Admin/packages.lock.json
+++ b/src/Admin/packages.lock.json
@@ -1128,7 +1128,7 @@
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1136,8 +1136,8 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "core": {
@@ -1203,7 +1203,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1212,21 +1212,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1235,7 +1235,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1243,8 +1243,8 @@
       "mysqlmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -1256,8 +1256,8 @@
       "postgresmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1271,9 +1271,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }
@@ -1281,8 +1281,8 @@
       "sqlitemigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "ssrfprotection": {

--- a/src/Api/packages.lock.json
+++ b/src/Api/packages.lock.json
@@ -1164,7 +1164,7 @@
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1172,8 +1172,8 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "core": {
@@ -1239,7 +1239,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1248,21 +1248,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1271,16 +1271,16 @@
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "pam": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OrganizationAuthorization": "[0.0.1, )",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -1300,9 +1300,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/src/Billing/packages.lock.json
+++ b/src/Billing/packages.lock.json
@@ -1137,7 +1137,7 @@
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1204,7 +1204,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1213,21 +1213,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1250,9 +1250,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -6,6 +6,12 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <!-- These opt outs should be removed when all warnings are addressed -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1304;CA1305</WarningsNotAsErrors>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Core/packages.lock.json
+++ b/src/Core/packages.lock.json
@@ -1216,7 +1216,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/src/Events/packages.lock.json
+++ b/src/Events/packages.lock.json
@@ -1169,7 +1169,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1178,21 +1178,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1215,9 +1215,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/src/EventsProcessor/packages.lock.json
+++ b/src/EventsProcessor/packages.lock.json
@@ -1169,7 +1169,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1178,21 +1178,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1215,9 +1215,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/src/HttpExtensions/HttpExtensions.csproj
+++ b/src/HttpExtensions/HttpExtensions.csproj
@@ -1,5 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
+  </PropertyGroup>
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/src/Identity/packages.lock.json
+++ b/src/Identity/packages.lock.json
@@ -1169,7 +1169,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1178,21 +1178,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1215,9 +1215,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/src/Infrastructure.Dapper/Infrastructure.Dapper.csproj
+++ b/src/Infrastructure.Dapper/Infrastructure.Dapper.csproj
@@ -3,6 +3,12 @@
     <PropertyGroup>
       <!-- These opt outs should be removed when all warnings are addressed -->
       <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1305</WarningsNotAsErrors>
+      <!--
+        Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+        reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+        on each service version bump.
+      -->
+      <Version>0.0.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Infrastructure.Dapper/packages.lock.json
+++ b/src/Infrastructure.Dapper/packages.lock.json
@@ -1231,7 +1231,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
+++ b/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
@@ -2,6 +2,12 @@
     <PropertyGroup>
       <!-- These opt outs should be removed when all warnings are addressed -->
       <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1304;CA1305</WarningsNotAsErrors>
+      <!--
+        Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+        reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+        on each service version bump.
+      -->
+      <Version>0.0.1</Version>
     </PropertyGroup>
 
 

--- a/src/Infrastructure.EntityFramework/packages.lock.json
+++ b/src/Infrastructure.EntityFramework/packages.lock.json
@@ -1389,7 +1389,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/src/Libraries/OrganizationAuthorization/packages.lock.json
+++ b/src/Libraries/OrganizationAuthorization/packages.lock.json
@@ -904,7 +904,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/src/Notifications/packages.lock.json
+++ b/src/Notifications/packages.lock.json
@@ -1214,7 +1214,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1223,21 +1223,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1260,9 +1260,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/src/Pam.Domain/Pam.Domain.csproj
+++ b/src/Pam.Domain/Pam.Domain.csproj
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <RootNamespace>Bit.Pam</RootNamespace>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharedWeb/SharedWeb.csproj
+++ b/src/SharedWeb/SharedWeb.csproj
@@ -4,6 +4,12 @@
   <PropertyGroup>
     <!-- These opt outs should be removed when all warnings are addressed -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1304</WarningsNotAsErrors>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SharedWeb/packages.lock.json
+++ b/src/SharedWeb/packages.lock.json
@@ -1411,7 +1411,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1420,21 +1420,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"

--- a/test/Admin.Test/packages.lock.json
+++ b/test/Admin.Test/packages.lock.json
@@ -1638,11 +1638,11 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Commercial.Infrastructure.EntityFramework": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
-          "Migrator": "[2026.8.0, )",
-          "MySqlMigrations": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Commercial.Infrastructure.EntityFramework": "[0.0.1, )",
+          "Core": "[0.0.1, )",
+          "Migrator": "[0.0.1, )",
+          "MySqlMigrations": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1650,15 +1650,15 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "PostgresMigrations": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )",
-          "SqliteMigrations": "[2026.8.0, )"
+          "PostgresMigrations": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )",
+          "SqliteMigrations": "[0.0.1, )"
         }
       },
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1666,8 +1666,8 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "common": {
@@ -1675,7 +1675,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1746,7 +1746,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1755,21 +1755,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1778,7 +1778,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1786,8 +1786,8 @@
       "mysqlmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -1799,8 +1799,8 @@
       "postgresmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1814,9 +1814,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }
@@ -1824,8 +1824,8 @@
       "sqlitemigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "ssrfprotection": {

--- a/test/Api.IntegrationTest/packages.lock.json
+++ b/test/Api.IntegrationTest/packages.lock.json
@@ -1374,10 +1374,10 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Commercial.Infrastructure.EntityFramework": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Commercial.Infrastructure.EntityFramework": "[0.0.1, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1387,14 +1387,14 @@
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
           "OrganizationAuthorization": "[0.0.1, )",
           "Pam": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Swashbuckle.AspNetCore": "[10.1.7, 10.1.7]"
         }
       },
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1402,8 +1402,8 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "common": {
@@ -1411,7 +1411,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1482,7 +1482,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1494,7 +1494,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1502,27 +1502,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1531,17 +1531,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1549,16 +1549,16 @@
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "pam": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OrganizationAuthorization": "[0.0.1, )",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -1574,10 +1574,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1591,9 +1591,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Api.Test/packages.lock.json
+++ b/test/Api.Test/packages.lock.json
@@ -1733,10 +1733,10 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Commercial.Infrastructure.EntityFramework": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Commercial.Infrastructure.EntityFramework": "[0.0.1, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1746,14 +1746,14 @@
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
           "OrganizationAuthorization": "[0.0.1, )",
           "Pam": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Swashbuckle.AspNetCore": "[10.1.7, 10.1.7]"
         }
       },
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1761,8 +1761,8 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "common": {
@@ -1770,7 +1770,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1840,8 +1840,8 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Common": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.Diagnostics.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1855,7 +1855,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1864,21 +1864,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1887,16 +1887,16 @@
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "pam": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OrganizationAuthorization": "[0.0.1, )",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -1916,9 +1916,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Billing.IntegrationTest/packages.lock.json
+++ b/test/Billing.IntegrationTest/packages.lock.json
@@ -1855,11 +1855,11 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Commercial.Infrastructure.EntityFramework": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
-          "Migrator": "[2026.8.0, )",
-          "MySqlMigrations": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Commercial.Infrastructure.EntityFramework": "[0.0.1, )",
+          "Core": "[0.0.1, )",
+          "Migrator": "[0.0.1, )",
+          "MySqlMigrations": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1867,9 +1867,9 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "PostgresMigrations": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )",
-          "SqliteMigrations": "[2026.8.0, )"
+          "PostgresMigrations": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )",
+          "SqliteMigrations": "[0.0.1, )"
         }
       },
       "api": {
@@ -1881,10 +1881,10 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Commercial.Infrastructure.EntityFramework": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Commercial.Infrastructure.EntityFramework": "[0.0.1, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1894,7 +1894,7 @@
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
           "OrganizationAuthorization": "[0.0.1, )",
           "Pam": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Swashbuckle.AspNetCore": "[10.1.7, 10.1.7]"
         }
       },
@@ -1905,7 +1905,7 @@
           "IntegrationTestCommon": "[2026.8.0, )",
           "Microsoft.Extensions.Diagnostics.Testing": "[9.10.0, 9.10.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
-          "Seeder": "[2026.8.0, )",
+          "Seeder": "[0.0.1, )",
           "xunit": "[2.6.6, )"
         }
       },
@@ -1915,8 +1915,8 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "MarkDig": "[1.3.2, 1.3.2]",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
@@ -1925,14 +1925,14 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Swashbuckle.AspNetCore": "[10.1.7, 10.1.7]"
         }
       },
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1940,8 +1940,8 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "common": {
@@ -1949,7 +1949,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -2020,7 +2020,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -2032,7 +2032,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -2040,27 +2040,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -2069,17 +2069,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -2087,23 +2087,23 @@
       "mysqlmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "pam": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OrganizationAuthorization": "[0.0.1, )",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -2115,8 +2115,8 @@
       "postgresmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "rustsdk": {
@@ -2126,10 +2126,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -2143,9 +2143,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }
@@ -2153,8 +2153,8 @@
       "sqlitemigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "ssrfprotection": {

--- a/test/Billing.Test/packages.lock.json
+++ b/test/Billing.Test/packages.lock.json
@@ -1695,8 +1695,8 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "MarkDig": "[1.3.2, 1.3.2]",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
@@ -1705,14 +1705,14 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Swashbuckle.AspNetCore": "[10.1.7, 10.1.7]"
         }
       },
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1721,7 +1721,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1791,8 +1791,8 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Common": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.Diagnostics.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1806,7 +1806,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1815,21 +1815,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1852,9 +1852,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Common/Common.csproj
+++ b/test/Common/Common.csproj
@@ -4,6 +4,12 @@
     <RootNamespace>Bit.Test.Common</RootNamespace>
     <!-- These opt outs should be removed when all warnings are addressed -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1305</WarningsNotAsErrors>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
     <ItemGroup>

--- a/test/Common/packages.lock.json
+++ b/test/Common/packages.lock.json
@@ -1385,7 +1385,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/test/Core.IntegrationTest/packages.lock.json
+++ b/test/Core.IntegrationTest/packages.lock.json
@@ -1360,7 +1360,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/test/Core.Test/packages.lock.json
+++ b/test/Core.Test/packages.lock.json
@@ -1368,7 +1368,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1439,7 +1439,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/test/Events.IntegrationTest/packages.lock.json
+++ b/test/Events.IntegrationTest/packages.lock.json
@@ -1741,7 +1741,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1815,7 +1815,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1823,13 +1823,13 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1841,7 +1841,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1849,27 +1849,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1878,17 +1878,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1906,10 +1906,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1923,9 +1923,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Events.Test/packages.lock.json
+++ b/test/Events.Test/packages.lock.json
@@ -1622,7 +1622,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1696,7 +1696,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1704,13 +1704,13 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1719,21 +1719,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1756,9 +1756,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/EventsProcessor.Test/packages.lock.json
+++ b/test/EventsProcessor.Test/packages.lock.json
@@ -1612,7 +1612,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1620,13 +1620,13 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1635,21 +1635,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1672,9 +1672,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Icons.Test/packages.lock.json
+++ b/test/Icons.Test/packages.lock.json
@@ -1549,7 +1549,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1620,7 +1620,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "globalsettingsbridge": {

--- a/test/Identity.IntegrationTest/packages.lock.json
+++ b/test/Identity.IntegrationTest/packages.lock.json
@@ -1321,7 +1321,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1391,8 +1391,8 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Common": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.Diagnostics.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1406,7 +1406,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1418,7 +1418,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1426,27 +1426,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1455,17 +1455,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1483,10 +1483,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1500,9 +1500,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Identity.Test/packages.lock.json
+++ b/test/Identity.Test/packages.lock.json
@@ -1658,7 +1658,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1729,7 +1729,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1741,7 +1741,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1749,27 +1749,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1792,9 +1792,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Infrastructure.Dapper.Test/packages.lock.json
+++ b/test/Infrastructure.Dapper.Test/packages.lock.json
@@ -1322,7 +1322,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1331,9 +1331,9 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "pam.domain": {

--- a/test/Infrastructure.EFIntegration.Test/packages.lock.json
+++ b/test/Infrastructure.EFIntegration.Test/packages.lock.json
@@ -1527,7 +1527,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1597,8 +1597,8 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Common": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.Diagnostics.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1612,7 +1612,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1621,21 +1621,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1644,8 +1644,8 @@
       "mysqlmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -1657,8 +1657,8 @@
       "postgresmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1670,8 +1670,8 @@
       "sqlitemigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "ssrfprotection": {

--- a/test/Infrastructure.IntegrationTest/packages.lock.json
+++ b/test/Infrastructure.IntegrationTest/packages.lock.json
@@ -1581,7 +1581,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1590,21 +1590,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1613,7 +1613,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1621,8 +1621,8 @@
       "mysqlmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -1634,8 +1634,8 @@
       "postgresmigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1647,8 +1647,8 @@
       "sqlitemigrations": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "ssrfprotection": {

--- a/test/IntegrationTestCommon/packages.lock.json
+++ b/test/IntegrationTestCommon/packages.lock.json
@@ -1728,7 +1728,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1799,7 +1799,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1811,7 +1811,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1819,27 +1819,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1848,7 +1848,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1866,10 +1866,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1883,9 +1883,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Libraries/ExceptionHandling.Test/packages.lock.json
+++ b/test/Libraries/ExceptionHandling.Test/packages.lock.json
@@ -108,7 +108,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/test/Libraries/OrganizationAuthorization.Test/packages.lock.json
+++ b/test/Libraries/OrganizationAuthorization.Test/packages.lock.json
@@ -1371,7 +1371,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1441,8 +1441,8 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Common": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.Diagnostics.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1456,7 +1456,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1465,7 +1465,7 @@
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {

--- a/test/Migrator.Test/packages.lock.json
+++ b/test/Migrator.Test/packages.lock.json
@@ -388,8 +388,8 @@
       },
       "Microsoft.AspNetCore.Cryptography.Internal": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "R0TKX26vPlw4kfyaLECwxn5GUIUAv6B+5s8kiEku9cl9VVCrDQDslPuhUUhN6oI/TvLj1lMFkz6AhHIpbPC3Lg=="
+        "resolved": "10.0.10",
+        "contentHash": "T/kOT3kAVZU1B0QlpRxASpdbAJ/o5DLFW7bWS6vyE44uMqPmojEcaFENt6ww1xaLH++ZNwsEJ1YUOwPK050lNQ=="
       },
       "Microsoft.AspNetCore.Cryptography.KeyDerivation": {
         "type": "Transitive",
@@ -401,22 +401,22 @@
       },
       "Microsoft.AspNetCore.DataProtection": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "Rlbrr3XSGB4dwnUY/pA70TpVyrQhelDAUkIiGfJ2Tm32mscTYxrRnk9Ooy1rRhGZ1g7rliJPuNzhyMMKmRH5pw==",
+        "resolved": "10.0.10",
+        "contentHash": "5sfrNrBShTlJeXvWNxjPS7ilLY4H6MICZPMZr/2vjoDoBH5Z8sQYJwbhulqfXh4yIpxIto0TcmOQHOElvpq+iQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.8",
-          "Microsoft.AspNetCore.DataProtection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "System.Security.Cryptography.Xml": "10.0.8"
+          "Microsoft.AspNetCore.Cryptography.Internal": "10.0.10",
+          "Microsoft.AspNetCore.DataProtection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "System.Security.Cryptography.Xml": "10.0.10"
         }
       },
       "Microsoft.AspNetCore.DataProtection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "NYxEmhe2tDPwwGgl0kNraUOJdOqaIYJpnZ1Lf7OlqWRf3aLagniVxMl8JSVmy0jiRtElsPYq8lTvLlbvRSwCLA=="
+        "resolved": "10.0.10",
+        "contentHash": "q2RNx0N/qrsU+JgbPE78I9pu5ekwguitAFVoeE1NCgxtkUTguvf7oTzBnn42zSQxuugJ4fmj0RSarob8Rvorrg=="
       },
       "Microsoft.Azure.Amqp": {
         "type": "Transitive",
@@ -577,10 +577,10 @@
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "EoK2TwVR1daxmfXUPnvIYZSk5XQjHe45sGekox4kvMt88KQZQhDVzYW5Na5+oNwTuRpE48hipyGJg12F1Tm70w==",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Caching.Cosmos": {
@@ -608,41 +608,41 @@
       },
       "Microsoft.Extensions.Caching.SqlServer": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "GSP1UIw/VFiLOWBOCQYwLHsLnkqqqqEC9sc8IqCXpbSkwz03EZ9u4jcFORTE4TJ/gkKXKP6L3AO+ZFZ5MFX4Gg==",
+        "resolved": "10.0.10",
+        "contentHash": "c5dyhJoeDapja0D3qbt+7iMsG3BFITaM77HCWHW/Yef4zgQSuKkooPw4/SWwc2HfZocbMp0mDvh40U9/iO1p/Q==",
         "dependencies": {
           "Azure.Identity": "1.11.4",
           "Microsoft.Data.SqlClient": "5.2.2",
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Caching.StackExchangeRedis": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "fle9ns3q2kk63vt/wHFtLw1U9kiEbM42vTk2Sar8VBjiGJFkXAgm0QEKFx15YMHkJIPRVdknWaovpvgGEgn10g==",
+        "resolved": "10.0.10",
+        "contentHash": "E+3pfEY68WQh1ZVFTGDNK0JCoayzL3aIDgVHHM85HIbQO7MiABG14A7+ajHH2P/y3a4W2Rla5p2nzut3+mzoyQ==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
           "StackExchange.Redis": "2.7.27"
         }
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "ehZcoPbjzWzS4XFvuz7R3V55SmpdkyMqFURLH3yXaN9NtXd9tR6CGB7pd49HYtCkenl+G7ctXSFLhNI08xLfRg==",
+        "resolved": "10.0.10",
+        "contentHash": "plJWK2zpWuuyxI8F8s2scx6Je7N1Ajjs6HvYUGKwRnDMWIVIz9FHwAkiT7ASgrvAOd10T0FPVlh9BzAJJME+jg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "resolved": "10.0.10",
+        "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -656,59 +656,59 @@
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "bVGqctAfPGfTxJvNp8pMshtvpsUj6r6JkeiCNVIGVYO5gBxuxdN0Lbr25kEvE/zXdctkEc44g8HssnPgDnFGVA==",
+        "resolved": "10.0.10",
+        "contentHash": "KRfFSSCV58vEdU7mPED/YMzeovIWF5P0g8s9K8n9HEfy0/WzMq37SrPdXdFN5/dFT/rPMHpF7AvpoXHckbcBFg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "1g9mzuu8gIHkjYb0jLxOTQVl/QDG5nn0b0JzgT/gbgNKr6gXZzxOHRAsdYRc1eDApB7LdHR8uK5vQrNjIQdRrQ==",
+        "resolved": "10.0.10",
+        "contentHash": "ZOhZYwvbXGTgGVRwswIirofEMVHuWdxjdh0JeUZXwaF9cgcjXdz/t0ELtgaevw7ezTyv47yPNCgGreWtLkn3IQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "KLtAZ6A38s1pIfCO2ns6aG14NNGMYNZ4PBYfFK4M+R4A+xuSc6oklhqDcpHZxvDpyBWeFtR5C8iQBw2ng8tUHQ==",
+        "resolved": "10.0.10",
+        "contentHash": "uvJ6sHwjgrkMEJOgiC76G0mcZGXerwyyWkwX34EOjCbxKG6TCtfAoqDKAMsCvEBf9HxjlGQEgqsSMOGCmGBf+A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "6XTfFOnf27WY8kEeZkTZ4YNn0t+imgvdQ0YaAdR4vgURKATo9bCaVJ1KB71IOJAQtJP7Elb53VHlTNXg2CtSsA==",
+        "resolved": "10.0.10",
+        "contentHash": "1s1sKFTk/Foam64JY6+m/diH8drL3Wx6V3gtSd5v1IEZtszZYyc1pW8uRnMblzpNiR0l0t8gGk7tXj3xHzFgdg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Json": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.8"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Json": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "daf62xHIrq8pnE709hgaZZN9tSam9TGGepWe1+bE6V3GEuVwJiMs6ib+38lfMCyAJAHiX0vapxBhsuMSV7U+cg==",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -722,46 +722,46 @@
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "resolved": "10.0.10",
+        "contentHash": "9uWiKpeOVac355STyChWR/pliFX/5CeLqChW9kKsaxyDH4EUTZxMkT4Jwp/J/peLm0GBFmSX5c0WCse3yCnq1Q==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Options": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "resolved": "10.0.10",
+        "contentHash": "c5zqFCY9DiIpMovLd7/d/CTiEtrMOuQ639dhv3PABtKQIKNQikSHwQt8+N679uii9q+B55lgK28Uv64FOwEu8w==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "GkPvQe6IdidLu6Q3Lw6+B8NJpW8feW8czZ5mBKt5rXM/x8MvZfEp5WvAsjznzDGd23chIDrW0b2mmt+ScnEgiw==",
+        "resolved": "10.0.10",
+        "contentHash": "jhJAyo38kSrH3ARvWUk0h8itogVnQu2DCZuPo+s0Z+tXes0ugTxMPaHYzap85785eHQmPFqD9TYERqBbtGxn/w==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.8",
-          "Microsoft.Extensions.FileSystemGlobbing": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "IUQet3SY51xIFcFZKtAB6a54/Zdxs7T3SQ84kJtOD6yeXfZgiOMksACWD5qtTmXGQGFH4QYGBOT0KIO8Uy/dJw=="
+        "resolved": "10.0.10",
+        "contentHash": "jSOCVxEwCd4Aq925kJVz1kSO1EpX2OHYKL04qVREXkDU7Ce3pVDdHPYm+fEy8y/th2kJf/DAstRHpJAqoNWP8w=="
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "resolved": "10.0.10",
+        "contentHash": "5LugpYGHk+mkn0a8IZgcyfBca8PCTAU9RQFoMrTdtOOidq88M2SI5f3px6ugnzgxC+eTkvYYJi8pzlUnG5xdAQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Http": {
@@ -800,29 +800,29 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "K60JhWC2hN/Gi7TP68tBxSzk5ACWOs7lkmPzsfA8Bcf/IXTajujt2ORMf9rSMk1bsng6Lv4Y3fuxp3bm1+15ug==",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
@@ -839,8 +839,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
@@ -1148,11 +1148,11 @@
       },
       "Stripe.net": {
         "type": "Transitive",
-        "resolved": "48.5.0",
-        "contentHash": "wOAZYR0EnrLMok/ScfVOpTxjci+n3vFP0A7w/BE63yJdkRSDwZVCJIhlOjeJvgyQnMX8ZbwDAHMaxaiDa0Z5TA==",
+        "resolved": "52.1.0",
+        "contentHash": "xzYOMenSrhR2UIgk+zBOjfzADSFe9NnCuhffs2FMpWSJst4M19m6QS7GAxq4cLeBdWvUoUo3RuHNc5uzI5eOFg==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
-          "System.Configuration.ConfigurationManager": "8.0.0"
+          "System.Configuration.ConfigurationManager": "9.0.0"
         }
       },
       "System.ClientModel": {
@@ -1204,8 +1204,8 @@
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "2wOycCqMyg9Tu+SDP03FFwDEWBni/3xOKgt0bRXplOvyeIcUJmWO7m3gTCF2mIdtQLROLtOP5VwWRT8YBwP/bA=="
+        "resolved": "10.0.10",
+        "contentHash": "KG8t5RHczdgB3IWvRndpI0nE1DSo7ikDYSDbITxfgRFyIvnYiKzuPjaZOsPnwFQ1aOGUl9sEulJul9wlHLEUoA=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
@@ -1214,10 +1214,10 @@
       },
       "System.Security.Cryptography.Xml": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "Fb+L55vEJaf8RCOzrzN564sfyCL8SZEfce9z6XkuhHg+294SBfyS4fIoLU3EljofDCkp+EKDeleI8ug5WO2NtA==",
+        "resolved": "10.0.10",
+        "contentHash": "Mz6Y+s+uMQKj1H2BUF0OhlmaOQkLgSG34/IrUaBDirYBQ6bgwcFvO/XtXWcoDlBLFoFB0uKqDNhybHOd+fQK1A==",
         "dependencies": {
-          "System.Security.Cryptography.Pkcs": "10.0.8"
+          "System.Security.Cryptography.Pkcs": "10.0.10"
         }
       },
       "System.Threading.RateLimiting": {
@@ -1357,7 +1357,7 @@
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "MailKit": "[4.17.0, 4.17.0]",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.8, 10.0.8]",
-          "Microsoft.AspNetCore.DataProtection": "[10.0.8, 10.0.8]",
+          "Microsoft.AspNetCore.DataProtection": "[10.0.10, 10.0.10]",
           "Microsoft.Azure.Cosmos": "[3.52.0, 3.52.0]",
           "Microsoft.Azure.NotificationHubs": "[4.2.0, 4.2.0]",
           "Microsoft.Bot.Builder": "[4.23.0, 4.23.0]",
@@ -1365,10 +1365,10 @@
           "Microsoft.Bot.Connector": "[4.23.0, 4.23.0]",
           "Microsoft.Data.SqlClient": "[7.0.0, 7.0.0]",
           "Microsoft.Extensions.Caching.Cosmos": "[1.8.0, 1.8.0]",
-          "Microsoft.Extensions.Caching.SqlServer": "[10.0.8, 10.0.8]",
-          "Microsoft.Extensions.Caching.StackExchangeRedis": "[10.0.8, 10.0.8]",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[10.0.8, 10.0.8]",
-          "Microsoft.Extensions.Configuration.UserSecrets": "[10.0.8, 10.0.8]",
+          "Microsoft.Extensions.Caching.SqlServer": "[10.0.10, 10.0.10]",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "[10.0.10, 10.0.10]",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "[10.0.10, 10.0.10]",
+          "Microsoft.Extensions.Configuration.UserSecrets": "[10.0.10, 10.0.10]",
           "Microsoft.Extensions.Identity.Stores": "[10.0.8, 10.0.8]",
           "Newtonsoft.Json": "[13.0.3, 13.0.3]",
           "OneOf": "[3.0.271, 3.0.271]",
@@ -1378,9 +1378,9 @@
           "Quartz.Extensions.Hosting": "[3.15.1, 3.15.1]",
           "RabbitMQ.Client": "[7.1.2, 7.1.2]",
           "SendGrid": "[9.29.3, 9.29.3]",
-          "Serilog.Extensions.Logging.File": "[3.0.0, 3.0.0]",
+          "SerilogFileLogging": "[0.0.1, )",
           "SsrfProtection": "[0.0.1, )",
-          "Stripe.net": "[48.5.0, 48.5.0]",
+          "Stripe.net": "[52.1.0, 52.1.0]",
           "YubicoDotNetClient": "[1.2.0, 1.2.0]",
           "ZiggyCreatures.FusionCache": "[2.0.2, 2.0.2]",
           "ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis": "[2.0.2, 2.0.2]",
@@ -1393,7 +1393,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.7.2, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1402,9 +1402,15 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.7.2, )",
-          "Microsoft.Extensions.Logging": "[10.0.8, 10.0.8]",
+          "Core": "[0.0.1, )",
+          "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
+        }
+      },
+      "serilogfilelogging": {
+        "type": "Project",
+        "dependencies": {
+          "Serilog.Extensions.Logging.File": "[3.0.0, 3.0.0]"
         }
       },
       "ssrfprotection": {

--- a/test/Notifications.Test/packages.lock.json
+++ b/test/Notifications.Test/packages.lock.json
@@ -1843,7 +1843,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1913,8 +1913,8 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Common": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.Diagnostics.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1928,7 +1928,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1940,7 +1940,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1948,27 +1948,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1977,17 +1977,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1998,7 +1998,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "MessagePack": "[3.1.7, 3.1.7]",
           "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "[10.0.10, 10.0.10]",
           "Microsoft.AspNetCore.SignalR.StackExchangeRedis": "[10.0.10, 10.0.10]",
@@ -2009,7 +2009,7 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -2025,10 +2025,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -2042,9 +2042,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/SeederApi.IntegrationTest/packages.lock.json
+++ b/test/SeederApi.IntegrationTest/packages.lock.json
@@ -1315,7 +1315,7 @@
         "dependencies": {
           "AutoFixture.AutoNSubstitute": "[4.18.1, )",
           "AutoFixture.Xunit2": "[4.18.1, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Kralizek.AutoFixture.Extensions.MockHttp": "[2.2.1, 2.2.1]",
           "Microsoft.Extensions.TimeProvider.Testing": "[10.8.0, 10.8.0]",
           "Microsoft.NET.Test.Sdk": "[18.0.1, )",
@@ -1386,7 +1386,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1398,7 +1398,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1406,27 +1406,27 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "SharedWeb": "[2026.8.0, )"
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1435,17 +1435,17 @@
       "integrationtestcommon": {
         "type": "Project",
         "dependencies": {
-          "Common": "[2026.8.0, )",
+          "Common": "[0.0.1, )",
           "Identity": "[2026.8.0, )",
           "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
-          "Seeder": "[2026.8.0, )"
+          "Migrator": "[0.0.1, )",
+          "Seeder": "[0.0.1, )"
         }
       },
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1463,10 +1463,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "seederapi": {
@@ -1475,7 +1475,7 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1483,15 +1483,15 @@
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
-          "Seeder": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Seeder": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "seederutility": {
         "type": "Project",
         "dependencies": {
           "CommandDotNet": "[7.0.5, 7.0.5]",
-          "Seeder": "[2026.8.0, )",
+          "Seeder": "[0.0.1, )",
           "Spectre.Console": "[0.55.2, 0.55.2]"
         }
       },
@@ -1506,9 +1506,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/test/Setup.Test/packages.lock.json
+++ b/test/Setup.Test/packages.lock.json
@@ -1446,7 +1446,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1455,7 +1455,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }
@@ -1469,10 +1469,10 @@
       "setup": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Handlebars.Net": "[2.1.6, 2.1.6]",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
-          "Migrator": "[2026.8.0, )",
+          "Migrator": "[0.0.1, )",
           "YamlDotNet": "[11.2.1, 11.2.1]"
         }
       },

--- a/test/SharedWeb.Test/packages.lock.json
+++ b/test/SharedWeb.Test/packages.lock.json
@@ -1640,7 +1640,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1649,21 +1649,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1686,9 +1686,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/util/Migrator/Migrator.csproj
+++ b/util/Migrator/Migrator.csproj
@@ -3,6 +3,12 @@
   <PropertyGroup>
     <!-- These opt outs should be removed when all warnings are addressed -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1305</WarningsNotAsErrors>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/util/Migrator/packages.lock.json
+++ b/util/Migrator/packages.lock.json
@@ -1244,7 +1244,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {

--- a/util/MsSqlMigratorUtility/packages.lock.json
+++ b/util/MsSqlMigratorUtility/packages.lock.json
@@ -1277,7 +1277,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1286,7 +1286,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }

--- a/util/MySqlMigrations/MySqlMigrations.csproj
+++ b/util/MySqlMigrations/MySqlMigrations.csproj
@@ -4,6 +4,12 @@
     <UserSecretsId>9f1cd3e0-70f2-4921-8068-b2538fd7c3f7</UserSecretsId>
     <!-- These opt outs should be removed when all warnings are addressed -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1305</WarningsNotAsErrors>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/util/MySqlMigrations/packages.lock.json
+++ b/util/MySqlMigrations/packages.lock.json
@@ -1503,7 +1503,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1513,12 +1513,12 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"

--- a/util/PostgresMigrations/PostgresMigrations.csproj
+++ b/util/PostgresMigrations/PostgresMigrations.csproj
@@ -3,6 +3,12 @@
   <PropertyGroup>
     <!-- These opt outs should be removed when all warnings are addressed -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1305</WarningsNotAsErrors>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/util/PostgresMigrations/packages.lock.json
+++ b/util/PostgresMigrations/packages.lock.json
@@ -1503,7 +1503,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1513,12 +1513,12 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"

--- a/util/RustSdk/RustSdk.csproj
+++ b/util/RustSdk/RustSdk.csproj
@@ -6,6 +6,12 @@
     <RootNamespace>Bit.RustSDK</RootNamespace>
     <UserSecretsId>Bit.RustSDK</UserSecretsId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/util/Seeder/Seeder.csproj
+++ b/util/Seeder/Seeder.csproj
@@ -9,6 +9,12 @@
     <Description>Core library for generating and managing test data for Bitwarden</Description>
     <OutputType>library</OutputType>
     <IsPackable>false</IsPackable>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/util/Seeder/packages.lock.json
+++ b/util/Seeder/packages.lock.json
@@ -1413,7 +1413,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1422,21 +1422,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1462,9 +1462,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/util/SeederApi/packages.lock.json
+++ b/util/SeederApi/packages.lock.json
@@ -1174,7 +1174,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1183,21 +1183,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1216,10 +1216,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1233,9 +1233,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/util/SeederUtility/packages.lock.json
+++ b/util/SeederUtility/packages.lock.json
@@ -1432,7 +1432,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1441,21 +1441,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1474,10 +1474,10 @@
         "type": "Project",
         "dependencies": {
           "Bogus": "[35.6.5, 35.6.5]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
-          "RustSdk": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
+          "RustSdk": "[0.0.1, )",
+          "SharedWeb": "[0.0.1, )"
         }
       },
       "serilogfilelogging": {
@@ -1491,9 +1491,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/util/Setup/packages.lock.json
+++ b/util/Setup/packages.lock.json
@@ -1250,7 +1250,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1259,7 +1259,7 @@
       "migrator": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.Extensions.Logging": "[10.0.10, 10.0.10]",
           "dbup-sqlserver": "[7.2.0, 7.2.0]"
         }

--- a/util/SqlServerEFScaffold/packages.lock.json
+++ b/util/SqlServerEFScaffold/packages.lock.json
@@ -1657,10 +1657,10 @@
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
           "Bitwarden.Server.Sdk.WebEssentials": "[0.5.0, )",
-          "Commercial.Core": "[2026.8.0, )",
-          "Commercial.Infrastructure.EntityFramework": "[2026.8.0, )",
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Commercial.Core": "[0.0.1, )",
+          "Commercial.Infrastructure.EntityFramework": "[0.0.1, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1670,14 +1670,14 @@
           "OpenTelemetry.Instrumentation.SqlClient": "[1.15.2, )",
           "OrganizationAuthorization": "[0.0.1, )",
           "Pam": "[2026.8.0, )",
-          "SharedWeb": "[2026.8.0, )",
+          "SharedWeb": "[0.0.1, )",
           "Swashbuckle.AspNetCore": "[10.1.7, 10.1.7]"
         }
       },
       "commercial.core": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "CsvHelper": "[33.1.0, 33.1.0]"
         }
       },
@@ -1685,8 +1685,8 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )"
+          "Core": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )"
         }
       },
       "core": {
@@ -1752,7 +1752,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1761,21 +1761,21 @@
       "infrastructure.dapper": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Dapper": "[2.1.66, 2.1.66]",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "infrastructure.entityframework": {
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"
@@ -1784,16 +1784,16 @@
       "organizationauthorization": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )"
+          "Core": "[0.0.1, )"
         }
       },
       "pam": {
         "type": "Project",
         "dependencies": {
-          "Core": "[2026.8.0, )",
-          "HttpExtensions": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "HttpExtensions": "[0.0.1, )",
           "OrganizationAuthorization": "[0.0.1, )",
-          "Pam.Domain": "[2026.8.0, )"
+          "Pam.Domain": "[0.0.1, )"
         }
       },
       "pam.domain": {
@@ -1813,9 +1813,9 @@
         "dependencies": {
           "Bitwarden.Server.Sdk.Environment": "[0.1.0, )",
           "Bitwarden.Server.Sdk.Features": "[1.4.0, )",
-          "Core": "[2026.8.0, )",
-          "Infrastructure.Dapper": "[2026.8.0, )",
-          "Infrastructure.EntityFramework": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
+          "Infrastructure.Dapper": "[0.0.1, )",
+          "Infrastructure.EntityFramework": "[0.0.1, )",
           "Microsoft.Bot.Builder.Integration.AspNet.Core": "[4.23.0, 4.23.0]",
           "Swashbuckle.AspNetCore.SwaggerGen": "[10.1.7, 10.1.7]"
         }

--- a/util/SqliteMigrations/SqliteMigrations.csproj
+++ b/util/SqliteMigrations/SqliteMigrations.csproj
@@ -5,6 +5,12 @@
     <Nullable>enable</Nullable>
     <!-- These opt outs should be removed when all warnings are addressed -->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CA1305</WarningsNotAsErrors>
+    <!--
+      Pinned to 0.0.1: this project is only consumed as a library, so its assembly version is never
+      reported anywhere. Keeping it fixed avoids regenerating every consumer's packages.lock.json
+      on each service version bump.
+    -->
+    <Version>0.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/util/SqliteMigrations/packages.lock.json
+++ b/util/SqliteMigrations/packages.lock.json
@@ -1503,7 +1503,7 @@
       "exceptionhandling": {
         "type": "Project",
         "dependencies": {
-          "HttpExtensions": "[2026.8.0, )"
+          "HttpExtensions": "[0.0.1, )"
         }
       },
       "httpextensions": {
@@ -1513,12 +1513,12 @@
         "type": "Project",
         "dependencies": {
           "AutoMapper": "[14.0.0, 14.0.0]",
-          "Core": "[2026.8.0, )",
+          "Core": "[0.0.1, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.8, 8.0.8]",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.8, 8.0.8]",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.4, 8.0.4]",
-          "Pam.Domain": "[2026.8.0, )",
+          "Pam.Domain": "[0.0.1, )",
           "Pomelo.EntityFrameworkCore.MySql": "[8.0.2, 8.0.2]",
           "linq2db": "[5.4.1, 5.4.1]",
           "linq2db.EntityFrameworkCore": "[8.1.0, 8.1.0]"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39513

Follow-up to the churn seen in #8179 (`Bump version to 2026.8.0`).

## 📔 Objective

Every project's `<Version>` is recorded in each consumer's `packages.lock.json`, so bumping
`<Version>` in the root `Directory.Build.props` rewrites ~60 of the 77 lock files on every
release. This pins projects that are only ever consumed as libraries to `0.0.1` so those
entries stop moving, extending the pattern already established in
`src/Libraries/Directory.Build.props` to the libraries living outside that folder.

**15 projects pinned**

- `src/`: Core, HttpExtensions, Infrastructure.Dapper, Infrastructure.EntityFramework, SharedWeb, Pam.Domain
- `bitwarden_license/src/`: Commercial.Core, Commercial.Infrastructure.EntityFramework
- `util/`: Migrator, MySqlMigrations, PostgresMigrations, SqliteMigrations, RustSdk, Seeder
- `test/`: Common

**Impact**

Measured by pointing `Directory.Build.props` at a throwaway next version and running
`dotnet restore --force-evaluate`:

| | lock files touched by a version bump |
|---|---|
| before | 60 / 77 |
| after | **11 / 77** |

`Pam.Domain` was the single biggest contributor — unpinned, it alone accounted for 40 files,
because both `Infrastructure.Dapper` and `Infrastructure.EntityFramework` reference it and it
therefore leaks into nearly every closure.

The remaining 11 are integration-test projects that legitimately reference `Identity`, `Api`,
or `Pam`. That is the floor without pinning the deployable services themselves.

**Why this is safe**

Nothing reports these assemblies' versions. `MapVersionEndpoint()` resolves
`IBitwardenEnvironment.Version`, which reads the **entry** assembly's
`AssemblyInformationalVersionAttribute` — and every deployable service (Api, Identity, Admin,
Events, EventsProcessor, Icons, Notifications, Billing, Sso, Scim, SeederApi, Pam) is left
unpinned. Admin's self-hosted "installed version" panel uses the same accessor. None of these
projects are packed or pushed to a feed, and none are strong-named.

**Note on `test/Migrator.Test/packages.lock.json`**

This is the one lock file whose diff is not purely the version pin. It was committed stale in
#8143 (added 2026-08-17, a week after the 2026-08-10 bump) and still referenced `2026.7.2`
plus older `Microsoft.Extensions.*` patch versions. `--force-evaluate` corrected it. The other
59 lock files contain version-pin changes only.

## 📸 Screenshots

N/A — build configuration only.
