### PR TITLE
[PM-42240] perms still returned for members who were previously custom

### DIFF
--- a/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
+++ b/src/Api/AdminConsole/Models/Request/Organizations/OrganizationUserRequestModels.cs
@@ -117,7 +117,11 @@ public class OrganizationUserUpdateRequestModel
     public OrganizationUser ToOrganizationUser(OrganizationUser existingUser)
     {
         existingUser.Type = Type.Value;
-        existingUser.Permissions = CoreHelpers.ClassToJsonData(Permissions);
+        // Custom permissions only apply to the Custom role. Clear them for any other role so a member demoted from
+        // Custom doesn't keep a stale permissions blob.
+        existingUser.Permissions = Type.Value == OrganizationUserType.Custom
+            ? CoreHelpers.ClassToJsonData(Permissions)
+            : null;
         existingUser.AccessSecretsManager = AccessSecretsManager;
         existingUser.AccessPam = AccessPam;
         return existingUser;

--- a/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/Organizations/OrganizationUserResponseModel.cs
@@ -28,7 +28,9 @@ public class OrganizationUserResponseModel : ResponseModel
         ExternalId = organizationUser.ExternalId;
         AccessSecretsManager = organizationUser.AccessSecretsManager;
         AccessPam = organizationUser.AccessPam;
-        Permissions = organizationUser.GetPermissions();
+        // The stored permissions blob is not guaranteed to be cleared when a member moves off Custom, so the role
+        // rather than the blob decides whether custom permissions are exposed.
+        Permissions = Type == OrganizationUserType.Custom ? organizationUser.GetPermissions() : null;
         ResetPasswordEnrolled = OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey);
     }
 
@@ -48,7 +50,7 @@ public class OrganizationUserResponseModel : ResponseModel
         ExternalId = organizationUser.ExternalId;
         AccessSecretsManager = organizationUser.AccessSecretsManager;
         AccessPam = organizationUser.AccessPam;
-        Permissions = organizationUser.GetPermissions();
+        Permissions = Type == OrganizationUserType.Custom ? organizationUser.GetPermissions() : null;
         ResetPasswordEnrolled = OrganizationUser.IsValidResetPasswordKey(organizationUser.ResetPasswordKey);
         UsesKeyConnector = organizationUser.UsesKeyConnector;
         HasMasterPassword = organizationUser.HasMasterPassword;

--- a/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
+++ b/src/Api/AdminConsole/Models/Response/ProfileOrganizationResponseModel.cs
@@ -21,7 +21,11 @@ public class ProfileOrganizationResponseModel : BaseProfileOrganizationResponseM
         Type = organizationDetails.Type;
         OrganizationUserId = organizationDetails.OrganizationUserId;
         UserIsClaimedByOrganization = organizationIdsClaimingUser.Contains(organizationDetails.OrganizationId);
-        Permissions = CoreHelpers.LoadClassFromJsonData<Permissions>(organizationDetails.Permissions);
+        // Custom permissions only apply to the Custom role, and the stored blob is not guaranteed to be cleared when
+        // a member moves off Custom. This mirrors how the role's claims are built.
+        Permissions = Type == OrganizationUserType.Custom
+            ? CoreHelpers.LoadClassFromJsonData<Permissions>(organizationDetails.Permissions)
+            : new Permissions();
         IsAdminInitiated = organizationDetails.IsAdminInitiated ?? false;
         FamilySponsorshipFriendlyName = organizationDetails.FamilySponsorshipFriendlyName;
         FamilySponsorshipLastSyncDate = organizationDetails.FamilySponsorshipLastSyncDate;

--- a/src/Api/AdminConsole/Public/Models/Request/MemberUpdateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/MemberUpdateRequestModel.cs
@@ -24,8 +24,13 @@ public class MemberUpdateRequestModel : MemberBaseModel, IValidatableObject
         existingUser.Type = Type.Value;
         existingUser.ExternalId = ExternalId;
 
+        if (existingUser.Type is not OrganizationUserType.Custom)
+        {
+            // Clear any permissions left over from a previous Custom role.
+            existingUser.Permissions = null;
+        }
         // Permissions property is optional for backwards compatibility with existing usage
-        if (existingUser.Type is OrganizationUserType.Custom && Permissions is not null)
+        else if (Permissions is not null)
         {
             existingUser.SetPermissions(Permissions.ToData());
         }

