### PR TITLE
Retry a PAM lease mint the provider could not serialize

### DIFF
--- a/src/Infrastructure.EntityFramework/Pam/Repositories/AccessLeaseRepository.cs
+++ b/src/Infrastructure.EntityFramework/Pam/Repositories/AccessLeaseRepository.cs
@@ -15,6 +15,9 @@ namespace Bit.Infrastructure.EntityFramework.Pam.Repositories;
 
 public class AccessLeaseRepository : Repository<CoreEntity, EfModel, Guid>, IAccessLeaseRepository
 {
+    // Bounds CreateFromApprovedRequestAsync's retry of provider serialization failures.
+    private const int MaxMintAttempts = 3;
+
     public AccessLeaseRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
         : base(serviceScopeFactory, mapper, context => context.AccessLeases)
     { }
@@ -115,7 +118,32 @@ public class AccessLeaseRepository : Repository<CoreEntity, EfModel, Guid>, IAcc
         return Mapper.Map<List<CoreEntity>>(leases);
     }
 
+    /// <remarks>
+    /// A provider serialization failure is retried rather than surfaced. The per-cipher guard below reads a
+    /// predicate rather than a row, so under Serializable isolation this transaction is a candidate for abort
+    /// whenever any other transaction inserts a lease before it commits -- including one that grants access to an
+    /// unrelated cipher. A losing attempt therefore runs again on a fresh transaction and re-reads the state its
+    /// guard needs, arriving at the same deterministic outcome the stored procedure's UPDLOCK/HOLDLOCK blocks for.
+    /// Retries are bounded: a failure that outlives them propagates, because on a path that grants access to Vault
+    /// Data an unresolved persistence failure must not be reported as a benign mint outcome.
+    /// </remarks>
     public async Task<AccessLeaseMintOutcome> CreateFromApprovedRequestAsync(CoreEntity lease, DateTime now,
+        bool enforceSingleActiveLease)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await MintFromApprovedRequestAsync(lease, now, enforceSingleActiveLease);
+            }
+            catch (Exception e) when (attempt < MaxMintAttempts && IsSerializationFailure(e))
+            {
+                // The aborted transaction committed nothing, so the next attempt starts from a fresh scope.
+            }
+        }
+    }
+
+    private async Task<AccessLeaseMintOutcome> MintFromApprovedRequestAsync(CoreEntity lease, DateTime now,
         bool enforceSingleActiveLease)
     {
         using var scope = ServiceScopeFactory.CreateScope();
@@ -125,9 +153,8 @@ public class AccessLeaseRepository : Repository<CoreEntity, EfModel, Guid>, IAcc
         // UPDLOCK/HOLDLOCK range lock used for the per-cipher singleton guard: it keeps a concurrent same-cipher
         // activation from reading a pre-mint state. Unlike the SQL Server proc (which blocks a concurrent caller
         // until this transaction commits, then re-evaluates deterministically), a losing concurrent transaction here
-        // may instead fail at commit time with a provider-level serialization error rather than cleanly returning
-        // SingleActiveLeaseConflict/PreconditionFailed -- callers should be prepared to treat such an exception as a
-        // conflict and re-read.
+        // fails at commit time with a provider-level serialization error instead of cleanly returning
+        // SingleActiveLeaseConflict/PreconditionFailed -- which is why the caller of this method retries it.
         await using var transaction = await dbContext.Database.BeginTransactionAsync(System.Data.IsolationLevel.Serializable);
 
         try
@@ -259,6 +286,23 @@ public class AccessLeaseRepository : Repository<CoreEntity, EfModel, Guid>, IAcc
     /// violations: the backstop here is a unique <em>index</em>, which reports different codes on SQL Server
     /// (2601 rather than 2627) and SQLite (2067 rather than 1555).
     /// </remarks>
+    /// <summary>
+    /// True when the provider refused the transaction because it could not serialize it against a concurrent one:
+    /// PostgreSQL's SSI aborting it at commit, or a deadlock victim elsewhere. The transaction is already gone in
+    /// every case, so the only recovery is to run the whole attempt again.
+    /// </summary>
+    private static bool IsSerializationFailure(Exception e) => e switch
+    {
+        Npgsql.PostgresException pg => pg.SqlState is "40001" or "40P01",
+        MySqlConnector.MySqlException my => my.ErrorCode is MySqlConnector.MySqlErrorCode.LockDeadlock
+            or MySqlConnector.MySqlErrorCode.LockWaitTimeout,
+        Microsoft.Data.SqlClient.SqlException ms => ms.Errors
+            .Cast<Microsoft.Data.SqlClient.SqlError>()
+            .Any(error => error.Number is 1205),
+        Microsoft.Data.Sqlite.SqliteException lite => lite.SqliteErrorCode is 5 or 6,
+        _ => e.InnerException is not null && IsSerializationFailure(e.InnerException),
+    };
+
     private static bool IsDuplicateKeyException(DbUpdateException e) => e.InnerException switch
     {
         MySqlConnector.MySqlException my => my.ErrorCode == MySqlConnector.MySqlErrorCode.DuplicateKeyEntry,

--- a/src/Infrastructure.EntityFramework/Pam/Repositories/AccessLeaseRepository.cs
+++ b/src/Infrastructure.EntityFramework/Pam/Repositories/AccessLeaseRepository.cs
@@ -276,17 +276,6 @@ public class AccessLeaseRepository : Repository<CoreEntity, EfModel, Guid>, IAcc
     }
 
     /// <summary>
-    /// True when the write failed because a duplicate key was inserted -- here, the unique
-    /// [IX_AccessLease_AccessRequestId] backstop tripping because a concurrent activation minted this request's
-    /// lease first. Deliberately narrow so that any other write failure propagates rather than being reported as a
-    /// benign mint outcome. Mirrors the Dapper counterpart's <c>SqlException.Number is 2601 or 2627</c>.
-    /// </summary>
-    /// <remarks>
-    /// Distinct from <c>EntityFrameworkCache.IsDuplicateKeyException</c>, which only recognises primary-key
-    /// violations: the backstop here is a unique <em>index</em>, which reports different codes on SQL Server
-    /// (2601 rather than 2627) and SQLite (2067 rather than 1555).
-    /// </remarks>
-    /// <summary>
     /// True when the provider refused the transaction because it could not serialize it against a concurrent one:
     /// PostgreSQL's SSI aborting it at commit, or a deadlock victim elsewhere. The transaction is already gone in
     /// every case, so the only recovery is to run the whole attempt again.
@@ -303,6 +292,17 @@ public class AccessLeaseRepository : Repository<CoreEntity, EfModel, Guid>, IAcc
         _ => e.InnerException is not null && IsSerializationFailure(e.InnerException),
     };
 
