### PR TITLE
[PC-42433] Handle Seat Expansion for Staged Users

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommand.cs
@@ -82,7 +82,7 @@ public class AcceptOrganizationInviteLinkCommand(
         }
 
         var acceptResult = existingOrganizationUser is not null
-            ? await AcceptExistingInviteAsync(existingOrganizationUser, user, autoConfirmPolicyEnabled)
+            ? await AcceptExistingInviteAsync(organization, existingOrganizationUser, user, autoConfirmPolicyEnabled)
             : await CreateNewMembershipAsync(organization, user, autoConfirmPolicyEnabled);
         if (acceptResult.IsError)
         {
@@ -123,9 +123,24 @@ public class AcceptOrganizationInviteLinkCommand(
         return await organizationUserRepository.GetByOrganizationEmailAsync(organization.Id, user.Email);
     }
 
+    /// <summary>
+    /// Accepts an existing membership: either a pending email invitation, which already occupies a seat, or a
+    /// Staged provisioning row, which does not. Staged members are excluded from the organization's occupied
+    /// seat count, so promoting one to Accepted consumes capacity exactly like a brand-new membership and must
+    /// reserve a seat first.
+    /// </summary>
     private async Task<CommandResult<OrganizationUser>> AcceptExistingInviteAsync(
-        OrganizationUser existingOrganizationUser, User user, bool autoConfirmPolicyEnabled)
+        Organization organization, OrganizationUser existingOrganizationUser, User user, bool autoConfirmPolicyEnabled)
     {
+        if (existingOrganizationUser.Status == OrganizationUserStatusType.Staged)
+        {
+            var seatReservationError = await ReserveSeatAsync(organization);
+            if (seatReservationError is not null)
+            {
+                return seatReservationError;
+            }
+        }
+
         existingOrganizationUser.Status = OrganizationUserStatusType.Accepted;
         existingOrganizationUser.UserId = user.Id;
         existingOrganizationUser.Email = null;
@@ -143,16 +158,10 @@ public class AcceptOrganizationInviteLinkCommand(
     private async Task<CommandResult<OrganizationUser>> CreateNewMembershipAsync(
         Organization organization, User user, bool autoConfirmPolicyEnabled)
     {
-        var occupiedSeatCount = (await organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)).Total;
-        if (!OrganizationSeatAvailability.HasAvailableSeats(organization, occupiedSeatCount))
+        var seatReservationError = await ReserveSeatAsync(organization);
+        if (seatReservationError is not null)
         {
-            return new OrganizationHasNoAvailableSeats(organization.DisplayName());
-        }
-
-        var seatExpansionError = await TryExpandSeatsAsync(organization, occupiedSeatCount);
-        if (seatExpansionError is not null)
-        {
-            return seatExpansionError;
+            return seatReservationError;
         }
 
         var accessSecretsManager = await stripePaymentService.HasSecretsManagerStandalone(organization);
@@ -177,8 +186,22 @@ public class AcceptOrganizationInviteLinkCommand(
     }
 
     /// <summary>
-    /// Expands the organization's seats before the new membership is created, so that a billing or
-    /// persistence failure leaves no orphaned seat. Only auto-adds when the org is already at capacity.
+    /// Reserves capacity for one more seat-occupying member. Runs before the membership is written so that a
+    /// billing or persistence failure leaves no orphaned seat.
+    /// </summary>
+    private async Task<Error?> ReserveSeatAsync(Organization organization)
+    {
+        var occupiedSeatCount = (await organizationRepository.GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)).Total;
+        if (!OrganizationSeatAvailability.HasAvailableSeats(organization, occupiedSeatCount))
+        {
+            return new OrganizationHasNoAvailableSeats(organization.DisplayName());
+        }
+
+        return await TryExpandSeatsAsync(organization, occupiedSeatCount);
+    }
+
+    /// <summary>
+    /// Only auto-adds when the organization is already at capacity.
     /// </summary>
     private async Task<Error?> TryExpandSeatsAsync(Organization organization, int occupiedSeatCount)
     {

--- a/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommand.cs
@@ -82,7 +82,7 @@ public class AcceptOrganizationInviteLinkCommand(
         }
 
         var acceptResult = existingOrganizationUser is not null
-            ? await AcceptExistingInviteAsync(organization, existingOrganizationUser, user, autoConfirmPolicyEnabled)
+            ? await AcceptExistingOrgUserAsync(organization, existingOrganizationUser, user, autoConfirmPolicyEnabled)
             : await CreateNewMembershipAsync(organization, user, autoConfirmPolicyEnabled);
         if (acceptResult.IsError)
         {
@@ -123,13 +123,7 @@ public class AcceptOrganizationInviteLinkCommand(
         return await organizationUserRepository.GetByOrganizationEmailAsync(organization.Id, user.Email);
     }
 
-    /// <summary>
-    /// Accepts an existing membership: either a pending email invitation, which already occupies a seat, or a
-    /// Staged provisioning row, which does not. Staged members are excluded from the organization's occupied
-    /// seat count, so promoting one to Accepted consumes capacity exactly like a brand-new membership and must
-    /// reserve a seat first.
-    /// </summary>
-    private async Task<CommandResult<OrganizationUser>> AcceptExistingInviteAsync(
+    private async Task<CommandResult<OrganizationUser>> AcceptExistingOrgUserAsync(
         Organization organization, OrganizationUser existingOrganizationUser, User user, bool autoConfirmPolicyEnabled)
     {
         if (existingOrganizationUser.Status == OrganizationUserStatusType.Staged)

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/InviteLinks/AcceptOrganizationInviteLinkCommandTests.cs
@@ -223,6 +223,195 @@ public class AcceptOrganizationInviteLinkCommandTests
             .AutoAddSeatsAsync(Arg.Any<Organization>(), Arg.Any<int>());
     }
 
+    // An Invited row already occupies a seat, so accepting it must not consume or expand capacity even when
+    // the organization is full. Guards the Staged handling below from over-reaching.
+    [Theory, BitAutoData]
+    public async Task AcceptAsync_WithExistingEmailInvite_AndOrganizationAtCapacity_DoesNotReserveSeat(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser invitedOrganizationUser,
+        SutProvider<AcceptOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        invitedOrganizationUser.Status = OrganizationUserStatusType.Invited;
+        invitedOrganizationUser.Email = user.Email;
+        invitedOrganizationUser.UserId = null;
+        organization.Seats = 2;
+        organization.MaxAutoscaleSeats = 2;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationEmailAsync(organization.Id, user.Email)
+            .Returns(invitedOrganizationUser);
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)
+            .Returns(new OrganizationSeatCounts { Users = 2, Sponsored = 0 });
+
+        var request = new AcceptOrganizationInviteLinkRequest
+        {
+            OrganizationId = organization.Id,
+            Code = Guid.Parse(inviteLink.Code),
+            User = user
+        };
+        var result = await sutProvider.Sut.AcceptAsync(request);
+
+        Assert.True(result.IsSuccess);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceAsync(Arg.Is<OrganizationUser>(ou => ou.Status == OrganizationUserStatusType.Accepted));
+        await sutProvider.GetDependency<IOrganizationService>()
+            .DidNotReceiveWithAnyArgs()
+            .AutoAddSeatsAsync(Arg.Any<Organization>(), Arg.Any<int>());
+    }
+
+    // A Staged row is excluded from the occupied seat count, so promoting it to Accepted consumes a seat.
+    [Theory, BitAutoData]
+    public async Task AcceptAsync_WithStagedMembership_AndSeatsAvailable_AcceptsWithoutAutoscaling(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser stagedOrganizationUser,
+        SutProvider<AcceptOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        SetupStagedMembership(organization, user, stagedOrganizationUser, sutProvider);
+        stagedOrganizationUser.ExternalId = "ext-123";
+
+        var request = new AcceptOrganizationInviteLinkRequest
+        {
+            OrganizationId = organization.Id,
+            Code = Guid.Parse(inviteLink.Code),
+            User = user
+        };
+        var result = await sutProvider.Sut.AcceptAsync(request);
+
+        Assert.True(result.IsSuccess);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceAsync(Arg.Is<OrganizationUser>(ou =>
+                ou.Id == stagedOrganizationUser.Id &&
+                ou.Status == OrganizationUserStatusType.Accepted &&
+                ou.UserId == user.Id &&
+                ou.Email == null &&
+                ou.ExternalId == "ext-123"));
+        await sutProvider.GetDependency<IOrganizationService>()
+            .DidNotReceiveWithAnyArgs()
+            .AutoAddSeatsAsync(Arg.Any<Organization>(), Arg.Any<int>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task AcceptAsync_WithStagedMembership_AndOrganizationAtCapacity_AutoAddsSeat(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser stagedOrganizationUser,
+        SutProvider<AcceptOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        SetupStagedMembership(organization, user, stagedOrganizationUser, sutProvider);
+        organization.Seats = 2;
+        organization.MaxAutoscaleSeats = 5;
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)
+            .Returns(new OrganizationSeatCounts { Users = 2, Sponsored = 0 });
+
+        var request = new AcceptOrganizationInviteLinkRequest
+        {
+            OrganizationId = organization.Id,
+            Code = Guid.Parse(inviteLink.Code),
+            User = user
+        };
+        var result = await sutProvider.Sut.AcceptAsync(request);
+
+        Assert.True(result.IsSuccess);
+        await sutProvider.GetDependency<IOrganizationService>()
+            .Received(1)
+            .AutoAddSeatsAsync(organization, 1);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .ReplaceAsync(Arg.Is<OrganizationUser>(ou =>
+                ou.Id == stagedOrganizationUser.Id &&
+                ou.Status == OrganizationUserStatusType.Accepted));
+    }
+
+    [Theory, BitAutoData]
+    public async Task AcceptAsync_WithStagedMembership_AndNoSeatsAvailable_ReturnsError(
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser stagedOrganizationUser,
+        SutProvider<AcceptOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        SetupStagedMembership(organization, user, stagedOrganizationUser, sutProvider);
+        organization.Seats = 2;
+        organization.MaxAutoscaleSeats = 2;
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)
+            .Returns(new OrganizationSeatCounts { Users = 2, Sponsored = 0 });
+
+        var request = new AcceptOrganizationInviteLinkRequest
+        {
+            OrganizationId = organization.Id,
+            Code = Guid.Parse(inviteLink.Code),
+            User = user
+        };
+        var result = await sutProvider.Sut.AcceptAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<OrganizationHasNoAvailableSeats>(result.AsError);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceAsync(Arg.Any<OrganizationUser>());
+        await sutProvider.GetDependency<IEventService>()
+            .DidNotReceiveWithAnyArgs()
+            .LogOrganizationUserEventAsync(Arg.Any<OrganizationUser>(), Arg.Any<EventType>());
+    }
+
+    [Theory]
+    [BitAutoData(typeof(BadRequestException))]
+    [BitAutoData(typeof(GatewayException))]
+    public async Task AcceptAsync_WithStagedMembership_AndAutoAddSeatsBusinessFailure_ReturnsSeatAddFailed(
+        Type exceptionType,
+        Organization organization,
+        OrganizationInviteLink inviteLink,
+        User user,
+        OrganizationUser stagedOrganizationUser,
+        SutProvider<AcceptOrganizationInviteLinkCommand> sutProvider)
+    {
+        SetupHappyPath(organization, inviteLink, user, sutProvider);
+        SetupStagedMembership(organization, user, stagedOrganizationUser, sutProvider);
+        organization.Seats = 2;
+        organization.MaxAutoscaleSeats = 5;
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)
+            .Returns(new OrganizationSeatCounts { Users = 2, Sponsored = 0 });
+
+        Exception businessFailure = exceptionType == typeof(BadRequestException)
+            ? new BadRequestException("seat failure")
+            : new GatewayException("seat failure");
+        sutProvider.GetDependency<IOrganizationService>()
+            .AutoAddSeatsAsync(organization, 1)
+            .Throws(businessFailure);
+
+        var request = new AcceptOrganizationInviteLinkRequest
+        {
+            OrganizationId = organization.Id,
+            Code = Guid.Parse(inviteLink.Code),
+            User = user
+        };
+        var result = await sutProvider.Sut.AcceptAsync(request);
+
+        Assert.True(result.IsError);
+        Assert.IsType<SeatAddFailed>(result.AsError);
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceiveWithAnyArgs()
+            .ReplaceAsync(Arg.Any<OrganizationUser>());
+    }
+
     [Theory, BitAutoData]
     public async Task AcceptAsync_WithNoSeatsAvailable_ReturnsError(
         Organization organization,
@@ -570,6 +759,24 @@ public class AcceptOrganizationInviteLinkCommandTests
                 Enabled = true,
                 Data = "{\"autoEnrollEnabled\": true}"
             });
+
+    // A Staged membership: SCIM/Directory-Connector provisioned, email set, not yet linked to a User.
+    // Call after SetupHappyPath, which stubs the email lookup as returning no membership.
+    private static void SetupStagedMembership(
+        Organization organization,
+        User user,
+        OrganizationUser stagedOrganizationUser,
+        SutProvider<AcceptOrganizationInviteLinkCommand> sutProvider)
+    {
+        stagedOrganizationUser.OrganizationId = organization.Id;
+        stagedOrganizationUser.Status = OrganizationUserStatusType.Staged;
+        stagedOrganizationUser.Email = user.Email;
+        stagedOrganizationUser.UserId = null;
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationEmailAsync(organization.Id, user.Email)
+            .Returns(stagedOrganizationUser);
+    }
 
     private static void SetupHappyPath(
         Organization org,


### PR DESCRIPTION
## 🎟️ Tracking
[PM-42433](https://bitwarden.atlassian.net/browse/PM-42433)

## 📔 Objective
Staged users are pre-existing organization users that do _not_ occupy a seat for billing purposes - it is therefore necessary to do seat-count validation before promoting them in all scenarios.
 

[PM-42433]: https://bitwarden.atlassian.net/browse/PM-42433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