### PR TITLE
Give every validation failure one coded problem shape (string matching)

### DIFF
--- a/src/Api/AdminConsole/Controllers/ValidationErrorTypedResultsExtensions.cs
+++ b/src/Api/AdminConsole/Controllers/ValidationErrorTypedResultsExtensions.cs
@@ -18,11 +18,11 @@ public static class ValidationErrorTypedResultsExtensions
             ArgumentNullException.ThrowIfNull(validationError);
 
             return TypedResults.BitwardenValidationProblem(
-                errors: new Dictionary<string, BitwardenTypedResultsExtensions.ErrorCode[]>
+                errors: new Dictionary<string, ErrorCode[]>
                 {
                     {
                         validationError.PropertyName,
-                        [new BitwardenTypedResultsExtensions.ErrorCode(validationError.Type, validationError.Message)]
+                        [new ErrorCode(validationError.Type, validationError.Message)]
                     }
                 });
         }

--- a/src/Api/Utilities/ModelStateValidationFilterAttribute.cs
+++ b/src/Api/Utilities/ModelStateValidationFilterAttribute.cs
@@ -14,15 +14,19 @@ public class ModelStateValidationFilterAttribute : SharedWeb.Utilities.ModelStat
         _publicApi = publicApi;
     }
 
+    /// <remarks>
+    /// Only the internal API takes the coded document. The public API's error shape is a published contract with
+    /// its own versioning, so it keeps answering as it always has until that contract is revised deliberately.
+    /// </remarks>
     protected override void OnModelStateInvalid(ActionExecutingContext context)
     {
         if (_publicApi)
         {
             context.Result = new BadRequestObjectResult(new ErrorResponseModel(context.ModelState));
+            return;
         }
-        else
-        {
-            context.Result = new BadRequestObjectResult(new InternalApi.ErrorResponseModel(context.ModelState));
-        }
+
+        context.Result = TryCodedProblem(context)
+            ?? new BadRequestObjectResult(new InternalApi.ErrorResponseModel(context.ModelState));
     }
 }

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -243,6 +243,7 @@ public static partial class FeatureFlagKeys
     public const string OrgCipherPushFanout = "pm-35168-org-cipher-push-fanout";
     public const string FedRampGovRegion = "fedramp-gov-region";
     public const string ManagedDeviceFramework = "pm-27719-managed-device-framework";
+    public const string CodedValidationProblems = "coded-validation-problems";
 
     /* Tools Team */
     public const string UseSdkPasswordGenerators = "pm-19976-use-sdk-password-generators";

--- a/src/HttpExtensions/BitwardenTypedResultsExtensions.cs
+++ b/src/HttpExtensions/BitwardenTypedResultsExtensions.cs
@@ -7,38 +7,88 @@ public static class BitwardenTypedResultsExtensions
     extension(TypedResults)
     {
         /// <summary>
-        /// Produces a 400 Bad Request RFC 7807 problem response, mirroring
-        /// <c>TypedResults.ValidationProblem</c> but typing each error entry as an array of
-        /// <see cref="ErrorCode"/> rather than <c>string[]</c>.
+        /// Produces an RFC 7807 problem response, mirroring <c>TypedResults.ValidationProblem</c> but typing
+        /// each error entry as an array of <see cref="ErrorCode"/> rather than <c>string[]</c>.
         /// <remarks>
         /// WARNING: This is currently experimental and may change in the future.
         /// </remarks>
         /// </summary>
+        /// <param name="statusCode">
+        /// The response status. Defaults to 400 Bad Request. Pass another 4xx when the failure is carried by this
+        /// same body but is not bad input — 409 Conflict for a state conflict, say — so a caller that only reads
+        /// the status still learns something before it reads the codes.
+        /// </param>
+        /// <param name="extensions">
+        /// Further problem members. A member named <c>errors</c> is dropped: that name belongs to
+        /// <paramref name="errors"/>, and a document carrying it twice is not parseable.
+        /// </param>
         public static BitwardenValidationProblemResult BitwardenValidationProblem(
             IDictionary<string, ErrorCode[]> errors,
             string? detail = null,
             string? instance = null,
             string title = "One or more validation errors occurred.",
             string type = "validation_error",
-            IDictionary<string, object?>? extensions = null)
+            IDictionary<string, object?>? extensions = null,
+            int statusCode = StatusCodes.Status400BadRequest)
         {
             ArgumentNullException.ThrowIfNull(errors);
 
-            var problemExtensions = extensions is null
-                ? new Dictionary<string, object?>()
-                : new Dictionary<string, object?>(extensions);
+            var problemDetails = new BitwardenValidationProblemDetails
+            {
+                Detail = detail,
+                Instance = instance,
+                Status = statusCode,
+                Title = title,
+                Type = type,
+                Errors = new Dictionary<string, ErrorCode[]>(errors),
+            };
 
-            problemExtensions["errors"] = errors;
+            if (extensions is not null)
+            {
+                foreach (var (key, value) in extensions
+                             .Where(extension => extension.Key != BitwardenValidationProblemDetails.ErrorsMember))
+                {
+                    problemDetails.Extensions[key] = value;
+                }
+            }
 
-            return new BitwardenValidationProblemResult(TypedResults.Problem(
+            return new BitwardenValidationProblemResult(problemDetails);
+        }
+
+        /// <summary>
+        /// Produces an RFC 7807 problem response from a flat sequence of property/code pairs, grouping them by
+        /// property so a caller that discovers failures one at a time does not have to build the dictionary itself.
+        /// <remarks>
+        /// WARNING: This is currently experimental and may change in the future.
+        /// </remarks>
+        /// </summary>
+        /// <param name="errors">
+        /// The failures, in the order they should appear under each property. More than one pair may name the same
+        /// property; they are collected into that property's array rather than overwriting one another.
+        /// </param>
+        public static BitwardenValidationProblemResult BitwardenValidationProblem(
+            IEnumerable<(string PropertyName, ErrorCode Code)> errors,
+            string? detail = null,
+            string? instance = null,
+            string title = "One or more validation errors occurred.",
+            string type = "validation_error",
+            IDictionary<string, object?>? extensions = null,
+            int statusCode = StatusCodes.Status400BadRequest)
+        {
+            ArgumentNullException.ThrowIfNull(errors);
+
+            var grouped = errors
+                .GroupBy(error => error.PropertyName)
+                .ToDictionary(group => group.Key, group => group.Select(error => error.Code).ToArray());
+
+            return TypedResults.BitwardenValidationProblem(
+                errors: grouped,
                 detail: detail,
                 instance: instance,
-                statusCode: StatusCodes.Status400BadRequest,
                 title: title,
                 type: type,
-                extensions: problemExtensions));
+                extensions: extensions,
+                statusCode: statusCode);
         }
     }
-
-    public record ErrorCode(string Type, string Detail);
 }

--- a/src/HttpExtensions/BitwardenValidationProblemDetails.cs
+++ b/src/HttpExtensions/BitwardenValidationProblemDetails.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Bit.HttpExtensions;
+
+/// <summary>
+/// The body a <see cref="BitwardenValidationProblemResult"/> writes: the RFC 7807 members plus an
+/// <c>errors</c> map keyed by the property that failed, each entry carrying a code the client switches on.
+/// </summary>
+/// <remarks>
+/// Named as a type rather than assembled into <see cref="ProblemDetails.Extensions"/> so that the document a
+/// client parses and the document OpenAPI describes are the same declaration, and neither can drift from the
+/// other.
+/// </remarks>
+public sealed class BitwardenValidationProblemDetails : ProblemDetails
+{
+    /// <summary>The document member the errors map is written under.</summary>
+    internal const string ErrorsMember = "errors";
+
+    /// <summary>
+    /// The failures, keyed by the property name as it appeared on the wire. A property that failed several ways
+    /// carries an entry per failure.
+    /// </summary>
+    /// <remarks>
+    /// Ordered after the inherited members so the code that reads the document meets <c>type</c> and
+    /// <c>status</c> before the detail of what went wrong, as it does in every other problem response.
+    /// </remarks>
+    [JsonPropertyOrder(100)]
+    [JsonPropertyName(ErrorsMember)]
+    public IDictionary<string, ErrorCode[]> Errors { get; init; } = new Dictionary<string, ErrorCode[]>();
+}

--- a/src/HttpExtensions/BitwardenValidationProblemResult.cs
+++ b/src/HttpExtensions/BitwardenValidationProblemResult.cs
@@ -1,17 +1,20 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.HttpExtensions;
 
 /// <summary>
 /// A Bitwarden-flavored RFC 7807 validation problem result. Wraps an inner
-/// <see cref="ProblemHttpResult"/> so we have room to grow — for example, implementing
-/// <c>IEndpointMetadataProvider</c> for OpenAPI — without changing the public signature of
+/// <see cref="ProblemHttpResult"/> so we have room to grow without changing the public signature of
 /// <c>TypedResults.BitwardenValidationProblem</c>.
 /// </summary>
 public sealed class BitwardenValidationProblemResult :
     IResult,
+    IEndpointMetadataProvider,
     IStatusCodeHttpResult,
     IContentTypeHttpResult,
     IValueHttpResult,