--- a/src/Api/AdminConsole/Public/Models/Request/MemberUpdateRequestModel.cs
+++ b/src/Api/AdminConsole/Public/Models/Request/MemberUpdateRequestModel.cs
@@ -29,9 +29,9 @@ public class MemberUpdateRequestModel : MemberBaseModel, IValidatableObject
             // Clear any permissions left over from a previous Custom role.
             existingUser.Permissions = null;
         }
-        // Permissions property is optional for backwards compatibility with existing usage
         else if (Permissions is not null)
         {
+            // Permissions property is optional for backwards compatibility with existing usage
             existingUser.SetPermissions(Permissions.ToData());
         }
 

--- a/src/Core/AdminConsole/Entities/OrganizationUser.cs
+++ b/src/Core/AdminConsole/Entities/OrganizationUser.cs
@@ -169,10 +169,17 @@ public class OrganizationUser : ITableObject<Guid>, IExternal, IOrganizationUser
         bool accessPam,
         TimeProvider timeProvider)
     {
-        if (permissions is not null)
+        if (organizationUserType != OrganizationUserType.Custom)
+        {
+            // Custom permissions only apply to the Custom role. Clear them so a member demoted from Custom doesn't
+            // keep a stale permissions blob.
+            Permissions = null;
+        }
+        else if (permissions is not null)
         {
             SetPermissions(permissions);
         }
+
         Type = organizationUserType;
         AccessSecretsManager = accessSecretsManager;
         AccessPam = accessPam;

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUserControllerPutTests.cs
@@ -7,6 +7,7 @@ using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.Interfaces;
 using Bit.Core.Context;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
@@ -31,7 +32,7 @@ public class OrganizationUserControllerPutTests
         SutProvider<OrganizationUsersController> sutProvider, Guid savingUserId)
     {
         // Arrange
-        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: []);
+        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: [], model);
 
         // Authorize all changes for basic happy path test. The controller authorizes the posted collections
         // as a single bulk set, then re-checks each current collection individually for the readonly merge.
@@ -67,6 +68,35 @@ public class OrganizationUserControllerPutTests
     }
 
     [Theory]
+    [BitAutoData(OrganizationUserType.User)]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    public async Task Put_ConvertedFromCustom_ClearsPermissions(OrganizationUserType newType,
+        OrganizationUserUpdateRequestModel model, OrganizationUser organizationUser, Organization organization,
+        SutProvider<OrganizationUsersController> sutProvider, Guid savingUserId)
+    {
+        // Arrange
+        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: [], model);
+
+        organizationUser.Type = OrganizationUserType.Custom;
+        organizationUser.SetPermissions(new Permissions { ManageUsers = true });
+        model.Type = newType;
+        model.Collections = new List<SelectionReadOnlyRequestModel>();
+
+        // Act
+        await sutProvider.Sut.Put(organization, organizationUser.Id, model);
+
+        // Assert
+        await sutProvider.GetDependency<IUpdateOrganizationUserCommand>().Received(1).UpdateUserAsync(
+            Arg.Is<OrganizationUser>(ou => ou.Permissions == null),
+            OrganizationUserType.Custom,
+            savingUserId,
+            Arg.Any<List<CollectionAccessSelection>>(),
+            Arg.Any<IEnumerable<Guid>>(),
+            model.DefaultUserCollectionName);
+    }
+
+    [Theory]
     [BitAutoData]
     public async Task Put_NoAdminAccess_CannotAddSelfToCollections(OrganizationUserUpdateRequestModel model,
         OrganizationUser organizationUser, Organization organization,
@@ -76,7 +106,7 @@ public class OrganizationUserControllerPutTests
         organizationUser.UserId = savingUserId;
         organization.AllowAdminAccessToAllCollectionItems = false;
 
-        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: []);
+        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: [], model);
 
         var exception = await Assert.ThrowsAsync<BadRequestException>(async () => await sutProvider.Sut.Put(organization, organizationUser.Id, model));
         Assert.Contains("You cannot add yourself to a collection.", exception.Message);
@@ -92,7 +122,7 @@ public class OrganizationUserControllerPutTests
         organizationUser.UserId = savingUserId;
         organization.AllowAdminAccessToAllCollectionItems = false;
 
-        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: []);
+        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: [], model);
 
         // Not changing any collection access
         model.Collections = new List<SelectionReadOnlyRequestModel>();
