### PR TITLE
QA-2398: support SM-off Enterprise org via seeder OrganizationOverrides

### DIFF
--- a/test/SeederApi.IntegrationTest/Factories/OrganizationSeederTests.cs
+++ b/test/SeederApi.IntegrationTest/Factories/OrganizationSeederTests.cs
@@ -62,6 +62,35 @@ public class OrganizationSeederTests
     }
 
     [Fact]
+    public void Create_OverrideDisablesSecretsManagerOnEnterprise()
+    {
+        // Enterprise flags Secrets Manager on by default; the override is the way to turn it back off.
+        var defaultOn = OrganizationSeeder.Create(
+            Seed() with { PlanType = PlanType.EnterpriseAnnually }, new NoOpManglerService());
+        Assert.True(defaultOn.UseSecretsManager);
+
+        var overriddenOff = OrganizationSeeder.Create(
+            Seed() with
+            {
+                PlanType = PlanType.EnterpriseAnnually,
+                Overrides = new OrganizationOverrides { UseSecretsManager = false }
+            },
+            new NoOpManglerService());
+        Assert.False(overriddenOff.UseSecretsManager);
+
+        // Intended precedence, not a bug: the EnableSecretsManager gate runs after overrides and forces SM on.
+        var gateWins = OrganizationSeeder.Create(
+            Seed() with
+            {
+                PlanType = PlanType.EnterpriseAnnually,
+                EnableSecretsManager = true,
+                Overrides = new OrganizationOverrides { UseSecretsManager = false }
+            },
+            new NoOpManglerService());
+        Assert.True(gateWins.UseSecretsManager);
+    }
+
+    [Fact]
     public void Create_SetsBillingGatewayIdentifiers()
     {
         var organization = OrganizationSeeder.Create(

--- a/util/Seeder/Factories/PlanFeatures.cs
+++ b/util/Seeder/Factories/PlanFeatures.cs
@@ -111,6 +111,8 @@ public static class PlanFeatures
         org.SyncSeats = overrides.SyncSeats ?? org.SyncSeats;
         org.UsePasswordManager = overrides.UsePasswordManager ?? org.UsePasswordManager;
         org.UsePam = overrides.UsePam ?? org.UsePam;
+        // Off-path only: the EnableSecretsManager gate in OrganizationSeeder.Create runs after this and forces SM on when set, so pair this with EnableSecretsManager=false to disable SM.
+        org.UseSecretsManager = overrides.UseSecretsManager ?? org.UseSecretsManager;
     }
 
     /// <summary>

--- a/util/Seeder/Options/OrganizationOverrides.cs
+++ b/util/Seeder/Options/OrganizationOverrides.cs
@@ -34,4 +34,5 @@ public sealed record OrganizationOverrides
     public bool? SyncSeats { get; init; }
     public bool? UsePasswordManager { get; init; }
     public bool? UsePam { get; init; }
+    public bool? UseSecretsManager { get; init; }
 }


### PR DESCRIPTION
## 🎟️ Tracking

QA-2398: https://bitwarden.atlassian.net/browse/QA-2398

## 📔 Objective

The seeder cannot create an Enterprise org with Secrets Manager off. Enterprise sets `UseSecretsManager = true` by plan default, and no override could turn it back off. This adds a `UseSecretsManager` flag to the seeder's `OrganizationOverrides` so a seed request can produce an SM-off Enterprise org, used with `EnableSecretsManager = false`. Default behavior is unchanged (Enterprise stays SM-on).

Includes an integration test locking both the override-off behavior and the `EnableSecretsManager` gate precedence (the gate still wins when set).