@@ -19,21 +22,41 @@ public sealed class BitwardenValidationProblemResult :
 {
     private readonly ProblemHttpResult _inner;
 
-    internal BitwardenValidationProblemResult(ProblemHttpResult inner)
+    internal BitwardenValidationProblemResult(BitwardenValidationProblemDetails problemDetails)
     {
-        ArgumentNullException.ThrowIfNull(inner);
-        _inner = inner;
+        ArgumentNullException.ThrowIfNull(problemDetails);
+        _inner = TypedResults.Problem(problemDetails);
+        ProblemDetails = problemDetails;
     }
 
-    public ProblemDetails ProblemDetails => _inner.ProblemDetails;
+    public BitwardenValidationProblemDetails ProblemDetails { get; }
 
     public int? StatusCode => _inner.StatusCode;
 
     public string? ContentType => _inner.ContentType;
 
-    object? IValueHttpResult.Value => _inner.ProblemDetails;
+    object? IValueHttpResult.Value => ProblemDetails;
 
-    ProblemDetails? IValueHttpResult<ProblemDetails>.Value => _inner.ProblemDetails;
+    ProblemDetails? IValueHttpResult<ProblemDetails>.Value => ProblemDetails;
 
     public Task ExecuteAsync(HttpContext httpContext) => _inner.ExecuteAsync(httpContext);
+
+    /// <summary>
+    /// Declares the problem document on every endpoint whose handler can return this result, so a client reads
+    /// the coded shape out of OpenAPI rather than out of our source.
+    /// </summary>
+    /// <remarks>
+    /// Declares 400, the status the result defaults to. An endpoint that carries this same body on another
+    /// status — 409 for a state conflict — declares that one itself with <c>Produces</c>.
+    /// </remarks>
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.Metadata.Add(new ProducesResponseTypeMetadata(
+            StatusCodes.Status400BadRequest,
+            typeof(BitwardenValidationProblemDetails),
+            ["application/problem+json"]));
+    }
 }

--- a/src/HttpExtensions/ErrorCode.cs
+++ b/src/HttpExtensions/ErrorCode.cs
@@ -1,0 +1,33 @@
+﻿using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Bit.HttpExtensions;
+
+/// <summary>
+/// One failure under a property: a stable <paramref name="Type"/> the client switches on, a human-readable
+/// <paramref name="Detail"/>, and the substitutions it needs to render that detail in another language.
+/// </summary>
+/// <param name="Type">
+/// The machine-readable code. Names what went wrong and never the property it is keyed under — <c>required</c>,
+/// not <c>name_required</c>. Draw it from <see cref="ValidationCodes"/> rather than spelling one locally.
+/// </param>
+/// <param name="Detail">
+/// The English message. A client that localizes renders from <paramref name="Type"/> and its
+/// <paramref name="Parameters"/> instead, so this is a fallback rather than the contract.
+/// </param>
+/// <param name="Parameters">
+/// The substitutions a client needs to render its own message for <paramref name="Type"/> — a length limit, a
+/// range bound. Omitted from the body when null, so a code needing no substitution costs nothing. Carries the
+/// limit that was breached and never anything derived from the value that breached it: a length ceiling, never
+/// the string that overran it. Key it from <see cref="ValidationParameters"/>.
+/// </param>
+/// <remarks>
+/// <see cref="JsonObject"/> rather than a dictionary of <c>object</c> so the document stays serializable without
+/// reflection. An <c>object</c> value has to have its runtime type resolved when it is written, which is the one
+/// thing a source-generated — and so trim- and AOT-safe — serializer cannot do.
+/// </remarks>
+public sealed record ErrorCode(
+    string Type,
+    string Detail,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    JsonObject? Parameters = null);

--- a/src/HttpExtensions/HttpExtensions.csproj
+++ b/src/HttpExtensions/HttpExtensions.csproj
@@ -1,5 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <!--
+        Turns the trim and AOT analyzers on for this assembly so it stays publishable from a trimmed or
+        ahead-of-time minimal API. Reflective paths here are reachable only from MVC, which is unsupported under
+        both, and say so with [RequiresUnreferencedCode]; this keeps anything new from quietly joining them.
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/src/HttpExtensions/README.md
+++ b/src/HttpExtensions/README.md
@@ -1,0 +1,101 @@
+# HttpExtensions — validation problems
+
+Every validation failure answers with one RFC 7807 document carrying a machine-readable code the
+client can switch on and localize.
+
+Before, a request that failed its DataAnnotations answered with the `ErrorResponseModel` envelope
+while a request its handler rejected answered with a problem document. Same endpoint, same field,
+two bodies and two key conventions — a client needed both parsers, and only one of them carried a
+code.
+
+```json
+{
+  "type": "validation_error",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "errors": {
+    "reason": [{ "type": "required", "detail": "The Reason field is required." }],
+    "name": [{
+      "type": "too_long",
+      "detail": "The field Name must be a string with a maximum length of 200.",
+      "parameters": { "max": 200 }
+    }]
+  }
+}
+```
+
+`type` names what went wrong and never the field it is keyed under (`required`, not
+`name_required`), so a client handles it generically wherever it appears. `parameters` carries what
+a client needs to write its own sentence in its own language.
+
+## Vocabulary
+
+Draw codes from [`ValidationCodes`](ValidationCodes.cs) and parameter keys from
+[`ValidationParameters`](ValidationParameters.cs). Two validators catching the same condition must
+answer with the same code — that is the point of a shared list, and it applies to parameter keys
+just as much: a client looking up `max` finds nothing under `maximum`.
+
+`parameters` carries the limit that was breached and never anything derived from the value that
+breached it — a length ceiling, never the string that overran it. Error bodies travel further than
+the request did.
+
+## Returning one from a handler
+
+```csharp
+return TypedResults.BitwardenValidationProblem(
+[
+    ("reason", new ErrorCode(ValidationCodes.Required, "Reason is required.")),
+]);
+```
+
+## Attribute failures
+
+DataAnnotations records a message and discards the constraint that produced it: the `200` in
+`[StringLength(200)]` is gone by the time the failure is reported. The sentence it leaves behind
+does still contain that `200`, so [`ValidationMessageCodes`](ValidationMessageCodes.cs) recognises
+the wording and lifts the value back out, and
+[`ValidationProblemFactory`](ValidationProblemFactory.cs) assembles the document.
+
+Nothing here validates anything and nothing here reflects. The framework decides whether a value is
+valid; this reads what it said afterwards. Being pure string work it needs no generator, no
+registration and no `[RequiresUnreferencedCode]` — the assembly builds with `IsAotCompatible` and is
+clean, so it can be published from a trimmed or ahead-of-time minimal API as-is.
+
+### What this costs
+
+The wording is the contract, and that has three consequences worth knowing before you rely on it.
+
+**A reworded message loses its code.** The failure is still reported, with its message intact, as
+`invalid`. `ValidationMessageCodesTests` asserts every pattern against the message its attribute
+actually produces, so a framework reword fails the build on the next SDK bump rather than in
+production.
+
+**An explicit `ErrorMessage` never matches.** `[Required(ErrorMessage = "'key' must be provided")]`
+is recognised by nothing and reports as `invalid`. Roughly 5% of the repo's validation attributes
+set one today.
+
+**Renamed and non-numeric values are approximate.** Model state keys the CLR name, so a property
+renamed by `[JsonPropertyName]` is reported under its camel-cased CLR name rather than the name the
+client sent — the same thing the previous envelope did. And a bound lifted out of prose is the
+framework's rendering of it, so `[Range(typeof(DateTime), "2020-01-01", …)]` yields
+`"2020-01-01 00:00:00"`, not the declared literal.
+
+All three are fixable by reading the model's attributes instead of its messages — with reflection,
+which is not trim-safe, or with a source generator, which is more machinery. This takes the cheap
+option deliberately.
+
+## Turning it on
+
+The coded document is behind `FeatureFlagKeys.CodedValidationProblems`. With the flag off, every
+surface answers exactly as it did before.
+
+It replaces a body clients are already parsing, so each surface opts in separately —
+`ModelStateValidationFilterAttribute.TryCodedProblem` offers it, and only the internal Api takes it
+today. The public API keeps its published shape, which is versioned on its own terms.
+
+## Known gaps
+
+- `ExceptionHandlerFilterAttribute` still answers with `ErrorResponseModel`, so
+  `throw new BadRequestException(modelState)` bypasses all of this.
+- `.Produces<BitwardenValidationProblemDetails>(400)` is not declared on endpoints, so OpenAPI does
+  not yet describe the coded shape.

