### PR TITLE
[PM-42584] Require single organization to enable fill assist policy

### DIFF
--- a/src/Core/AdminConsole/Enums/PolicyType.cs
+++ b/src/Core/AdminConsole/Enums/PolicyType.cs
@@ -66,7 +66,7 @@ public static class PolicyTypeExtensions
             PolicyType.BlockClaimedDomainAccountCreation => "Block account creation for claimed domains",
             PolicyType.OrganizationUserNotification => "Vault banner message",
             PolicyType.SendControls => "Send controls",
-            PolicyType.FillAssist => "Fill Assist",
+            PolicyType.FillAssist => "Fill assist",
         };
     }
 }

--- a/src/Core/AdminConsole/Enums/PolicyType.cs
+++ b/src/Core/AdminConsole/Enums/PolicyType.cs
@@ -66,7 +66,7 @@ public static class PolicyTypeExtensions
             PolicyType.BlockClaimedDomainAccountCreation => "Block account creation for claimed domains",
             PolicyType.OrganizationUserNotification => "Vault banner message",
             PolicyType.SendControls => "Send controls",
-            PolicyType.FillAssist => "Fill assist",
+            PolicyType.FillAssist => "Activate fill assist",
         };
     }
 }

--- a/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/FillAssistPolicyEventHandler.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/Policies/PolicyEventHandlers/FillAssistPolicyEventHandler.cs
@@ -8,9 +8,10 @@ using Bit.Core.Utilities;
 
 namespace Bit.Core.AdminConsole.OrganizationFeatures.Policies.PolicyEventHandlers;
 
-public class FillAssistPolicyEventHandler : IPolicyValidationEvent
+public class FillAssistPolicyEventHandler : IPolicyValidationEvent, IEnforceDependentPoliciesEvent
 {
     public PolicyType Type => PolicyType.FillAssist;
+    public IEnumerable<PolicyType> RequiredPolicies => [PolicyType.SingleOrg];
 
     public Task<string> ValidateAsync(SavePolicyModel policyRequest, Policy? currentPolicy)
     {

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/PoliciesControllerTests.cs
@@ -500,6 +500,11 @@ public class PoliciesControllerTests : IClassFixture<ApiApplicationFactory>, IAs
     public async Task Put_FillAssistPolicy_Success()
     {
         // Arrange
+        // FillAssist requires SingleOrg to be enabled first (IEnforceDependentPoliciesEvent).
+        await _client.PutAsync(
+            $"/organizations/{_organization.Id}/policies/{PolicyType.SingleOrg}",
+            JsonContent.Create(new SavePolicyRequest { Policy = new PolicyRequestModel { Enabled = true } }));
+
         var policyType = PolicyType.FillAssist;
         const string rulesUrl = "https://github.com/bitwarden/map-the-web/releases/latest/download";
         var request = new SavePolicyRequest


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

https://bitwarden.atlassian.net/browse/PM-42584

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Require that an org enable the “Single organization membership” policy before they can enable the “Activate fill assist” policy. 

### Context

PolicyType.FillAssist (added in PM-41311) can currently be enabled independently of Single organization. Because fill assist rule URLs are org-scoped, admins should not be able to enable Fill assist without Single organization first. Matches the existing prerequisite already enforced for UriMatchDefaults, ResetPassword, and MaximumVaultTimeout.

### Change

FillAssistPolicyEventHandler implements IEnforceDependentPoliciesEvent with RequiredPolicies => [PolicyType.SingleOrg]. The SavePolicyCommand framework handles both directions automatically:

- Enabling Fill assist while SingleOrg is disabled → 400

- Disabling SingleOrg while Fill assist is enabled → 400

Both error messages are generated by the framework from PolicyType.GetName(). No new copy, no localization work.

NOTE: We decided to skip QA for these `server` changes. We'll do QA in the companion PR in `clients` for https://bitwarden.atlassian.net/browse/PM-42585