+    /// <summary>
+    /// True when the write failed because a duplicate key was inserted -- here, the unique
+    /// [IX_AccessLease_AccessRequestId] backstop tripping because a concurrent activation minted this request's
+    /// lease first. Deliberately narrow so that any other write failure propagates rather than being reported as a
+    /// benign mint outcome. Mirrors the Dapper counterpart's <c>SqlException.Number is 2601 or 2627</c>.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <c>EntityFrameworkCache.IsDuplicateKeyException</c>, which only recognises primary-key
+    /// violations: the backstop here is a unique <em>index</em>, which reports different codes on SQL Server
+    /// (2601 rather than 2627) and SQLite (2067 rather than 1555).
+    /// </remarks>
     private static bool IsDuplicateKeyException(DbUpdateException e) => e.InnerException switch
     {
         MySqlConnector.MySqlException my => my.ErrorCode == MySqlConnector.MySqlErrorCode.DuplicateKeyEntry,

--- a/test/Infrastructure.IntegrationTest/Pam/Repositories/AccessLeaseRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Pam/Repositories/AccessLeaseRepositoryTests.cs
@@ -310,6 +310,38 @@ public class LeaseRepositoryTests
         Assert.Null(await accessLeaseRepository.GetByAccessRequestIdAsync(second.Id));
     }
 