--- a/src/HttpExtensions/ValidationCodes.cs
+++ b/src/HttpExtensions/ValidationCodes.cs
@@ -1,0 +1,62 @@
+﻿namespace Bit.HttpExtensions;
+
+/// <summary>
+/// The repo-wide vocabulary of validation codes. A code names <em>what went wrong</em>; the property it is keyed
+/// under names <em>where</em>, so a code never repeats the field it describes — <c>required</c>, not
+/// <c>name_required</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Codes are scoped to their property, so the same code under two properties means the same thing in both, and a
+/// client can handle <c>required</c> generically wherever it appears rather than learning one spelling per field.
+/// </para>
+/// <para>
+/// Two validators catching the same condition must answer with the same code — that is the point of a shared
+/// list. Add a constant here before inventing a spelling locally.
+/// </para>
+/// </remarks>
+public static class ValidationCodes
+{
+    /// <summary>A value is absent that must be present.</summary>
+    public const string Required = "required";
+
+    /// <summary>A value is longer than its limit. Carries <c>max</c>.</summary>
+    public const string TooLong = "too_long";
+
+    /// <summary>A value is shorter than its limit. Carries <c>min</c>.</summary>
+    public const string TooShort = "too_short";
+
+    /// <summary>
+    /// A value breaches a length constraint that bounds it at both ends. Carries <c>min</c> and <c>max</c>.
+    /// </summary>
+    /// <remarks>
+    /// One code rather than <see cref="TooLong"/> and <see cref="TooShort"/> because a two-ended constraint
+    /// reports the same message whichever end was breached, leaving nothing to tell them apart. The client has
+    /// both bounds and composes the sentence itself.
+    /// </remarks>
+    public const string InvalidLength = "invalid_length";
+
+    /// <summary>A number falls outside its permitted range. Carries <c>min</c> and <c>max</c>.</summary>
+    public const string OutOfRange = "out_of_range";
+
+    /// <summary>A number is zero or negative where only a positive value makes sense.</summary>
+    public const string MustBePositive = "must_be_positive";
+
+    /// <summary>A value exceeds a ceiling. Carries <c>max</c>.</summary>
+    public const string ExceedsMax = "exceeds_max";
+
+    /// <summary>A value is not a well-formed email address.</summary>
+    public const string InvalidEmail = "invalid_email";
+
+    /// <summary>A value does not match the pattern this property requires. Carries <c>pattern</c>.</summary>
+    public const string InvalidFormat = "invalid_format";
+
+    /// <summary>A value differs from the one it was required to equal. Carries <c>other</c>.</summary>
+    public const string MustMatch = "must_match";
+
+    /// <summary>A value is not one this property accepts, for a reason no more specific code covers.</summary>
+    public const string Invalid = "invalid";
+
+    /// <summary>A value is well-formed but already taken by something else.</summary>
+    public const string Taken = "taken";
+}

