### PR TITLE
QA-2398: correct SeederApi README overrides bullet for SM-off support

### DIFF
--- a/util/SeederApi/README.md
+++ b/util/SeederApi/README.md
@@ -77,9 +77,11 @@ Use the `X-Play-Id` header value to later destroy the seeded data.
 
 Beyond `planType` and `seats`, the request accepts:
 
-- `overrides` — optional capability/collection-management flags applied **on top of** the plan defaults. Any flag left
-  unset keeps the plan default. Set Secrets Manager via `enableSecretsManager` (with optional `smSeats` /
-  `smServiceAccounts`), not via `overrides`.
+- `overrides`: optional capability/collection-management flags applied **on top of** the plan defaults. Any flag left
+  unset keeps the plan default. This includes `useSecretsManager`: to seed an SM-off Enterprise org, send
+  `overrides.useSecretsManager: false` together with `enableSecretsManager: false`. If both
+  `enableSecretsManager: true` and `overrides.useSecretsManager: false` are sent, Secrets Manager stays on. Seat
+  provisioning (`smSeats` / `smServiceAccounts`) applies only when `enableSecretsManager: true`.
 - `gateway`, `gatewayCustomerId`, `gatewaySubscriptionId` — billing gateway identity, so the seeded org resembles a
   real billed org.
 


### PR DESCRIPTION
## 🎟️ Tracking

QA-2398: https://bitwarden.atlassian.net/browse/QA-2398

## 📔 Objective

Doc-only follow-up to #8249. That PR added `overrides.useSecretsManager` to the seeder, but `util/SeederApi/README.md` still told API users to set Secrets Manager "not via `overrides`", which now contradicts the code. This corrects the `overrides` bullet to document the SM-off recipe (`overrides.useSecretsManager: false` with `enableSecretsManager: false`), the precedence (SM stays on when `enableSecretsManager: true` is also sent), and that seat provisioning still applies only when `enableSecretsManager: true`.