+    // The same per-cipher contention under real concurrency: two users activate approved requests for one cipher at
+    // the same instant on separate connections. Serializable isolation makes the loser a candidate for a provider
+    // serialization failure at commit rather than a clean refusal, so this is the guard for the mint's retry -- the
+    // loser must still report the conflict, and the cipher must end up carrying exactly one lease.
+    [DatabaseTheory, DatabaseData]
+    public async Task CreateFromApprovedRequestAsync_ConcurrentSameCipherActivations_OneMintsAndTheOtherConflicts(
+        IOrganizationRepository organizationRepository,
+        IAccessRequestRepository accessRequestRepository,
+        IAccessLeaseRepository accessLeaseRepository)
+    {
+        var organization = await organizationRepository.CreateTestOrganizationAsync();
+        var now = DateTime.UtcNow;
+        var cipherId = Guid.NewGuid();
+        var first = await CreateApprovedRequestAsync(
+            accessRequestRepository, organization.Id, now.AddHours(-1), now.AddHours(1), cipherId: cipherId);
+        var second = await CreateApprovedRequestAsync(
+            accessRequestRepository, organization.Id, now.AddHours(-1), now.AddHours(1), cipherId: cipherId);
+
+        var outcomes = await Task.WhenAll(
+            accessLeaseRepository.CreateFromApprovedRequestAsync(BuildLeaseFor(first, now), now, true),
+            accessLeaseRepository.CreateFromApprovedRequestAsync(BuildLeaseFor(second, now), now, true));
+
+        Assert.Single(outcomes, outcome => outcome == AccessLeaseMintOutcome.Minted);
+        Assert.Single(outcomes, outcome => outcome == AccessLeaseMintOutcome.SingleActiveLeaseConflict);
+
+        // Whichever request won, only its lease exists: the refused activation left nothing behind.
+        var minted = outcomes[0] == AccessLeaseMintOutcome.Minted ? first : second;
+        var refused = outcomes[0] == AccessLeaseMintOutcome.Minted ? second : first;
+        Assert.NotNull(await accessLeaseRepository.GetByAccessRequestIdAsync(minted.Id));
+        Assert.Null(await accessLeaseRepository.GetByAccessRequestIdAsync(refused.Id));
+    }
+
     [DatabaseTheory, DatabaseData]
     public async Task GetManyActiveByCollectionIdsAsync_ReturnsActiveInWindowLeasesOnGivenCollections(
         IOrganizationRepository organizationRepository,


### PR DESCRIPTION
## 🎟️ Tracking

No ticket — a CI flake, first triaged on #8243 where it failed the mint on Postgres.

## 📔 Objective

`AccessLeaseRepository.CreateFromApprovedRequestAsync` (EF) enforces its per-cipher singleton with a **predicate** read inside a `Serializable` transaction:

```csharp
var conflict = await dbContext.AccessLeases
    .AnyAsync(l => l.CipherId == cipherId.Value
        && l.Status == AccessLeaseStatus.Active
        && l.NotBefore <= now
        && l.NotAfter > now);
```

PostgreSQL records a predicate lock for that read, so the transaction becomes a candidate for abort whenever **any** other transaction inserts a lease before it commits — including one granting access to an unrelated cipher, and including one at a weaker isolation level, since only the *reader* has to be `Serializable` for SSI to find a read-write dependency. The abort escaped the repository as a raw `Npgsql.PostgresException: 40001`, which means a 500 for a caller whose activation was merely unlucky, and an intermittently red CI as soon as anything else seeds a lease concurrently.

### What this changes

The single attempt is now retried on a provider serialization failure. Each attempt takes a fresh scope, context and transaction and re-reads the state its guard needs, so a losing caller reaches the same deterministic outcome that the SQL Server procedure's `UPDLOCK`/`HOLDLOCK` blocks for. Retries are bounded and anything outliving them propagates — on a path that grants access to Vault Data, an unresolved persistence failure must not be reported as a benign mint outcome.

This is the contract PostgreSQL specifies for `SERIALIZABLE`: applications at that level must be prepared to retry on serialization failure. The stale comment telling *callers* to treat the exception as a conflict is updated, since the repository now handles it.

Deliberately unchanged:

- **The guard's semantics.** Same isolation level, same predicate, same outcomes.
- **The MSSQL path.** The Dapper procedure blocks rather than aborting, and never flaked.
- **The schema.** A partial unique index on `(CipherId) WHERE Status = Active` can't replace the guard: the invariant is "Active *and* the window covers `now`", and an index predicate can't reference `now`.

### Testing

`CreateFromApprovedRequestAsync_ConcurrentSameCipherActivations_OneMintsAndTheOtherConflicts` races two activations of one cipher on separate connections and asserts exactly one mint, one conflict, and one surviving lease. Without the retry it reproduces the escaping `40001` on **3 of 3** runs; with it, it passes on SqlServer, Postgres and Sqlite.

At suite level, `--filter "FullyQualifiedName~IntegrationTest.Pam"` on Postgres hit `40001` in **1 of 6** runs before the change and **0 of 8** after.

Not verified locally: MySQL (my local container's credentials are broken, so every MySql case errors on connect) — relying on CI for that provider.

## 📸 Screenshots

n/a