--- a/src/HttpExtensions/ValidationMessageCodes.cs
+++ b/src/HttpExtensions/ValidationMessageCodes.cs
@@ -1,0 +1,175 @@
+﻿using System.Globalization;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace Bit.HttpExtensions;
+
+/// <summary>
+/// Names a validation failure by recognising the message the framework recorded for it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// DataAnnotations records a message and discards the constraint that produced it, so the only thing left to work
+/// from is the sentence — which does at least still contain the limit that was breached. Each pattern below
+/// recognises one attribute's wording and lifts its values back out.
+/// </para>
+/// <para>
+/// Nothing here validates anything, and nothing here reflects. The framework decides whether a value is valid;
+/// this only reads what it said afterwards. Being pure string work, it survives trimming and ahead-of-time
+/// publishing with no annotations and no generated lookup.
+/// </para>
+/// <para>
+/// The cost is that the wording is the contract. A framework release that rewrites a message stops it being
+/// recognised, and the failure is reported as <see cref="ValidationCodes.Invalid"/> with its message intact
+/// rather than under a wrong code. <c>ValidationMessageCodesTests</c> asserts every pattern against the message
+/// its attribute actually produces, so a reword fails the build on the next SDK bump instead of in production.
+/// </para>
+/// </remarks>
+public static partial class ValidationMessageCodes
+{
+    /// <summary>
+    /// The code and parameters for <paramref name="message"/>, or <see cref="ValidationCodes.Invalid"/> when no
+    /// pattern claims it.
+    /// </summary>
+    /// <remarks>
+    /// Always answers. An unrecognised message keeps its detail and loses only its code, because a failure that
+    /// reached the client uncoded is still a failure it can read.
+    /// </remarks>
+    public static ErrorCode Resolve(string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        if (Required().IsMatch(message))
+        {
+            return new ErrorCode(ValidationCodes.Required, message);
+        }
+
+        if (BoundedLength().Match(message) is { Success: true } bounded)
+        {
+            // One message covers both directions of a two-ended constraint, so there is nothing to tell them
+            // apart. The client gets both bounds and composes the sentence itself.
+            return Coded(ValidationCodes.InvalidLength, message,
+                (ValidationParameters.Min, bounded.Groups[1].Value),
+                (ValidationParameters.Max, bounded.Groups[2].Value));
+        }
+
+        if (MaximumLength().Match(message) is { Success: true } tooLong)
+        {
+            return Coded(ValidationCodes.TooLong, message, (ValidationParameters.Max, tooLong.Groups[1].Value));
+        }
+
+        if (MinimumLength().Match(message) is { Success: true } tooShort)
+        {
+            return Coded(ValidationCodes.TooShort, message, (ValidationParameters.Min, tooShort.Groups[1].Value));
+        }
+
+        if (Range().Match(message) is { Success: true } range)
+        {
+            return Coded(ValidationCodes.OutOfRange, message,
+                (ValidationParameters.Min, range.Groups[1].Value),
+                (ValidationParameters.Max, range.Groups[2].Value));
+        }
+
+        if (EmailAddress().IsMatch(message))
+        {
+            return new ErrorCode(ValidationCodes.InvalidEmail, message);
+        }
+
+        if (Pattern().Match(message) is { Success: true } pattern)
+        {
+            return Coded(ValidationCodes.InvalidFormat, message,
+                (ValidationParameters.Pattern, pattern.Groups[1].Value));
+        }
+
+        if (Compare().Match(message) is { Success: true } compare)
+        {
+            return Coded(ValidationCodes.MustMatch, message, (ValidationParameters.Other, compare.Groups[1].Value));
+        }
+
+        if (Url().IsMatch(message) || Phone().IsMatch(message) || CreditCard().IsMatch(message))
+        {
+            return new ErrorCode(ValidationCodes.InvalidFormat, message);
+        }
+
+        return new ErrorCode(ValidationCodes.Invalid, message);
+    }
+
+    private static ErrorCode Coded(string code, string message, params (string Name, string Value)[] parameters)
+    {
+        var bag = new JsonObject();
+        foreach (var (name, value) in parameters)
+        {
+            bag[name] = Number(value);
+        }
+
+        return new ErrorCode(code, message, bag);
+    }
+
+    /// <summary>
+    /// The bound as the closest thing it reads as.
+    /// </summary>
+    /// <remarks>
+    /// Lifted out of prose, so a bound that is not a number is carried as the text it was written as — a date
+    /// range states its bounds as dates, and inventing a number for them would be worse than passing them along.
+    /// </remarks>
+    private static JsonNode? Number(string value)
+    {
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var whole))
+        {
+            return JsonValue.Create(whole);
+        }
+
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var wide))
+        {
+            return JsonValue.Create(wide);
+        }
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var real))
+        {
+            return JsonValue.Create(real);
+        }
+
+        return JsonValue.Create(value);
+    }
+
+    [GeneratedRegex(@"^The (?:.+) field is required\.$", RegexOptions.CultureInvariant)]
+    private static partial Regex Required();
+
+    [GeneratedRegex(
+        @"^The field (?:.+) must be a string with a minimum length of (.+) and a maximum length of (.+)\.$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex BoundedLength();
+
+    [GeneratedRegex(
+        @"^The field (?:.+) must be a string (?:or array type )?with a maximum length of '?(.+?)'?\.$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex MaximumLength();
+
+    [GeneratedRegex(
+        @"^The field (?:.+) must be a string (?:or array type )?with a minimum length of '?(.+?)'?\.$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex MinimumLength();
+
+    [GeneratedRegex(@"^The field (?:.+) must be between (.+) and (.+)\.$", RegexOptions.CultureInvariant)]
+    private static partial Regex Range();
+
+    [GeneratedRegex(@"^The (?:.+) field is not a valid e-mail address\.$", RegexOptions.CultureInvariant)]
+    private static partial Regex EmailAddress();
+
+    [GeneratedRegex(@"^The field (?:.+) must match the regular expression '(.+)'\.$", RegexOptions.CultureInvariant)]
+    private static partial Regex Pattern();
+
+    [GeneratedRegex(@"^'(?:.+)' and '(.+)' do not match\.$", RegexOptions.CultureInvariant)]
+    private static partial Regex Compare();
+
+    [GeneratedRegex(
+        @"^The (?:.+) field is not a valid fully-qualified http, https, or ftp URL\.$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex Url();
+
+    [GeneratedRegex(@"^The (?:.+) field is not a valid phone number\.$", RegexOptions.CultureInvariant)]
+    private static partial Regex Phone();
+
+    [GeneratedRegex(@"^The (?:.+) field is not a valid credit card number\.$", RegexOptions.CultureInvariant)]
+    private static partial Regex CreditCard();
+}

--- a/src/HttpExtensions/ValidationParameters.cs
+++ b/src/HttpExtensions/ValidationParameters.cs
@@ -1,0 +1,24 @@
+﻿namespace Bit.HttpExtensions;
+
+/// <summary>
+/// The repo-wide spelling of the keys an <see cref="ErrorCode.Parameters"/> bag carries.
+/// </summary>
+/// <remarks>
+/// A shared list for the same reason <see cref="ValidationCodes"/> is one: a client renders its own message by
+/// looking a substitution up by name, so two validators reporting the same limit as <c>max</c> and <c>maximum</c>
+/// break it exactly as surely as two spellings of the code would.
+/// </remarks>
+public static class ValidationParameters
+{
+    /// <summary>The lower bound a value missed.</summary>
+    public const string Min = "min";
+
+    /// <summary>The upper bound a value exceeded.</summary>
+    public const string Max = "max";
+
+    /// <summary>The pattern a value did not match.</summary>
+    public const string Pattern = "pattern";
+
+    /// <summary>The property this one was required to match.</summary>
+    public const string Other = "other";
+}

--- a/src/HttpExtensions/ValidationProblemFactory.cs
+++ b/src/HttpExtensions/ValidationProblemFactory.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Bit.HttpExtensions;
+
+/// <summary>
+/// Turns the model state the framework filled in into the coded problem document clients read.
+/// </summary>
+/// <remarks>
+/// Every failure in the model state reaches the document, coded when
+/// <see cref="ValidationMessageCodes"/> recognises its message and as <see cref="ValidationCodes.Invalid"/> when
+/// it does not — a failure is never dropped for want of a code, because a client that gets a 400 with an empty
+/// <c>errors</c> map has been told less than nothing.
+/// </remarks>
+public static class ValidationProblemFactory
+{
+    /// <summary>
+    /// Builds the document for <paramref name="modelState"/>, keyed by the property names the client sent.
+    /// </summary>
+    public static BitwardenValidationProblemDetails FromModelState(
+        ModelStateDictionary modelState,
+        string title = "One or more validation errors occurred.",
+        string type = "validation_error",
+        int statusCode = StatusCodes.Status400BadRequest)
+    {
+        ArgumentNullException.ThrowIfNull(modelState);
+
+        var errors = new Dictionary<string, List<ErrorCode>>(StringComparer.Ordinal);
+
+        foreach (var (key, entry) in modelState)
+        {
+            if (entry.ValidationState != ModelValidationState.Invalid || entry.Errors.Count == 0)
+            {
+                continue;
+            }
+
+            var wirePath = ToWireName(key);
+            if (!errors.TryGetValue(wirePath, out var codes))
+            {
+                codes = [];
+                errors[wirePath] = codes;
+            }
+
+            foreach (var modelError in entry.Errors)
+            {
+                codes.Add(ValidationMessageCodes.Resolve(Describe(modelError)));
+            }
+        }
+
+        return new BitwardenValidationProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Type = type,
+            Errors = errors.ToDictionary(pair => pair.Key, pair => pair.Value.ToArray(), StringComparer.Ordinal),
+        };
+    }
+
+    /// <summary>
+    /// The message to report, falling back when model binding recorded an exception instead of one.
+    /// </summary>
+    /// <remarks>
+    /// The exception's own message is not used: a binding failure carries framework or serializer detail that
+    /// describes our internals rather than the caller's mistake, and it is not ours to put on the wire.
+    /// </remarks>
+    private static string Describe(ModelError modelError) =>
+        !string.IsNullOrEmpty(modelError.ErrorMessage)
+            ? modelError.ErrorMessage
+            : "The value provided is not valid.";
+
+    /// <summary>
+    /// The property path as the client wrote it, matching the camel casing the serializer applies to everything
+    /// else.
+    /// </summary>
+    /// <remarks>
+    /// Model state keys the CLR name, and without reading the model there is nothing to consult for a property
+    /// renamed by <c>[JsonPropertyName]</c>. Such a property is reported under its camel-cased CLR name, which is
+    /// what the previous envelope did too.
+    /// </remarks>
+    private static string ToWireName(string modelStateKey)
+    {
+        if (string.IsNullOrEmpty(modelStateKey))
+        {
+            return string.Empty;
+        }
+
+        var segments = modelStateKey.Split('.');
+        for (var i = 0; i < segments.Length; i++)
+        {
+            segments[i] = CamelCase(segments[i]);
+        }
+
+        return string.Join('.', segments);
+    }
+
+    private static string CamelCase(string segment) =>
+        segment.Length > 0 && char.IsUpper(segment[0])
+            ? char.ToLowerInvariant(segment[0]) + segment[1..]
+            : segment;
+}

--- a/src/HttpExtensions/packages.lock.json
+++ b/src/HttpExtensions/packages.lock.json
@@ -1,6 +1,13 @@
 {
   "version": 1,
   "dependencies": {
-    "net10.0": {}
+    "net10.0": {
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[10.0.8, )",
+        "resolved": "10.0.8",
+        "contentHash": "dVbSXGIFNR5nZcv2tOLoWI+a9T4jtFd77IYjuND+QVe360qWgAF7H0WtoopYhRw/+SgpGUTyrkrh+65+ClNnfw=="
+      }
+    }
   }
 }

--- a/src/SharedWeb/Utilities/ModelStateValidationFilterAttribute.cs
+++ b/src/SharedWeb/Utilities/ModelStateValidationFilterAttribute.cs
@@ -1,6 +1,11 @@
-﻿using Bit.Core.Models.Api;
+﻿using Bit.Core;
+using Bit.Core.Models.Api;
+using Bit.HttpExtensions;
+using Bitwarden.Server.Sdk.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Bit.SharedWeb.Utilities;
 
@@ -27,5 +32,30 @@ public class ModelStateValidationFilterAttribute : ActionFilterAttribute
     protected virtual void OnModelStateInvalid(ActionExecutingContext context)
     {
         context.Result = new BadRequestObjectResult(new ErrorResponseModel(context.ModelState));
+    }
+
+    /// <summary>
+    /// The coded problem document for this failure, or null when the surface has not been switched over to it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Offered rather than applied, because the shape is a breaking change for whoever is reading it: a caller
+    /// parsing <c>validationErrors</c> finds nothing it recognises in an RFC 7807 body. Each surface opts in on
+    /// its own schedule, and none is switched by inheriting from this.
+    /// </para>
+    /// </remarks>
+    protected static IActionResult? TryCodedProblem(ActionExecutingContext context)
+    {
+        var featureService = context.HttpContext.RequestServices.GetService<IFeatureService>();
+        if (featureService?.IsEnabled(FeatureFlagKeys.CodedValidationProblems) != true)
+        {
+            return null;
+        }
+
+        return new ObjectResult(ValidationProblemFactory.FromModelState(context.ModelState))
+        {
+            StatusCode = StatusCodes.Status400BadRequest,
+            ContentTypes = { "application/problem+json" },
+        };
     }
 }

--- a/test/Api.Test/AdminConsole/Controllers/ValidationErrorTypedResultsExtensionsTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/ValidationErrorTypedResultsExtensionsTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Xunit;
-using static Microsoft.AspNetCore.Http.HttpResults.BitwardenTypedResultsExtensions;
 
 namespace Bit.Api.Test.AdminConsole.Controllers;
 
@@ -16,7 +15,7 @@ public class ValidationErrorTypedResultsExtensionsTests
         var result = TypedResults.BitwardenValidationProblem(validationError);
 
         Assert.Equal(StatusCodes.Status400BadRequest, result.StatusCode);
-        var errors = Assert.IsType<Dictionary<string, ErrorCode[]>>(result.ProblemDetails.Extensions["errors"]);
+        var errors = result.ProblemDetails.Errors;
         var entry = Assert.Single(errors);
         Assert.Equal("email", entry.Key);
         var error = Assert.Single(entry.Value);

--- a/test/Api.Test/Utilities/ModelStateValidationFilterAttributeTests.cs
+++ b/test/Api.Test/Utilities/ModelStateValidationFilterAttributeTests.cs
@@ -1,0 +1,109 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Api.Utilities;
+using Bit.Core;
+using Bit.HttpExtensions;
+using Bitwarden.Server.Sdk.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+using InternalApi = Bit.Core.Models.Api;
+using PublicApi = Bit.Api.Models.Public.Response;
+
+namespace Bit.Api.Test.Utilities;
+
+/// <summary>
+/// Which body each surface answers a failed model with, and when.
+/// </summary>
+/// <remarks>
+/// The coded document replaces one a client is already parsing, so what matters here is not that it is produced
+/// but that nothing produces it until it is switched on, and that the public API never does.
+/// </remarks>
+public class ModelStateValidationFilterAttributeTests
+{
+    private sealed class Model
+    {
+        [Required]
+        public string? Name { get; set; }
+    }
+
+    [Fact]
+    public void InternalApi_WithTheFlagOff_AnswersWithTheLegacyEnvelope()
+    {
+        var context = Context();
+
+        new ModelStateValidationFilterAttribute(publicApi: false).OnActionExecuting(context);
+
+        var result = Assert.IsType<BadRequestObjectResult>(context.Result);
+        Assert.IsType<InternalApi.ErrorResponseModel>(result.Value);
+    }
+
+    [Fact]
+    public void InternalApi_WithTheFlagOn_AnswersWithTheCodedProblemDocument()
+    {
+        var context = Context(flagEnabled: true);
+
+        new ModelStateValidationFilterAttribute(publicApi: false).OnActionExecuting(context);
+
+        var result = Assert.IsType<ObjectResult>(context.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, result.StatusCode);
+        Assert.Contains("application/problem+json", result.ContentTypes);
+        var problem = Assert.IsType<BitwardenValidationProblemDetails>(result.Value);
+        Assert.Equal("validation_error", problem.Type);
+        Assert.Single(problem.Errors);
+    }
+
+    [Fact]
+    public void PublicApi_WithTheFlagOn_StillAnswersWithItsPublishedShape()
+    {
+        // The public API's error shape is versioned separately and is not carried along by this flag.
+        var context = Context(flagEnabled: true);
+
+        new ModelStateValidationFilterAttribute(publicApi: true).OnActionExecuting(context);
+
+        var result = Assert.IsType<BadRequestObjectResult>(context.Result);
+        Assert.IsType<PublicApi.ErrorResponseModel>(result.Value);
+    }
+
+    [Fact]
+    public void AValidModel_IsLeftAlone()
+    {
+        var context = Context(flagEnabled: true, invalid: false);
+
+        new ModelStateValidationFilterAttribute(publicApi: false).OnActionExecuting(context);
+
+        Assert.Null(context.Result);
+    }
+
+    private static ActionExecutingContext Context(bool flagEnabled = false, bool invalid = true)
+    {
+        var featureService = Substitute.For<IFeatureService>();
+        featureService.IsEnabled(FeatureFlagKeys.CodedValidationProblems).Returns(flagEnabled);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(featureService);
+
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        var descriptor = new ControllerActionDescriptor
+        {
+            Parameters = [new ParameterDescriptor { Name = "model", ParameterType = typeof(Model) }],
+        };
+
+        var actionContext = new ActionContext(httpContext, new RouteData(), descriptor);
+        if (invalid)
+        {
+            actionContext.ModelState.AddModelError("Name", "The Name field is required.");
+        }
+
+        return new ActionExecutingContext(
+            actionContext,
+            [],
+            new Dictionary<string, object?> { ["model"] = new Model() },
+            controller: null!);
+    }
+}

--- a/test/HttpExtensions.Test/BitwardenTypedResultsExtensionsTests.cs
+++ b/test/HttpExtensions.Test/BitwardenTypedResultsExtensionsTests.cs
@@ -1,14 +1,13 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Xunit;
-using static Microsoft.AspNetCore.Http.HttpResults.BitwardenTypedResultsExtensions;
 
 namespace Bit.HttpExtensions.Test;
 
 public class BitwardenTypedResultsExtensionsTests
 {
     [Fact]
-    public void BitwardenValidationProblem_WithErrorsDictionary_Returns400WithErrorsExtension()
+    public void BitwardenValidationProblem_WithErrorsDictionary_Returns400CarryingThem()
     {
         var errors = new Dictionary<string, ErrorCode[]>
         {
@@ -20,8 +19,7 @@ public class BitwardenTypedResultsExtensionsTests
         Assert.Equal(StatusCodes.Status400BadRequest, result.StatusCode);
         Assert.Equal("One or more validation errors occurred.", result.ProblemDetails.Title);
         Assert.Equal("validation_error", result.ProblemDetails.Type);
-        Assert.True(result.ProblemDetails.Extensions.ContainsKey("errors"));
-        Assert.Same(errors, result.ProblemDetails.Extensions["errors"]);
+        Assert.Equal("invalid", Assert.Single(result.ProblemDetails.Errors["email"]).Type);
     }
 
     [Fact]
@@ -39,11 +37,11 @@ public class BitwardenTypedResultsExtensionsTests
         var result = TypedResults.BitwardenValidationProblem(errors, extensions: callerExtensions);
 
         Assert.Equal("abc-123", result.ProblemDetails.Extensions["traceId"]);
-        Assert.Same(errors, result.ProblemDetails.Extensions["errors"]);
+        Assert.Equal("invalid", Assert.Single(result.ProblemDetails.Errors["email"]).Type);
     }
 
     [Fact]
-    public void BitwardenValidationProblem_WithExtensionsContainingErrorsKey_OverwritesWithProvidedErrors()
+    public void BitwardenValidationProblem_WithExtensionsContainingErrorsKey_DropsItForTheErrorsMap()
     {
         var errors = new Dictionary<string, ErrorCode[]>
         {
@@ -51,17 +49,75 @@ public class BitwardenTypedResultsExtensionsTests
         };
         var callerExtensions = new Dictionary<string, object?>
         {
-            { "errors", "should be overwritten" }
+            { "errors", "should be dropped" }
         };
 
         var result = TypedResults.BitwardenValidationProblem(errors, extensions: callerExtensions);
 
-        Assert.Same(errors, result.ProblemDetails.Extensions["errors"]);
+        Assert.DoesNotContain("errors", result.ProblemDetails.Extensions.Keys);
+        Assert.Equal("invalid", Assert.Single(result.ProblemDetails.Errors["email"]).Type);
+    }
+
+    [Fact]
+    public void BitwardenValidationProblem_WithAStatusCode_UsesItInsteadOf400()
+    {
+        var errors = new Dictionary<string, ErrorCode[]>
+        {
+            { "code", [new ErrorCode("already_active", "You already have this.")] }
+        };
+
+        var result = TypedResults.BitwardenValidationProblem(
+            errors, title: "The request conflicts with the current state.", type: "conflict_error",
+            statusCode: StatusCodes.Status409Conflict);
+
+        Assert.Equal(StatusCodes.Status409Conflict, result.StatusCode);
+        Assert.Equal(StatusCodes.Status409Conflict, result.ProblemDetails.Status);
+        Assert.Equal("conflict_error", result.ProblemDetails.Type);
+        Assert.Equal("already_active", Assert.Single(result.ProblemDetails.Errors["code"]).Type);
     }
 
     [Fact]
     public void BitwardenValidationProblem_WithNullErrors_Throws()
     {
         Assert.Throws<ArgumentNullException>(() => TypedResults.BitwardenValidationProblem(((IDictionary<string, ErrorCode[]>)null!)!));
+    }
+
+    [Fact]
+    public void BitwardenValidationProblem_WithPairs_GroupsThemByProperty()
+    {
+        (string, ErrorCode)[] errors =
+        [
+            ("password", new ErrorCode("too_short", "Password is too short.")),
+            ("email", new ErrorCode("invalid", "Email is invalid.")),
+            ("password", new ErrorCode("missing_digit", "Password needs a digit.")),
+        ];
+
+        var result = TypedResults.BitwardenValidationProblem(errors);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, result.StatusCode);
+        var grouped = result.ProblemDetails.Errors;
+        Assert.Equal(2, grouped.Count);
+        Assert.Equal("invalid", Assert.Single(grouped["email"]).Type);
+        Assert.Equal(["too_short", "missing_digit"], grouped["password"].Select(error => error.Type));
+    }
+
+    [Fact]
+    public void BitwardenValidationProblem_WithPairsAndAStatusCode_UsesItInsteadOf400()
+    {
+        (string, ErrorCode)[] errors = [("code", new ErrorCode("already_active", "You already have this."))];
+
+        var result = TypedResults.BitwardenValidationProblem(
+            errors, title: "The request conflicts with the current state.", type: "conflict_error",
+            statusCode: StatusCodes.Status409Conflict);
+
+        Assert.Equal(StatusCodes.Status409Conflict, result.StatusCode);
+        Assert.Equal("conflict_error", result.ProblemDetails.Type);
+    }
+
+    [Fact]
+    public void BitwardenValidationProblem_WithNullPairs_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            TypedResults.BitwardenValidationProblem((IEnumerable<(string, ErrorCode)>)null!));
     }
 }

--- a/test/HttpExtensions.Test/BitwardenValidationProblemResultTests.cs
+++ b/test/HttpExtensions.Test/BitwardenValidationProblemResultTests.cs
@@ -1,11 +1,11 @@
 ﻿using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
-using static Microsoft.AspNetCore.Http.HttpResults.BitwardenTypedResultsExtensions;
 
 namespace Bit.HttpExtensions.Test;
 
@@ -60,5 +60,17 @@ public class BitwardenValidationProblemResultTests
         var firstError = emailErrors[0];
         Assert.Equal("memberNotClaimed", firstError.GetProperty("type").GetString());
         Assert.Equal("Member not claimed", firstError.GetProperty("detail").GetString());
+    }
+
+    [Fact]
+    public void ReturningIt_DocumentsTheProblemDocumentOnTheEndpoint()
+    {
+        var handler = RequestDelegateFactory.Create(() =>
+            TypedResults.BitwardenValidationProblem(new Dictionary<string, ErrorCode[]>()));
+
+        var response = Assert.Single(handler.EndpointMetadata.OfType<IProducesResponseTypeMetadata>());
+        Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
+        Assert.Equal(typeof(BitwardenValidationProblemDetails), response.Type);
+        Assert.Equal(["application/problem+json"], response.ContentTypes);
     }
 }

