### PR TITLE
Add support for DDG ext device type

### DIFF
--- a/src/Core/Enums/DeviceType.cs
+++ b/src/Core/Enums/DeviceType.cs
@@ -58,4 +58,6 @@ public enum DeviceType : byte
     LinuxCLI = 25,
     [Display(Name = "DuckDuckGo")]
     DuckDuckGoBrowser = 26,
+    [Display(Name = "DuckDuckGo Extension")]
+    DuckDuckGoExtension = 27,
 }

--- a/src/Core/Utilities/DeviceTypes.cs
+++ b/src/Core/Utilities/DeviceTypes.cs
@@ -33,7 +33,8 @@ public static class DeviceTypes
         DeviceType.OperaExtension,
         DeviceType.EdgeExtension,
         DeviceType.VivaldiExtension,
-        DeviceType.SafariExtension
+        DeviceType.SafariExtension,
+        DeviceType.DuckDuckGoExtension
     ];
 
     public static IReadOnlyCollection<DeviceType> BrowserTypes { get; } =


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42510

## 📔 Objective

Adds `DeviceType.DuckDuckGoExtension = 27` so DuckDuckGo can be identified as a browser
extension client.

DuckDuckGo now exposes itself as a browser brand — `DuckDuckGo` appears in
`navigator.userAgentData.brands` in both popup and service-worker contexts, and they set
matching `sec-ch-ua` headers during regular browsing. The browser variant
(`DuckDuckGoBrowser = 26`) already landed and covers the web vault case; this adds the
missing extension variant.

Without it, a DDG extension client has no accurate device type to report and falls back to
`ChromeExtension`, mislabeling the device in device lists, new-device-login emails, 2FA
emails, and TDE login-approval prompts.

See https://github.com/bitwarden/clients/pull/22696 for corresponding `clients` PR.

## 📸 Screenshots

n/a