@@ -130,7 +160,7 @@ public class OrganizationUserControllerPutTests
         organizationUser.UserId = savingUserId;
         organization.AllowAdminAccessToAllCollectionItems = true;
 
-        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: []);
+        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: [], model);
 
         // Not changing any collection access
         model.Collections = new List<SelectionReadOnlyRequestModel>();
@@ -192,7 +222,7 @@ public class OrganizationUserControllerPutTests
             },
         };
 
-        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess);
+        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess, model);
 
         // User is upgrading editedCollectionId to manage
         model.Collections = new List<SelectionReadOnlyRequestModel>
@@ -252,7 +282,7 @@ public class OrganizationUserControllerPutTests
     {
         // Target user is currently assigned to the POSTed collections
         Put_Setup(sutProvider, organization, organizationUser, savingUserId,
-            currentCollectionAccess: model.Collections.Select(cas => cas.ToSelectionReadOnly()).ToList());
+            currentCollectionAccess: model.Collections.Select(cas => cas.ToSelectionReadOnly()).ToList(), model);
 
         var postedCollectionIds = model.Collections.Select(c => c.Id).ToHashSet();
 
@@ -272,7 +302,7 @@ public class OrganizationUserControllerPutTests
         SutProvider<OrganizationUsersController> sutProvider, Guid savingUserId)
     {
         // The target user is not currently assigned to any collections, so we're granting access for the first time
-        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: []);
+        Put_Setup(sutProvider, organization, organizationUser, savingUserId, currentCollectionAccess: [], model);
 
         var postedCollectionIds = model.Collections.Select(c => c.Id).ToHashSet();
         // But the saving user does not have permission to assign access to the collections
@@ -286,9 +316,13 @@ public class OrganizationUserControllerPutTests
 
     private void Put_Setup(SutProvider<OrganizationUsersController> sutProvider,
         Organization organization, OrganizationUser organizationUser, Guid savingUserId,
-        List<CollectionAccessSelection> currentCollectionAccess)
+        List<CollectionAccessSelection> currentCollectionAccess, OrganizationUserUpdateRequestModel model)
     {
         var orgId = organization.Id = organizationUser.OrganizationId;
+
+        // Custom permissions are only persisted for the Custom role, so pin the requested role to keep the
+        // permissions assertions below deterministic.
+        model.Type = OrganizationUserType.Custom;
 
         sutProvider.GetDependency<ICurrentContext>().ManageUsers(orgId).Returns(true);
         sutProvider.GetDependency<IOrganizationUserRepository>().GetByIdAsync(organizationUser.Id)

--- a/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationUserUpdateRequestModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Request/Organizations/OrganizationUserUpdateRequestModelTests.cs
@@ -1,0 +1,47 @@
+﻿using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Models.Request.Organizations;
+
+public class OrganizationUserUpdateRequestModelTests
+{
+    [Theory]
+    [BitAutoData(OrganizationUserType.User)]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    public void ToOrganizationUser_NonCustomRole_ClearsPermissions(OrganizationUserType type)
+    {
+        var existingUser = new OrganizationUser { Type = OrganizationUserType.Custom };
+        existingUser.SetPermissions(new Permissions { ManageUsers = true });
+
+        var model = new OrganizationUserUpdateRequestModel
+        {
+            Type = type,
+            Permissions = new Permissions { ManageUsers = true }
+        };
+
+        var result = model.ToOrganizationUser(existingUser);
+
+        Assert.Null(result.Permissions);
+    }
+
+    [Fact]
+    public void ToOrganizationUser_CustomRole_SetsPermissions()
+    {
+        var existingUser = new OrganizationUser { Type = OrganizationUserType.User };
+
+        var model = new OrganizationUserUpdateRequestModel
+        {
+            Type = OrganizationUserType.Custom,
+            Permissions = new Permissions { ManageUsers = true }
+        };
+
+        var result = model.ToOrganizationUser(existingUser);
+
+        Assert.True(result.GetPermissions()!.ManageUsers);
+    }
+}

--- a/test/Api.Test/AdminConsole/Models/Response/OrganizationUserResponseModelTests.cs
+++ b/test/Api.Test/AdminConsole/Models/Response/OrganizationUserResponseModelTests.cs
@@ -1,7 +1,9 @@
 ﻿using Bit.Api.AdminConsole.Models.Response.Organizations;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Data.Organizations.OrganizationUsers;
+using Bit.Core.Utilities;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Xunit;
 
@@ -69,5 +71,58 @@ public class OrganizationUserResponseModelTests
         var result = new OrganizationUserUserDetailsResponseModel((orgUser, false, true));
 
         Assert.Equal(orgUser.CreationDate, result.CreationDate);
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.User)]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    public void Constructor_OrganizationUser_NonCustomRole_OmitsPermissions(OrganizationUserType type,
+        OrganizationUser orgUser)
+    {
+        orgUser.Type = type;
+        orgUser.SetPermissions(new Permissions { ManageUsers = true });
+
+        var result = new OrganizationUserResponseModel(orgUser);
+
+        Assert.Null(result.Permissions);
+    }
+
+    [Theory]
+    [BitAutoData(OrganizationUserType.User)]
+    [BitAutoData(OrganizationUserType.Admin)]
+    [BitAutoData(OrganizationUserType.Owner)]
+    public void Constructor_OrganizationUserUserDetails_NonCustomRole_OmitsPermissions(OrganizationUserType type,
+        OrganizationUserUserDetails orgUser)
+    {
+        orgUser.Type = type;
+        orgUser.Permissions = CoreHelpers.ClassToJsonData(new Permissions { ManageUsers = true });
+
+        var result = new OrganizationUserResponseModel(orgUser);
+
+        Assert.Null(result.Permissions);
+    }
+
+    [Theory, BitAutoData]
+    public void Constructor_OrganizationUser_CustomRole_ReturnsPermissions(OrganizationUser orgUser)
+    {
+        orgUser.Type = OrganizationUserType.Custom;
+        orgUser.SetPermissions(new Permissions { ManageUsers = true });
+
+        var result = new OrganizationUserResponseModel(orgUser);
+
+        Assert.True(result.Permissions.ManageUsers);
+    }
+
+    [Theory, BitAutoData]
+    public void Constructor_OrganizationUserUserDetails_CustomRole_ReturnsPermissions(
+        OrganizationUserUserDetails orgUser)
+    {
+        orgUser.Type = OrganizationUserType.Custom;
+        orgUser.Permissions = CoreHelpers.ClassToJsonData(new Permissions { ManageUsers = true });
+
+        var result = new OrganizationUserResponseModel(orgUser);
+
+        Assert.True(result.Permissions.ManageUsers);
     }
 }