--- a/test/HttpExtensions.Test/HttpExtensions.Test.csproj
+++ b/test/HttpExtensions.Test/HttpExtensions.Test.csproj
@@ -9,6 +9,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="[10.0.10]" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />

--- a/test/HttpExtensions.Test/ValidationMessageCodesTests.cs
+++ b/test/HttpExtensions.Test/ValidationMessageCodesTests.cs
@@ -1,0 +1,144 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Xunit;
+
+namespace Bit.HttpExtensions.Test;
+
+/// <summary>
+/// Every pattern, checked against the message its attribute actually produces.
+/// </summary>
+/// <remarks>
+/// Recognising a message is the whole mechanism, so the wording is the contract. These ask the real attribute to
+/// format itself and assert the code that comes back, which turns a framework reword into a failure here on the
+/// next SDK bump rather than a silently uncoded error in production.
+/// </remarks>
+public class ValidationMessageCodesTests
+{
+    private static ErrorCode Resolve(ValidationAttribute attribute, string name = "Name") =>
+        ValidationMessageCodes.Resolve(attribute.FormatErrorMessage(name));
+
+    [Fact]
+    public void Required()
+    {
+        Assert.Equal(ValidationCodes.Required, Resolve(new RequiredAttribute()).Type);
+    }
+
+    [Fact]
+    public void StringLengthWithOnlyAMaximum_IsTooLongAndCarriesIt()
+    {
+        var error = Resolve(new StringLengthAttribute(200));
+
+        Assert.Equal(ValidationCodes.TooLong, error.Type);
+        Assert.Equal(200, (int)error.Parameters![ValidationParameters.Max]!);
+    }
+
+    [Fact]
+    public void StringLengthWithBothBounds_IsOneCodeCarryingBoth()
+    {
+        // The attribute words both directions identically, so there is nothing to tell them apart.
+        var error = Resolve(new StringLengthAttribute(200) { MinimumLength = 5 });
+
+        Assert.Equal(ValidationCodes.InvalidLength, error.Type);
+        Assert.Equal(5, (int)error.Parameters![ValidationParameters.Min]!);
+        Assert.Equal(200, (int)error.Parameters[ValidationParameters.Max]!);
+    }
+
+    [Fact]
+    public void MaxLength_IsTooLongAndCarriesIt()
+    {
+        var error = Resolve(new MaxLengthAttribute(100));
+
+        Assert.Equal(ValidationCodes.TooLong, error.Type);
+        Assert.Equal(100, (int)error.Parameters![ValidationParameters.Max]!);
+    }
+
+    [Fact]
+    public void MinLength_IsTooShortAndCarriesIt()
+    {
+        var error = Resolve(new MinLengthAttribute(1));
+
+        Assert.Equal(ValidationCodes.TooShort, error.Type);
+        Assert.Equal(1, (int)error.Parameters![ValidationParameters.Min]!);
+    }
+
+    [Fact]
+    public void Range_CarriesBothBounds()
+    {
+        var error = Resolve(new RangeAttribute(1, 100));
+
+        Assert.Equal(ValidationCodes.OutOfRange, error.Type);
+        Assert.Equal(1, (int)error.Parameters![ValidationParameters.Min]!);
+        Assert.Equal(100, (int)error.Parameters[ValidationParameters.Max]!);
+    }
+
+    [Fact]
+    public void ARangeStatedInNonNumbers_CarriesTheBoundsAsTheMessageRendered_Them()
+    {
+        // The limitation of reading bounds out of prose, pinned rather than papered over: what comes back is the
+        // framework's rendering of the bound, not the string the attribute was declared with. A client gets
+        // something it can display, but not the original literal.
+        var error = Resolve(new RangeAttribute(typeof(DateTime), "2020-01-01", "2030-01-01"), "Starts");
+
+        Assert.Equal(ValidationCodes.OutOfRange, error.Type);
+        Assert.Equal("2020-01-01 00:00:00", (string)error.Parameters![ValidationParameters.Min]!);
+        Assert.Equal("2030-01-01 00:00:00", (string)error.Parameters[ValidationParameters.Max]!);
+    }
+
+    [Fact]
+    public void EmailAddress()
+    {
+        Assert.Equal(ValidationCodes.InvalidEmail, Resolve(new EmailAddressAttribute()).Type);
+    }
+
+    [Fact]
+    public void RegularExpression_CarriesThePattern()
+    {
+        var error = Resolve(new RegularExpressionAttribute("^a+$"));
+
+        Assert.Equal(ValidationCodes.InvalidFormat, error.Type);
+        Assert.Equal("^a+$", (string)error.Parameters![ValidationParameters.Pattern]!);
+    }
+
+    [Fact]
+    public void Compare_CarriesTheOtherProperty()
+    {
+        var error = Resolve(new CompareAttribute("Password"), "ConfirmPassword");
+
+        Assert.Equal(ValidationCodes.MustMatch, error.Type);
+        Assert.Equal("Password", (string)error.Parameters![ValidationParameters.Other]!);
+    }
+
+    [Fact]
+    public void Url_IsInvalidFormat() =>
+        Assert.Equal(ValidationCodes.InvalidFormat, Resolve(new UrlAttribute()).Type);
+
+    [Fact]
+    public void Phone_IsInvalidFormat() =>
+        Assert.Equal(ValidationCodes.InvalidFormat, Resolve(new PhoneAttribute()).Type);
+
+    [Fact]
+    public void CreditCard_IsInvalidFormat() =>
+        Assert.Equal(ValidationCodes.InvalidFormat, Resolve(new CreditCardAttribute()).Type);
+
+    [Fact]
+    public void AMessageNoPatternClaims_KeepsItsDetailAndLosesOnlyItsCode()
+    {
+        // What an explicit ErrorMessage looks like: recognised by nothing, still reported.
+        var error = ValidationMessageCodes.Resolve("'key' must be provided");
+
+        Assert.Equal(ValidationCodes.Invalid, error.Type);
+        Assert.Equal("'key' must be provided", error.Detail);
+        Assert.Null(error.Parameters);
+    }
+
+    [Fact]
+    public void EveryMessageCarriesItsOriginalDetail()
+    {
+        var message = new StringLengthAttribute(200).FormatErrorMessage("Name");
+
+        Assert.Equal(message, ValidationMessageCodes.Resolve(message).Detail);
+    }
+
+    [Fact]
+    public void NullMessage_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ValidationMessageCodes.Resolve(null!));
+}

