### PR TITLE
[SHOT-252] fix: Move MSSQL base to RHEL, bump to CU8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
             dotnet: true
           - project_name: MsSql
             base_path: ./util
+            platforms: linux/amd64
           - project_name: MsSqlMigratorUtility
             base_path: ./util
             dotnet: true

--- a/util/MsSql/Dockerfile
+++ b/util/MsSql/Dockerfile
@@ -1,14 +1,8 @@
-FROM mcr.microsoft.com/mssql/server:2025-CU5-ubuntu-22.04
+FROM mcr.microsoft.com/mssql/rhel/server:2025-CU5-rhel-9.1
 
 LABEL com.bitwarden.product="bitwarden"
 
 USER root:root
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    gosu \
-    tzdata \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY util/MsSql/backup-db.sql /
 COPY util/MsSql/backup-db.sh /

--- a/util/MsSql/entrypoint.sh
+++ b/util/MsSql/entrypoint.sh
@@ -27,6 +27,9 @@ useradd -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1 ||
 usermod -o -u $LUID -g $GROUPNAME -s /bin/false $USERNAME >/dev/null 2>&1
 mkhomedir_helper $USERNAME
 
+# setpriv, update the $HOME for the target user
+export HOME=/home/$USERNAME
+
 # Read the SA_PASSWORD value from a file for swarm environments.
 # See https://github.com/Microsoft/mssql-docker/issues/326
 if [ ! -z "$SA_PASSWORD" ] && [ ! -z "$SA_PASSWORD_FILE" ]
@@ -59,7 +62,7 @@ chown $USERNAME:$GROUPNAME /backup-db.sql
 # Launch a loop to backup database on a daily basis
 if [ "$BACKUP_DB" != "0" ]
 then
-    gosu $USERNAME:$GROUPNAME /bin/sh -c "/backup-db.sh loop >/dev/null 2>&1 &"
+    setpriv --reuid $USERNAME --regid $GROUPNAME --init-groups /bin/sh -c "/backup-db.sh loop >/dev/null 2>&1 &"
 fi
 
-exec gosu $USERNAME:$GROUPNAME /opt/mssql/bin/sqlservr
+exec setpriv --reuid $USERNAME --regid $GROUPNAME --init-groups /opt/mssql/bin/sqlservr


### PR DESCRIPTION
Moves MSSQL base to mcr.microsoft.com/mssql/rhel/server:2025-CU8-rhel-10 (SQL Server CU5->CU8) for FIPS support on a currently patched RHEL base. Draft: pending DBOps sign-off and FIPS VM re-test.