--- a/test/Core.Test/AdminConsole/Entities/OrganizationUserTests.cs
+++ b/test/Core.Test/AdminConsole/Entities/OrganizationUserTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.AdminConsole.Enums;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
@@ -137,5 +138,32 @@ public class OrganizationUserTests
         orgUser.UpdateOrganizationUser(OrganizationUserType.User, null, false, false, timeProvider);
 
         Assert.Equal(now.UtcDateTime, orgUser.RevisionDate);
+    }
+
+    [Theory]
+    [InlineData(OrganizationUserType.User)]
+    [InlineData(OrganizationUserType.Admin)]
+    [InlineData(OrganizationUserType.Owner)]
+    public void UpdateOrganizationUser_ConvertedFromCustom_ClearsPermissions(OrganizationUserType newType)
+    {
+        var orgUser = new OrganizationUser { Type = OrganizationUserType.Custom };
+        orgUser.SetPermissions(new Permissions { ManageUsers = true });
+
+        orgUser.UpdateOrganizationUser(newType, new Permissions { ManageUsers = true }, false, false,
+            TimeProvider.System);
+
+        Assert.Null(orgUser.Permissions);
+        Assert.Null(orgUser.GetPermissions());
+    }
+
+    [Fact]
+    public void UpdateOrganizationUser_ConvertedToCustom_SetsPermissions()
+    {
+        var orgUser = new OrganizationUser { Type = OrganizationUserType.User };
+
+        orgUser.UpdateOrganizationUser(OrganizationUserType.Custom, new Permissions { ManageUsers = true }, false,
+            false, TimeProvider.System);
+
+        Assert.True(orgUser.GetPermissions()!.ManageUsers);
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42240

## 📔 Objective

Fixes bug found in QA where previously custom users would still send back the permissions map to the frontend even though it is now irrelevant if they are no longer a custom user.