--- a/test/HttpExtensions.Test/ValidationProblemDocumentTests.cs
+++ b/test/HttpExtensions.Test/ValidationProblemDocumentTests.cs
@@ -1,0 +1,181 @@
+﻿using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Bit.HttpExtensions.Test;
+
+/// <summary>
+/// The whole document, not one field at a time. Everything else asserts the piece it cares about, which cannot
+/// catch a member appearing, disappearing, or moving — and the document is the contract every client parses, so a
+/// change to it is a breaking change however the C# side is spelled. Read these as the wire format's spec.
+/// </summary>
+public class ValidationProblemDocumentTests
+{
+    [Fact]
+    public async Task SeveralPropertiesFailingAtOnce()
+    {
+        var result = TypedResults.BitwardenValidationProblem(errors: new[]
+        {
+            ("reason", new ErrorCode("required", "Reason is required.")),
+            ("name", new ErrorCode("too_long", "Name must be 200 characters or shorter.",
+                new JsonObject { ["max"] = 200 })),
+            ("duration", new ErrorCode("must_be_positive", "Duration must be greater than zero.")),
+        });
+
+        Assert.Equal(
+            """
+            {
+              "type": "validation_error",
+              "title": "One or more validation errors occurred.",
+              "status": 400,
+              "errors": {
+                "reason": [
+                  {
+                    "type": "required",
+                    "detail": "Reason is required."
+                  }
+                ],
+                "name": [
+                  {
+                    "type": "too_long",
+                    "detail": "Name must be 200 characters or shorter.",
+                    "parameters": {
+                      "max": 200
+                    }
+                  }
+                ],
+                "duration": [
+                  {
+                    "type": "must_be_positive",
+                    "detail": "Duration must be greater than zero."
+                  }
+                ]
+              }
+            }
+            """,
+            await ExecuteAsync(result));
+    }
+
+    [Fact]
+    public async Task ConflictCarriedInTheSameBodyOnADifferentStatus()
+    {
+        var result = TypedResults.BitwardenValidationProblem(
+            errors: new[] { ("code", new ErrorCode("already_active", "You already have active access to this item.")) },
+            title: "The request conflicts with the current state.",
+            type: "conflict_error",
+            statusCode: StatusCodes.Status409Conflict);
+
+        Assert.Equal(
+            """
+            {
+              "type": "conflict_error",
+              "title": "The request conflicts with the current state.",
+              "status": 409,
+              "errors": {
+                "code": [
+                  {
+                    "type": "already_active",
+                    "detail": "You already have active access to this item."
+                  }
+                ]
+              }
+            }
+            """,
+            await ExecuteAsync(result));
+    }
+
+    [Fact]
+    public async Task SeveralFailuresOnOneProperty()
+    {
+        var result = TypedResults.BitwardenValidationProblem(errors: new[]
+        {
+            ("password", new ErrorCode("too_short", "Password must be at least 12 characters.",
+                new JsonObject { ["min"] = 12 })),
+            ("password", new ErrorCode("invalid", "Password is not valid.")),
+        });
+
+        Assert.Equal(
+            """
+            {
+              "type": "validation_error",
+              "title": "One or more validation errors occurred.",
+              "status": 400,
+              "errors": {
+                "password": [
+                  {
+                    "type": "too_short",
+                    "detail": "Password must be at least 12 characters.",
+                    "parameters": {
+                      "min": 12
+                    }
+                  },
+                  {
+                    "type": "invalid",
+                    "detail": "Password is not valid."
+                  }
+                ]
+              }
+            }
+            """,
+            await ExecuteAsync(result));
+    }
+
+    [Fact]
+    public async Task ANestedModelAndACollectionElement()
+    {
+        var result = TypedResults.BitwardenValidationProblem(errors: new[]
+        {
+            ("owner.email", new ErrorCode("invalid_email", "Email is not an address.")),
+            ("members[1].name", new ErrorCode("too_long", "Name must be 200 characters or shorter.",
+                new JsonObject { ["max"] = 200 })),
+        });
+
+        Assert.Equal(
+            """
+            {
+              "type": "validation_error",
+              "title": "One or more validation errors occurred.",
+              "status": 400,
+              "errors": {
+                "owner.email": [
+                  {
+                    "type": "invalid_email",
+                    "detail": "Email is not an address."
+                  }
+                ],
+                "members[1].name": [
+                  {
+                    "type": "too_long",
+                    "detail": "Name must be 200 characters or shorter.",
+                    "parameters": {
+                      "max": 200
+                    }
+                  }
+                ]
+              }
+            }
+            """,
+            await ExecuteAsync(result));
+    }
+
+    private static async Task<string> ExecuteAsync(IResult result)
+    {
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider(),
+        };
+        using var stream = new MemoryStream();
+        context.Response.Body = stream;
+
+        await result.ExecuteAsync(context);
+
+        stream.Position = 0;
+        return Indent(await new StreamReader(stream).ReadToEndAsync());
+    }
+
+    private static string Indent(string json) => JsonSerializer.Serialize(
+        JsonSerializer.Deserialize<JsonElement>(json), new JsonSerializerOptions { WriteIndented = true });
+}

