### PR TITLE
fix(mac-certs): Support OpenSSL/LIbreSSL and immediate returns on failure

### DIFF
--- a/dev/create_certificates_mac.sh
+++ b/dev/create_certificates_mac.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout identity_server_dev.key -out identity_server_dev.crt \
     -subj "/CN=Bitwarden Identity Server Dev" -days 3650
-openssl pkcs12 -export -legacy -out identity_server_dev.pfx -inkey identity_server_dev.key -in identity_server_dev.crt \
-    -certfile identity_server_dev.crt
 
-security import ./identity_server_dev.pfx -k ~/Library/Keychains/Login.keychain
+# macOS ships with LibreSSL by default;
+# it will often be replaced by users with OpenSSL v3.
+# If OpenSSL v3, a -legacy flag is required.
+# !NOTE: If on OpenSSL v3, you must use a non-empty password.
+if [[ "$(openssl version)" == OpenSSL\ 3* ]]; then
+    openssl pkcs12 -export -legacy -out identity_server_dev.pfx -inkey identity_server_dev.key \
+        -in identity_server_dev.crt -certfile identity_server_dev.crt
+else
+    openssl pkcs12 -export -out identity_server_dev.pfx -inkey identity_server_dev.key \
+        -in identity_server_dev.crt -certfile identity_server_dev.crt
+fi
+
+# Use default system keychain
+security import ./identity_server_dev.pfx
 
 identity=($(openssl x509 -in identity_server_dev.crt -outform der | shasum -a 1 | tr a-z A-Z));
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42233](https://bitwarden.atlassian.net/browse/PM-42233)

## 📔 Objective

Improves the usability of `create_certificates_mac.sh` for local server development as follows:

- Drops the specific-named `-k ~/Library/Keychains/Login.keychain` and uses the _default_ keychain (login, named `login.keychain-db`, which was not found by the current script).
  - Default login keychain name changed some time back (~Sierra).
- Will support _either_ macOS default `LibreSSL` (shipped in `/usr/bin`) _or_ `OpenSSL`, which users often bring as a replacement.
- Will return immediately on any failure in the script.
  - Previously, errors would propagate, but the calculated thumbprint would _always_ display at the end, whether a cert was properly loaded or not, potentially confusing or obfuscating the incomplete operation.

Verified locally by creating cert with both `LibreSSL` and `OpenSSL`, and seeing cert material flow through to the application.


[PM-42233]: https://bitwarden.atlassian.net/browse/PM-42233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