--- a/test/HttpExtensions.Test/ValidationProblemFactoryTests.cs
+++ b/test/HttpExtensions.Test/ValidationProblemFactoryTests.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Xunit;
+
+namespace Bit.HttpExtensions.Test;
+
+public class ValidationProblemFactoryTests
+{
+    private static ModelStateDictionary ModelState(params (string Key, string Message)[] errors)
+    {
+        var modelState = new ModelStateDictionary();
+        foreach (var (key, message) in errors)
+        {
+            modelState.AddModelError(key, message);
+        }
+
+        return modelState;
+    }
+
+    [Fact]
+    public void ARecognisedMessage_IsReportedWithItsCode()
+    {
+        var problem = ValidationProblemFactory.FromModelState(
+            ModelState(("Name", "The Name field is required.")));
+
+        var error = Assert.Single(problem.Errors["name"]);
+        Assert.Equal(ValidationCodes.Required, error.Type);
+        Assert.Equal("The Name field is required.", error.Detail);
+    }
+
+    [Fact]
+    public void AnUnrecognisedMessage_IsStillReported()
+    {
+        // Dropping it would answer 400 with an empty errors map, which tells the client less than nothing.
+        var problem = ValidationProblemFactory.FromModelState(ModelState(("Mystery", "Something was wrong.")));
+
+        var error = Assert.Single(problem.Errors["mystery"]);
+        Assert.Equal(ValidationCodes.Invalid, error.Type);
+        Assert.Equal("Something was wrong.", error.Detail);
+    }
+
+    [Fact]
+    public void ANestedPath_IsCamelCasedSegmentBySegment()
+    {
+        var problem = ValidationProblemFactory.FromModelState(ModelState(("Owner.PostCode", "Bad.")));
+
+        Assert.True(problem.Errors.ContainsKey("owner.postCode"));
+    }
+
+    [Fact]
+    public void ACollectionElement_KeepsItsIndex()
+    {
+        var problem = ValidationProblemFactory.FromModelState(
+            ModelState(("Members[1].Email", "The Email field is required.")));
+
+        Assert.Equal(ValidationCodes.Required, Assert.Single(problem.Errors["members[1].email"]).Type);
+    }
+
+    [Fact]
+    public void AModelLevelFailure_KeepsTheEmptyKey()
+    {
+        var problem = ValidationProblemFactory.FromModelState(ModelState((string.Empty, "Body is empty.")));
+
+        Assert.Equal(ValidationCodes.Invalid, Assert.Single(problem.Errors[string.Empty]).Type);
+    }
+
+    [Fact]
+    public void SeveralFailuresOnOnePath_AreCollectedUnderIt()
+    {
+        var problem = ValidationProblemFactory.FromModelState(
+            ModelState(("Name", "The Name field is required."), ("Name", "Name is also wrong.")));
+
+        Assert.Equal(2, problem.Errors["name"].Length);
+    }
+
+    [Fact]
+    public void ValidModelState_ProducesAnEmptyErrorsMap() =>
+        Assert.Empty(ValidationProblemFactory.FromModelState(new ModelStateDictionary()).Errors);
+
+    [Fact]
+    public void TheDocumentCarriesTheProblemMembers()
+    {
+        var problem = ValidationProblemFactory.FromModelState(ModelState(("Name", "The Name field is required.")));
+
+        Assert.Equal(StatusCodes.Status400BadRequest, problem.Status);
+        Assert.Equal("validation_error", problem.Type);
+        Assert.Equal("One or more validation errors occurred.", problem.Title);
+    }
+
+    [Fact]
+    public void NullModelState_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => ValidationProblemFactory.FromModelState(null!));
+}

--- a/test/HttpExtensions.Test/ValidationRoundTripTests.cs
+++ b/test/HttpExtensions.Test/ValidationRoundTripTests.cs
@@ -1,0 +1,227 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Bit.HttpExtensions.Test;
+
+/// <summary>
+/// The whole chain, end to end: a DataAnnotations attribute, the message the framework records for it, the
+/// generated map, and the coded document that reaches the client.
+/// </summary>
+/// <remarks>
+/// This is the test that earns the design. The generator recovers a code by recognising what the framework said,
+/// so a framework release that rewords a message breaks the mapping silently — everywhere except here, where the
+/// assertion is on the code rather than the message and turns the drift into a failure on the next SDK bump.
+/// </remarks>
+public class ValidationRoundTripTests
+{
+    [Fact]
+    public async Task ARequiredValue_ReportsRequired()
+    {
+        var errors = await PostAsync(new { });
+
+        Assert.Equal(ValidationCodes.Required, Code(errors, "reason"));
+    }
+
+    [Fact]
+    public async Task AValueOverItsMaximum_ReportsTooLongAndCarriesTheLimit()
+    {
+        var errors = await PostAsync(new { reason = "r", name = new string('n', 201) });
+
+        Assert.Equal(ValidationCodes.TooLong, Code(errors, "name"));
+        Assert.Equal(200, errors.GetProperty("name")[0].GetProperty("parameters").GetProperty("max").GetInt32());
+    }
+
+    [Fact]
+    public async Task ANumberOutsideItsRange_ReportsOutOfRangeAndCarriesBothBounds()
+    {
+        var errors = await PostAsync(new { reason = "r", seats = 0 });
+
+        var parameters = errors.GetProperty("seats")[0].GetProperty("parameters");
+        Assert.Equal(ValidationCodes.OutOfRange, Code(errors, "seats"));
+        Assert.Equal(1, parameters.GetProperty("min").GetInt32());
+        Assert.Equal(100, parameters.GetProperty("max").GetInt32());
+    }
+
+    [Fact]
+    public async Task AMalformedAddress_ReportsInvalidEmail()
+    {
+        var errors = await PostAsync(new { reason = "r", email = "not-an-address" });
+
+        Assert.Equal(ValidationCodes.InvalidEmail, Code(errors, "email"));
+    }
+
+    [Fact]
+    public async Task ATwoEndedLengthConstraint_ReportsOneCodeCarryingBothBounds()
+    {
+        // The constraint reports the same message whichever end was breached, so both breaches answer alike.
+        var tooShort = await PostAsync(new { reason = "r", bounded = "ab" });
+        var tooLong = await PostAsync(new { reason = "r", bounded = new string('b', 201) });
+
+        Assert.Equal(ValidationCodes.InvalidLength, Code(tooShort, "bounded"));
+        Assert.Equal(ValidationCodes.InvalidLength, Code(tooLong, "bounded"));
+
+        var parameters = tooShort.GetProperty("bounded")[0].GetProperty("parameters");
+        Assert.Equal(5, parameters.GetProperty("min").GetInt32());
+        Assert.Equal(200, parameters.GetProperty("max").GetInt32());
+    }
+
+    [Fact]
+    public async Task APropertyThatCanFailTwoWays_ReportsTheOneThatFired()
+    {
+        // Two attributes on one property, told apart by the message the framework recorded.
+        var missing = await PostAsync(new { reason = "r" });
+        var overlong = await PostAsync(new { reason = "r", accessCode = new string('a', 26) });
+
+        Assert.Equal(ValidationCodes.Required, Code(missing, "accessCode"));
+        Assert.Equal(ValidationCodes.TooLong, Code(overlong, "accessCode"));
+        Assert.Equal(25, overlong.GetProperty("accessCode")[0].GetProperty("parameters").GetProperty("max").GetInt32());
+    }
+
+    [Fact]
+    public async Task ARenamedProperty_IsKeyedByItsCamelCasedClrName()
+    {
+        // The limit of not reading the model: model state keys the CLR name, so a property renamed by
+        // [JsonPropertyName] cannot be reported under the name the client actually sent. This matches what the
+        // previous envelope did, so it is not a regression — but it is not the ideal either.
+        var errors = await PostAsync(new { reason = "r" });
+
+        Assert.True(errors.TryGetProperty("renamedOnTheWire", out _));
+        Assert.False(errors.TryGetProperty("tag", out _));
+    }
+
+    [Fact]
+    public async Task ANestedModel_IsKeyedByItsPath()
+    {
+        var errors = await PostAsync(new { reason = "r", owner = new { } });
+
+        Assert.Equal(ValidationCodes.Required, Code(errors, "owner.postcode"));
+    }
+
+    [Fact]
+    public async Task ACollectionElement_IsKeyedByItsIndex()
+    {
+        var errors = await PostAsync(new { reason = "r", members = new[] { new { }, new { } } });
+
+        Assert.Equal(ValidationCodes.Required, Code(errors, "members[0].postcode"));
+        Assert.Equal(ValidationCodes.Required, Code(errors, "members[1].postcode"));
+    }
+
+    [Fact]
+    public async Task TheDocumentIsAProblemDocument()
+    {
+        var (response, body) = await PostRawAsync(new { });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.StartsWith("application/problem+json", response.Content.Headers.ContentType?.ToString());
+        Assert.Equal("validation_error", body.GetProperty("type").GetString());
+        Assert.Equal(400, body.GetProperty("status").GetInt32());
+        Assert.Equal("One or more validation errors occurred.", body.GetProperty("title").GetString());
+    }
+
+    private static string? Code(JsonElement errors, string property) =>
+        errors.GetProperty(property)[0].GetProperty("type").GetString();
+
+    private static async Task<JsonElement> PostAsync(object payload) =>
+        (await PostRawAsync(payload)).Body.GetProperty("errors");
+
+    private static async Task<(HttpResponseMessage Response, JsonElement Body)> PostRawAsync(object payload)
+    {
+        var builder = WebApplication.CreateEmptyBuilder(new WebApplicationOptions());
+        builder.WebHost.UseTestServer();
+        builder.Services.AddLogging();
+        builder.Services
+            .AddControllers(options => options.Conventions.Add(new CodedValidationConvention()))
+            .AddApplicationPart(typeof(ValidationRoundTripTests).Assembly);
+
+        var app = builder.Build();
+        app.MapControllers();
+
+        await app.StartAsync();
+        using var client = app.GetTestClient();
+
+        var response = await client.PostAsJsonAsync("/round-trip", payload);
+        var raw = await response.Content.ReadAsStringAsync();
+        Assert.False(string.IsNullOrWhiteSpace(raw), $"Empty body, status {(int)response.StatusCode}.");
+        var body = JsonSerializer.Deserialize<JsonElement>(raw);
+
+        await app.StopAsync();
+        return (response, body);
+    }
+
+    /// <summary>Applies the coded filter the way the Api's convention applies it to every controller.</summary>
+    private sealed class CodedValidationConvention : IControllerModelConvention
+    {
+        public void Apply(ControllerModel controller) => controller.Filters.Add(new CodedValidationFilter());
+    }
+
+    private sealed class CodedValidationFilter : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            if (context.ModelState.IsValid)
+            {
+                return;
+            }
+
+            context.Result = new ObjectResult(ValidationProblemFactory.FromModelState(context.ModelState))
+            {
+                StatusCode = StatusCodes.Status400BadRequest,
+                ContentTypes = { "application/problem+json" },
+            };
+        }
+    }
+}
+
+public sealed class RoundTripInner
+{
+    [Required]
+    public string? Postcode { get; set; }
+}
+
+public sealed class RoundTripModel
+{
+    [Required]
+    public string? Reason { get; set; }
+
+    [StringLength(200)]
+    public string? Name { get; set; }
+
+    [Required]
+    [StringLength(25)]
+    public string? AccessCode { get; set; }
+
+    [StringLength(200, MinimumLength = 5)]
+    public string? Bounded { get; set; }
+
+    [Range(1, 100)]
+    public int Seats { get; set; } = 1;
+
+    [EmailAddress]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("tag")]
+    [Required]
+    public string? RenamedOnTheWire { get; set; }
+
+    public RoundTripInner? Owner { get; set; }
+
+    public List<RoundTripInner>? Members { get; set; }
+}
+
+[Route("round-trip")]
+public sealed class RoundTripController : ControllerBase
+{
+    [HttpPost]
+    public IActionResult Post([FromBody] RoundTripModel model) => Ok();
+}

--- a/test/HttpExtensions.Test/packages.lock.json
+++ b/test/HttpExtensions.Test/packages.lock.json
@@ -18,6 +18,12 @@
         "resolved": "6.0.0",
         "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Direct",
+        "requested": "[10.0.10, 10.0.10]",
+        "resolved": "10.0.10",
+        "contentHash": "Kks+OpQlP/eWQhnTjkiv0H9kc9Uqa7ieAzNV62yJpZ8Ips/WwpfpwrwZUKzV83CBJaBl5OI7J2XxVVTC8vah/Q=="
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.0.1, )",


### PR DESCRIPTION
## 🎟️ Tracking

No ticket — foundation extracted from the PAM error-codes work so it can land on `main` independently of it.

> **Alternative to #8237.** Same wire contract, same feature flag, same behaviour for every case the repo actually has today — but no source generator and no reflection. **25 files / +1520** here against **39 files / +3135** there. Pick one; they are mutually exclusive.

## 📔 Objective

A request that failed its DataAnnotations answered with the `ErrorResponseModel` envelope while a request its handler rejected answered with an RFC 7807 problem document. Same endpoint, same field, two bodies and two key conventions — a client needed both parsers, and only one of them carried a code it could switch on.

One document now serves both:

```json
{
  "type": "validation_error",
  "title": "One or more validation errors occurred.",
  "status": 400,
  "errors": {
    "reason": [{ "type": "required", "detail": "The Reason field is required." }],
    "name": [{
      "type": "too_long",
      "detail": "The field Name must be a string with a maximum length of 200.",
      "parameters": { "max": 200 }
    }]
  }
}
```

**One vocabulary.** Codes come from `ValidationCodes` and parameter keys from `ValidationParameters`. A client looking a substitution up by name is broken by a second spelling as surely as by a second code. A code names what went wrong and never the field it is keyed under — `required`, not `name_required`. Parameters carry the limit that was breached and nothing derived from the value that breached it.

## How the code is recovered

DataAnnotations records a message and discards the constraint behind it — but the sentence it leaves still contains the limit. The `200` in `[StringLength(200)]` is right there in *"must be a string with a maximum length of 200."* `ValidationMessageCodes` is ~12 `[GeneratedRegex]` patterns that recognise each attribute's wording and lift the value back out.

Nothing validates anything; the framework still decides. Nothing reflects, either — so there is **no generator, no registration step, and not one `[RequiresUnreferencedCode]`**. `HttpExtensions` builds with `IsAotCompatible` and is analyzer-clean as it stands, publishable from a trimmed or AOT minimal API.

## What this costs, and why it is written down

The wording is the contract. That is the trade, taken knowingly:

| | Behaviour |
| --- | --- |
| Framework rewords a message | Loses its code, keeps its detail, reports as `invalid` |
| Explicit `ErrorMessage` (~5% of the repo's attributes) | Matches nothing, reports as `invalid` |
| `[JsonPropertyName]` rename | Keyed by camel-cased CLR name — same as the current envelope |
| Non-numeric bound | The framework's rendering, e.g. `"2020-01-01 00:00:00"`, not the declared literal |

Nothing is ever **dropped or mis-coded** — the failure always reaches the client with its message. And `ValidationMessageCodesTests` asserts every pattern against the message its attribute *actually produces*, by calling `FormatErrorMessage` on the real attribute, so a framework reword fails the build on the next SDK bump rather than degrading silently in production.

All four rows are fixable only by reading the model's attributes rather than its messages — with reflection, which is not trim-safe, or a generator, which is #8237.

## Notes for review

- **Behind `FeatureFlagKeys.CodedValidationProblems`; off means nothing changes.** Each surface opts in separately — `TryCodedProblem` offers it and only the internal Api takes it. The public API keeps its published shape.
- **`src/HttpExtensions/README.md`** documents the design and the four costs above.
- `ValidationProblemDocumentTests` asserts the complete serialized body against a literal, so the wire format has a spec that fails on any shape change.
- `ValidationRoundTripTests` drives a real MVC pipeline end to end and asserts on codes.

### Known gaps, deliberately not in scope

- `ExceptionHandlerFilterAttribute` still answers with `ErrorResponseModel`, so `throw new BadRequestException(modelState)` bypasses this. Same in both PRs; the natural follow-up.
- `.Produces<BitwardenValidationProblemDetails>(400)` is not declared on endpoints, so OpenAPI does not yet describe the coded shape.

## 📸 Screenshots

N/A
