### PR TITLE
[PM-42319] - Add Inject Collection

### DIFF
--- a/src/Api/AdminConsole/Attributes/InjectCollectionAttribute.cs
+++ b/src/Api/AdminConsole/Attributes/InjectCollectionAttribute.cs
@@ -1,0 +1,86 @@
+﻿using Bit.Api.AdminConsole.Authorization;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace Bit.Api.AdminConsole.Attributes;
+
+/// <summary>
+/// Binds a <see cref="Bit.Core.Entities.Collection"/> parameter by loading it from the database
+/// and validating that it belongs to the organization identified by the <c>orgId</c> or
+/// <c>organizationId</c> route parameter.
+/// </summary>
+/// <remarks>
+/// The collection is resolved from the route parameter named by
+/// <see cref="CollectionIdRouteParam"/> (default <c>"id"</c>). If the collection is not found or
+/// does not belong to the organization, a <see cref="Bit.Core.Exceptions.NotFoundException"/> is thrown.
+/// </remarks>
+/// <example>
+/// <code><![CDATA[
+/// [HttpGet("{id}")]
+/// public async Task<CollectionResponseModel> Get(Guid orgId,
+///     [InjectCollection] Collection collection)
+///
+/// [HttpDelete("{collectionId}")]
+/// public async Task Delete(Guid orgId,
+///     [InjectCollection("collectionId")] Collection collection)
+/// ]]></code>
+/// </example>
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class InjectCollectionAttribute(string collectionIdRouteParam = "id")
+    : ModelBinderAttribute(typeof(CollectionModelBinder))
+{
+    /// <summary>
+    /// Name of the route parameter containing the collection ID. Defaults to <c>"id"</c>.
+    /// </summary>
+    public string CollectionIdRouteParam { get; } = collectionIdRouteParam;
+}
+
+/// <summary>
+/// Custom model binder that loads a <see cref="Bit.Core.Entities.Collection"/> from the database,
+/// validates that it belongs to the organization identified by the route, and binds it to the parameter.
+/// </summary>
+/// <remarks>
+/// This binder is used via the <see cref="InjectCollectionAttribute"/>.
+/// </remarks>
+public class CollectionModelBinder : IModelBinder
+{
+    public async Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        var defaultMetadata = bindingContext.ModelMetadata as DefaultModelMetadata;
+        var attr = defaultMetadata?.Attributes.ParameterAttributes
+            ?.OfType<InjectCollectionAttribute>()
+            .FirstOrDefault()
+            ?? new InjectCollectionAttribute();
+
+        Guid orgId;
+        try
+        {
+            orgId = bindingContext.HttpContext.GetOrganizationId();
+        }
+        catch (InvalidOperationException)
+        {
+            throw new BadRequestException("Route parameter 'orgId' or 'organizationId' is missing or invalid.");
+        }
+
+        var collectionId = bindingContext.HttpContext.TryGetRouteParameterAsGuid(attr.CollectionIdRouteParam);
+        if (collectionId is null)
+        {
+            throw new BadRequestException(
+                $"Route parameter '{attr.CollectionIdRouteParam}' is missing or invalid.");
+        }
+
+        var repo = bindingContext.HttpContext.RequestServices
+            .GetRequiredService<ICollectionRepository>();
+
+        var collection = await repo.GetByIdAsync(collectionId.Value);
+        if (collection is null || collection.OrganizationId != orgId)
+        {
+            throw new NotFoundException();
+        }
+
+        bindingContext.Result = ModelBindingResult.Success(collection);
+    }
+}

--- a/src/Api/AdminConsole/Controllers/CollectionsController.cs
+++ b/src/Api/AdminConsole/Controllers/CollectionsController.cs
@@ -192,14 +192,8 @@ public class CollectionsController : Controller
     }
 
     [HttpPut("{id}")]
-    public async Task<CollectionResponseModel> Put(Guid orgId, Guid id, [FromBody] UpdateCollectionRequestModel model)
+    public async Task<CollectionResponseModel> Put(Guid orgId, [InjectCollection] Collection collection, [FromBody] UpdateCollectionRequestModel model)
     {
-        var collection = await _collectionRepository.GetByIdAsync(id);
-        if (collection is null || collection.OrganizationId != orgId)
-        {
-            throw new NotFoundException();
-        }
-
         var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.Update)).Succeeded;
         if (!authorized)
         {
@@ -229,9 +223,9 @@ public class CollectionsController : Controller
 
     [HttpPost("{id}")]
     [Obsolete("This endpoint is deprecated. Use PUT /{id} instead.")]
-    public async Task<CollectionResponseModel> PostPut(Guid orgId, Guid id, [FromBody] UpdateCollectionRequestModel model)
+    public async Task<CollectionResponseModel> PostPut(Guid orgId, [InjectCollection] Collection collection, [FromBody] UpdateCollectionRequestModel model)
     {
-        return await Put(orgId, id, model);
+        return await Put(orgId, collection, model);
     }
 
     [HttpPost("bulk-access")]

--- a/src/Api/AdminConsole/Controllers/CollectionsController.cs
+++ b/src/Api/AdminConsole/Controllers/CollectionsController.cs
@@ -1,6 +1,7 @@
 ﻿// FIXME: Update this file to be null safe and then delete the line below
 #nullable disable
 
+using Bit.Api.AdminConsole.Attributes;
 using Bit.Api.AdminConsole.Authorization.Collections;
 using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.AdminConsole.Models.Response;
@@ -56,9 +57,8 @@ public class CollectionsController : Controller
     }
 
     [HttpGet("{id}")]
-    public async Task<CollectionResponseModel> Get(Guid orgId, Guid id)
+    public async Task<CollectionResponseModel> Get(Guid orgId, [InjectCollection] Collection collection)
     {
-        var collection = await _collectionRepository.GetByIdAsync(id);
         var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.Read)).Succeeded;
         if (!authorized)
         {
@@ -73,6 +73,11 @@ public class CollectionsController : Controller
     {
         var collectionAdminDetails =
             await _collectionRepository.GetByIdWithPermissionsAsync(id, _currentContext.UserId, true);
+
+        if (collectionAdminDetails is null || collectionAdminDetails.OrganizationId != orgId)
+        {
+            throw new NotFoundException();
+        }
 
         var authorized = (await _authorizationService.AuthorizeAsync(User, collectionAdminDetails, BulkCollectionOperations.ReadWithAccess)).Succeeded;
         if (!authorized)
@@ -140,9 +145,8 @@ public class CollectionsController : Controller
     }
 
     [HttpGet("{id}/users")]
-    public async Task<IEnumerable<SelectionReadOnlyResponseModel>> GetUsers(Guid orgId, Guid id)
+    public async Task<IEnumerable<SelectionReadOnlyResponseModel>> GetUsers(Guid orgId, [InjectCollection] Collection collection)
     {
-        var collection = await _collectionRepository.GetByIdAsync(id);
         var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.ReadAccess)).Succeeded;
         if (!authorized)
         {
@@ -191,6 +195,11 @@ public class CollectionsController : Controller
     public async Task<CollectionResponseModel> Put(Guid orgId, Guid id, [FromBody] UpdateCollectionRequestModel model)
     {
         var collection = await _collectionRepository.GetByIdAsync(id);
+        if (collection is null || collection.OrganizationId != orgId)
+        {
+            throw new NotFoundException();
+        }
+
         var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.Update)).Succeeded;
         if (!authorized)
         {
@@ -235,7 +244,7 @@ public class CollectionsController : Controller
         }
 
         var result = await _authorizationService.AuthorizeAsync(User, collections,
-            new[] { BulkCollectionOperations.ModifyUserAccess, BulkCollectionOperations.ModifyGroupAccess });
+            [BulkCollectionOperations.ModifyUserAccess, BulkCollectionOperations.ModifyGroupAccess]);
 
         if (!result.Succeeded)
         {
@@ -249,9 +258,8 @@ public class CollectionsController : Controller
     }
 
     [HttpDelete("{id}")]
-    public async Task Delete(Guid orgId, Guid id)
+    public async Task Delete(Guid orgId, [InjectCollection] Collection collection)
     {
-        var collection = await _collectionRepository.GetByIdAsync(id);
         var authorized = (await _authorizationService.AuthorizeAsync(User, collection, BulkCollectionOperations.Delete)).Succeeded;
         if (!authorized)
         {
@@ -263,15 +271,20 @@ public class CollectionsController : Controller
 
     [HttpPost("{id}/delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE /{id} instead.")]
-    public async Task PostDelete(Guid orgId, Guid id)
+    public async Task PostDelete(Guid orgId, [InjectCollection] Collection collection)
     {
-        await Delete(orgId, id);
+        await Delete(orgId, collection);
     }
 
     [HttpDelete("")]
     public async Task DeleteMany(Guid orgId, [FromBody] CollectionBulkDeleteRequestModel model)
     {
         var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Ids);
+        if (collections.Count(c => c.OrganizationId == orgId) != model.Ids.Count())
+        {
+            throw new NotFoundException();
+        }
+
         var result = await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.Delete);
         if (!result.Succeeded)
         {

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/CollectionsControllerTests.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Api.AdminConsole.Models.Public.Request;
+﻿using System.Net;
+using Bit.Api.AdminConsole.Models.Public.Request;
 using Bit.Api.AdminConsole.Models.Public.Response;
 using Bit.Api.AdminConsole.Public.Models.Request;
 using Bit.Api.IntegrationTest.Factories;
@@ -26,6 +27,7 @@ public class CollectionsControllerTests : IClassFixture<ApiApplicationFactory>, 
 
     private string _ownerEmail = null!;
     private Organization _organization = null!;
+    private OrganizationUser _organizationOwner = null!;
 
     public CollectionsControllerTests(ApiApplicationFactory factory)
     {
@@ -41,7 +43,7 @@ public class CollectionsControllerTests : IClassFixture<ApiApplicationFactory>, 
         _ownerEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
         await _factory.LoginWithNewAccount(_ownerEmail);
 
-        (_organization, _) = await OrganizationTestHelpers.SignUpAsync(_factory,
+        (_organization, _organizationOwner) = await OrganizationTestHelpers.SignUpAsync(_factory,
             plan: PlanType.EnterpriseAnnually,
             ownerEmail: _ownerEmail,
             passwordManagerSeats: 10,
@@ -175,5 +177,47 @@ public class CollectionsControllerTests : IClassFixture<ApiApplicationFactory>, 
         Assert.False(groupResponse.ReadOnly);
         Assert.False(groupResponse.HidePasswords);
         Assert.True(groupResponse.Manage);
+    }
+
+    [Fact]
+    public async Task Get_CollectionBelongsToDifferentOrg_ReturnsNotFound()
+    {
+        var otherOwnerEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(otherOwnerEmail);
+        var (otherOrganization, _) = await OrganizationTestHelpers.SignUpAsync(_factory,
+            plan: PlanType.EnterpriseAnnually,
+            ownerEmail: otherOwnerEmail,
+            passwordManagerSeats: 10,
+            paymentMethod: PaymentMethodType.Card);
+
+        var otherOrgCollection = await OrganizationTestHelpers.CreateCollectionAsync(
+            _factory, otherOrganization.Id, "Other Org Collection");
+
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.GetAsync(
+            $"organizations/{_organization.Id}/collections/{otherOrgCollection.Id}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_CollectionBelongsToRouteOrg_ReturnsOk()
+    {
+        var collection = await OrganizationTestHelpers.CreateCollectionAsync(
+            _factory,
+            _organization.Id,
+            "Same Org Collection",
+            users:
+            [
+                new CollectionAccessSelection { Id = _organizationOwner.Id, ReadOnly = false, HidePasswords = false, Manage = true }
+            ]);
+
+        await _loginHelper.LoginAsync(_ownerEmail);
+
+        var response = await _client.GetAsync(
+            $"organizations/{_organization.Id}/collections/{collection.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/CollectionsControllerTests.cs
@@ -180,28 +180,6 @@ public class CollectionsControllerTests : IClassFixture<ApiApplicationFactory>, 
     }
 
     [Fact]
-    public async Task Get_CollectionBelongsToDifferentOrg_ReturnsNotFound()
-    {
-        var otherOwnerEmail = $"integration-test{Guid.NewGuid()}@example.com";
-        await _factory.LoginWithNewAccount(otherOwnerEmail);
-        var (otherOrganization, _) = await OrganizationTestHelpers.SignUpAsync(_factory,
-            plan: PlanType.EnterpriseAnnually,
-            ownerEmail: otherOwnerEmail,
-            passwordManagerSeats: 10,
-            paymentMethod: PaymentMethodType.Card);
-
-        var otherOrgCollection = await OrganizationTestHelpers.CreateCollectionAsync(
-            _factory, otherOrganization.Id, "Other Org Collection");
-
-        await _loginHelper.LoginAsync(_ownerEmail);
-
-        var response = await _client.GetAsync(
-            $"organizations/{_organization.Id}/collections/{otherOrgCollection.Id}");
-
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-    }
-
-    [Fact]
     public async Task Get_CollectionBelongsToRouteOrg_ReturnsOk()
     {
         var collection = await OrganizationTestHelpers.CreateCollectionAsync(

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/CollectionsControllerTests.cs
@@ -40,7 +40,7 @@ public class CollectionsControllerTests : IClassFixture<ApiApplicationFactory>, 
 
     public async Task InitializeAsync()
     {
-        _ownerEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        _ownerEmail = $"integration-test{Guid.NewGuid()}@example.com";
         await _factory.LoginWithNewAccount(_ownerEmail);
 
         (_organization, _organizationOwner) = await OrganizationTestHelpers.SignUpAsync(_factory,
@@ -182,7 +182,7 @@ public class CollectionsControllerTests : IClassFixture<ApiApplicationFactory>, 
     [Fact]
     public async Task Get_CollectionBelongsToDifferentOrg_ReturnsNotFound()
     {
-        var otherOwnerEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        var otherOwnerEmail = $"integration-test{Guid.NewGuid()}@example.com";
         await _factory.LoginWithNewAccount(otherOwnerEmail);
         var (otherOrganization, _) = await OrganizationTestHelpers.SignUpAsync(_factory,
             plan: PlanType.EnterpriseAnnually,

--- a/test/Api.Test/AdminConsole/Attributes/CollectionModelBinderTests.cs
+++ b/test/Api.Test/AdminConsole/Attributes/CollectionModelBinderTests.cs
@@ -1,0 +1,202 @@
+﻿using System.Reflection;
+using Bit.Api.AdminConsole.Attributes;
+using Bit.Core.Entities;
+using Bit.Core.Exceptions;
+using Bit.Core.Repositories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Attributes;
+
+public class CollectionModelBinderTests
+{
+    private readonly ICollectionRepository _collectionRepository;
+    private readonly Collection _collection;
+    private readonly Guid _orgId;
+    private readonly Guid _collectionId;
+
+    public CollectionModelBinderTests()
+    {
+        _collectionRepository = Substitute.For<ICollectionRepository>();
+        _orgId = Guid.NewGuid();
+        _collectionId = Guid.NewGuid();
+        _collection = new Collection { Id = _collectionId, OrganizationId = _orgId };
+    }
+
+    [Fact]
+    public async Task BindModelAsync_CollectionExistsAndBelongsToOrg_BindsSuccessfully()
+    {
+        var binder = new CollectionModelBinder();
+        _collectionRepository.GetByIdAsync(_collectionId).Returns(_collection);
+
+        var context = CreateBindingContext();
+
+        await binder.BindModelAsync(context);
+
+        Assert.True(context.Result.IsModelSet);
+        Assert.Equal(_collection, context.Result.Model);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_CollectionNotFound_ThrowsNotFoundException()
+    {
+        var binder = new CollectionModelBinder();
+        _collectionRepository.GetByIdAsync(_collectionId).Returns((Collection)null);
+
+        var context = CreateBindingContext();
+
+        await Assert.ThrowsAsync<NotFoundException>(() => binder.BindModelAsync(context));
+    }
+
+    [Fact]
+    public async Task BindModelAsync_CollectionBelongsToDifferentOrg_ThrowsNotFoundException()
+    {
+        var binder = new CollectionModelBinder();
+        var wrongOrgCollection = new Collection { Id = _collectionId, OrganizationId = Guid.NewGuid() };
+        _collectionRepository.GetByIdAsync(_collectionId).Returns(wrongOrgCollection);
+
+        var context = CreateBindingContext();
+
+        await Assert.ThrowsAsync<NotFoundException>(() => binder.BindModelAsync(context));
+    }
+
+    [Fact]
+    public async Task BindModelAsync_InvalidOrgId_ThrowsBadRequestException()
+    {
+        var binder = new CollectionModelBinder();
+        var context = CreateBindingContext(orgIdRouteValue: "not-a-guid");
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => binder.BindModelAsync(context));
+        Assert.Equal("Route parameter 'orgId' or 'organizationId' is missing or invalid.", exception.Message);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_MissingOrgId_ThrowsBadRequestException()
+    {
+        var binder = new CollectionModelBinder();
+        var context = CreateBindingContext(includeOrgId: false);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => binder.BindModelAsync(context));
+        Assert.Equal("Route parameter 'orgId' or 'organizationId' is missing or invalid.", exception.Message);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_InvalidCollectionId_ThrowsBadRequestException()
+    {
+        var binder = new CollectionModelBinder();
+        var context = CreateBindingContext(collectionIdRouteValue: "not-a-guid");
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => binder.BindModelAsync(context));
+        Assert.Equal("Route parameter 'id' is missing or invalid.", exception.Message);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_MissingCollectionId_ThrowsBadRequestException()
+    {
+        var binder = new CollectionModelBinder();
+        var context = CreateBindingContext(includeCollectionId: false);
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(() => binder.BindModelAsync(context));
+        Assert.Equal("Route parameter 'id' is missing or invalid.", exception.Message);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_OrganizationIdRouteParam_ResolvesOrgId()
+    {
+        var binder = new CollectionModelBinder();
+        _collectionRepository.GetByIdAsync(_collectionId).Returns(_collection);
+
+        var context = CreateBindingContext(useOrganizationIdRoute: true);
+
+        await binder.BindModelAsync(context);
+
+        Assert.True(context.Result.IsModelSet);
+        Assert.Equal(_collection, context.Result.Model);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_CustomRouteParamName_ReadsCorrectRouteValue()
+    {
+        var binder = new CollectionModelBinder();
+        _collectionRepository.GetByIdAsync(_collectionId).Returns(_collection);
+
+        var parameterInfo = typeof(CollectionModelBinderTests)
+            .GetMethod(nameof(DummyMethodWithCustomRouteParam), BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters()[0];
+
+        var context = CreateBindingContext(
+            collectionIdRouteKey: "collectionId",
+            parameterInfo: parameterInfo);
+
+        await binder.BindModelAsync(context);
+
+        Assert.True(context.Result.IsModelSet);
+        Assert.Equal(_collection, context.Result.Model);
+    }
+
+    /// <summary>
+    /// Dummy method used to produce a <see cref="ParameterInfo"/> carrying a custom
+    /// <see cref="InjectCollectionAttribute"/> for the custom route param test.
+    /// </summary>
+    private static void DummyMethodWithCustomRouteParam(
+        [InjectCollection("collectionId")] Collection collection)
+    { }
+
+    private DefaultModelBindingContext CreateBindingContext(
+        string orgIdRouteValue = null,
+        string collectionIdRouteValue = null,
+        string collectionIdRouteKey = "id",
+        bool includeOrgId = true,
+        bool includeCollectionId = true,
+        bool useOrganizationIdRoute = false,
+        ParameterInfo parameterInfo = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _collectionRepository);
+        httpContext.RequestServices = services.BuildServiceProvider();
+
+        var routeData = new RouteData();
+        if (includeOrgId)
+        {
+            var key = useOrganizationIdRoute ? "organizationId" : "orgId";
+            routeData.Values[key] = orgIdRouteValue ?? _orgId.ToString();
+        }
+        if (includeCollectionId)
+        {
+            routeData.Values[collectionIdRouteKey] = collectionIdRouteValue ?? _collectionId.ToString();
+        }
+
+        httpContext.Request.RouteValues = routeData.Values;
+
+        var actionContext = new ActionContext(
+            httpContext,
+            routeData,
+            new Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor(),
+            new ModelStateDictionary());
+
+        var metadataProvider = new EmptyModelMetadataProvider();
+        ModelMetadata metadata;
+
+        if (parameterInfo != null)
+        {
+            metadata = metadataProvider.GetMetadataForParameter(parameterInfo);
+        }
+        else
+        {
+            metadata = metadataProvider.GetMetadataForType(typeof(Collection));
+        }
+
+        return new DefaultModelBindingContext
+        {
+            ActionContext = actionContext,
+            ModelMetadata = metadata,
+            ModelName = "collection"
+        };
+    }
+}

--- a/test/Api.Test/AdminConsole/Attributes/CollectionModelBinderTests.cs
+++ b/test/Api.Test/AdminConsole/Attributes/CollectionModelBinderTests.cs
@@ -106,20 +106,6 @@ public class CollectionModelBinderTests
     }
 
     [Fact]
-    public async Task BindModelAsync_OrganizationIdRouteParam_ResolvesOrgId()
-    {
-        var binder = new CollectionModelBinder();
-        _collectionRepository.GetByIdAsync(_collectionId).Returns(_collection);
-
-        var context = CreateBindingContext(useOrganizationIdRoute: true);
-
-        await binder.BindModelAsync(context);
-
-        Assert.True(context.Result.IsModelSet);
-        Assert.Equal(_collection, context.Result.Model);
-    }
-
-    [Fact]
     public async Task BindModelAsync_CustomRouteParamName_ReadsCorrectRouteValue()
     {
         var binder = new CollectionModelBinder();
@@ -143,8 +129,7 @@ public class CollectionModelBinderTests
     /// Dummy method used to produce a <see cref="ParameterInfo"/> carrying a custom
     /// <see cref="InjectCollectionAttribute"/> for the custom route param test.
     /// </summary>
-    private static void DummyMethodWithCustomRouteParam(
-        [InjectCollection("collectionId")] Collection collection)
+    private static void DummyMethodWithCustomRouteParam([InjectCollection("collectionId")] Collection collection)
     { }
 
     private DefaultModelBindingContext CreateBindingContext(
@@ -153,7 +138,6 @@ public class CollectionModelBinderTests
         string collectionIdRouteKey = "id",
         bool includeOrgId = true,
         bool includeCollectionId = true,
-        bool useOrganizationIdRoute = false,
         ParameterInfo parameterInfo = null)
     {
         var httpContext = new DefaultHttpContext();
@@ -164,8 +148,7 @@ public class CollectionModelBinderTests
         var routeData = new RouteData();
         if (includeOrgId)
         {
-            var key = useOrganizationIdRoute ? "organizationId" : "orgId";
-            routeData.Values[key] = orgIdRouteValue ?? _orgId.ToString();
+            routeData.Values["orgId"] = orgIdRouteValue ?? _orgId.ToString();
         }
         if (includeCollectionId)
         {
@@ -183,14 +166,7 @@ public class CollectionModelBinderTests
         var metadataProvider = new EmptyModelMetadataProvider();
         ModelMetadata metadata;
 
-        if (parameterInfo != null)
-        {
-            metadata = metadataProvider.GetMetadataForParameter(parameterInfo);
-        }
-        else
-        {
-            metadata = metadataProvider.GetMetadataForType(typeof(Collection));
-        }
+        metadata = parameterInfo != null ? metadataProvider.GetMetadataForParameter(parameterInfo) : metadataProvider.GetMetadataForType(typeof(Collection));
 
         return new DefaultModelBindingContext
         {

--- a/test/Api.Test/AdminConsole/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/CollectionsControllerTests.cs
@@ -221,6 +221,70 @@ public class CollectionsControllerTests
     }
 
     [Theory, BitAutoData]
+    public async Task GetDetails_CollectionBelongsToDifferentOrg_ThrowsNotFound(Guid orgId,
+        CollectionAdminDetails collectionAdminDetails, SutProvider<CollectionsController> sutProvider)
+    {
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetByIdWithPermissionsAsync(collectionAdminDetails.Id, Arg.Any<Guid?>(), true)
+            .Returns(collectionAdminDetails);
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.GetDetails(orgId, collectionAdminDetails.Id));
+
+        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task Put_CollectionBelongsToDifferentOrg_ThrowsNotFound(Guid orgId, Collection collection,
+        UpdateCollectionRequestModel collectionRequest, SutProvider<CollectionsController> sutProvider)
+    {
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetByIdAsync(collection.Id)
+            .Returns(collection);
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            sutProvider.Sut.Put(orgId, collection.Id, collectionRequest));
+
+        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
+        await sutProvider.GetDependency<IUpdateCollectionCommand>().DidNotReceiveWithAnyArgs()
+            .UpdateAsync(Arg.Any<Collection>(), Arg.Any<IEnumerable<CollectionAccessSelection>>(),
+                Arg.Any<IEnumerable<CollectionAccessSelection>>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task DeleteMany_CollectionsBelongToDifferentOrg_ThrowsNotFound(Organization organization,
+        Collection collection1, Collection collection2, SutProvider<CollectionsController> sutProvider)
+    {
+        var orgId = organization.Id;
+        var model = new CollectionBulkDeleteRequestModel
+        {
+            Ids = [collection1.Id, collection2.Id]
+        };
+
+        // Second collection belongs to a different organization
+        var collections = new List<Collection>
+        {
+            new CollectionDetails { Id = collection1.Id, OrganizationId = orgId },
+            new CollectionDetails { Id = collection2.Id, OrganizationId = Guid.NewGuid() },
+        };
+
+        sutProvider.GetDependency<ICollectionRepository>().GetManyByManyIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(collections);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.DeleteMany(orgId, model));
+
+        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
+        await sutProvider.GetDependency<IDeleteCollectionCommand>().DidNotReceiveWithAnyArgs()
+            .DeleteManyAsync((IEnumerable<Collection>)default);
+    }
+
+    [Theory, BitAutoData]
     public async Task Put_WithNoCollectionPermission_ThrowsNotFound(Collection collection, UpdateCollectionRequestModel collectionRequest,
         SutProvider<CollectionsController> sutProvider)
     {

--- a/test/Api.Test/AdminConsole/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/CollectionsControllerTests.cs
@@ -57,17 +57,13 @@ public class CollectionsControllerTests
             c.Name == collectionRequest.Name && c.ExternalId == collectionRequest.ExternalId &&
             c.OrganizationId == collection.OrganizationId);
 
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetByIdAsync(collection.Id)
-            .Returns(collection);
-
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 collection,
                 Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.Update)))
             .Returns(AuthorizationResult.Success());
 
-        _ = await sutProvider.Sut.Put(collection.OrganizationId, collection.Id, collectionRequest);
+        _ = await sutProvider.Sut.Put(collection.OrganizationId, collection, collectionRequest);
 
         await sutProvider.GetDependency<IUpdateCollectionCommand>()
             .Received(1)
@@ -157,8 +153,6 @@ public class CollectionsControllerTests
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(collection.OrganizationId).Returns(new CurrentContextOrganization());
 
-        sutProvider.GetDependency<ICollectionRepository>().GetByIdAsync(collection.Id).Returns(collection);
-
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), collection,
                 Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.Update)))
@@ -173,7 +167,7 @@ public class CollectionsControllerTests
             .GetByIdWithPermissionsAsync(collection.Id, userId, true)
             .Returns(serverDetails);
 
-        var result = await sutProvider.Sut.Put(collection.OrganizationId, collection.Id, collectionRequest);
+        var result = await sutProvider.Sut.Put(collection.OrganizationId, collection, collectionRequest);
 
         var response = Assert.IsType<CollectionAccessDetailsResponseModel>(result);
         Assert.Empty(response.Groups);
@@ -193,8 +187,6 @@ public class CollectionsControllerTests
         sutProvider.GetDependency<ICurrentContext>().UserId.Returns(userId);
         sutProvider.GetDependency<ICurrentContext>().GetOrganization(collection.OrganizationId).Returns(new CurrentContextOrganization());
 
-        sutProvider.GetDependency<ICollectionRepository>().GetByIdAsync(collection.Id).Returns(collection);
-
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), collection,
                 Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.Update)))
@@ -209,7 +201,7 @@ public class CollectionsControllerTests
             .GetByIdWithPermissionsAsync(collection.Id, userId, true)
             .Returns(serverDetails);
 
-        var result = await sutProvider.Sut.Put(collection.OrganizationId, collection.Id, collectionRequest);
+        var result = await sutProvider.Sut.Put(collection.OrganizationId, collection, collectionRequest);
 
         // Without ReadWithAccess the response falls back to the basic Collection constructor — Groups/Users are not populated.
         var response = Assert.IsType<CollectionAccessDetailsResponseModel>(result);
@@ -234,25 +226,6 @@ public class CollectionsControllerTests
         await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
                 Arg.Any<IEnumerable<IAuthorizationRequirement>>());
-    }
-
-    [Theory, BitAutoData]
-    public async Task Put_CollectionBelongsToDifferentOrg_ThrowsNotFound(Guid orgId, Collection collection,
-        UpdateCollectionRequestModel collectionRequest, SutProvider<CollectionsController> sutProvider)
-    {
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetByIdAsync(collection.Id)
-            .Returns(collection);
-
-        await Assert.ThrowsAsync<NotFoundException>(() =>
-            sutProvider.Sut.Put(orgId, collection.Id, collectionRequest));
-
-        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
-            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(),
-                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
-        await sutProvider.GetDependency<IUpdateCollectionCommand>().DidNotReceiveWithAnyArgs()
-            .UpdateAsync(Arg.Any<Collection>(), Arg.Any<IEnumerable<CollectionAccessSelection>>(),
-                Arg.Any<IEnumerable<CollectionAccessSelection>>());
     }
 
     [Theory, BitAutoData]
@@ -294,11 +267,7 @@ public class CollectionsControllerTests
                 Arg.Is<IEnumerable<IAuthorizationRequirement>>(r => r.Contains(BulkCollectionOperations.Update)))
             .Returns(AuthorizationResult.Failed());
 
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetByIdAsync(collection.Id)
-            .Returns(collection);
-
-        _ = await Assert.ThrowsAsync<NotFoundException>(async () => await sutProvider.Sut.Put(collection.OrganizationId, collection.Id, collectionRequest));
+        _ = await Assert.ThrowsAsync<NotFoundException>(async () => await sutProvider.Sut.Put(collection.OrganizationId, collection, collectionRequest));
     }
 
     [Theory, BitAutoData]
@@ -711,10 +680,6 @@ public class CollectionsControllerTests
 
         collectionRequest.Name = newName;
 
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetByIdAsync(existingCollection.Id)
-            .Returns(existingCollection);
-
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 existingCollection,
@@ -722,7 +687,7 @@ public class CollectionsControllerTests
             .Returns(AuthorizationResult.Success());
 
         // Act
-        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection.Id, collectionRequest);
+        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection, collectionRequest);
 
         // Assert
         await sutProvider.GetDependency<IUpdateCollectionCommand>()
@@ -745,10 +710,6 @@ public class CollectionsControllerTests
 
         collectionRequest.Name = null;
 
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetByIdAsync(existingCollection.Id)
-            .Returns(existingCollection);
-
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 existingCollection,
@@ -756,7 +717,7 @@ public class CollectionsControllerTests
             .Returns(AuthorizationResult.Success());
 
         // Act
-        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection.Id, collectionRequest);
+        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection, collectionRequest);
 
         // Assert
         await sutProvider.GetDependency<IUpdateCollectionCommand>()
@@ -780,10 +741,6 @@ public class CollectionsControllerTests
 
         collectionRequest.Name = "new name";
 
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetByIdAsync(existingCollection.Id)
-            .Returns(existingCollection);
-
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 existingCollection,
@@ -791,7 +748,7 @@ public class CollectionsControllerTests
             .Returns(AuthorizationResult.Success());
 
         // Act
-        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection.Id, collectionRequest);
+        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection, collectionRequest);
 
         // Assert
         await sutProvider.GetDependency<IUpdateCollectionCommand>()
@@ -814,10 +771,6 @@ public class CollectionsControllerTests
 
         collectionRequest.Name = ""; // Empty string
 
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetByIdAsync(existingCollection.Id)
-            .Returns(existingCollection);
-
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 existingCollection,
@@ -825,7 +778,7 @@ public class CollectionsControllerTests
             .Returns(AuthorizationResult.Success());
 
         // Act
-        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection.Id, collectionRequest);
+        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection, collectionRequest);
 
         // Assert
         await sutProvider.GetDependency<IUpdateCollectionCommand>()
@@ -848,10 +801,6 @@ public class CollectionsControllerTests
 
         collectionRequest.Name = "   "; // Whitespace only
 
-        sutProvider.GetDependency<ICollectionRepository>()
-            .GetByIdAsync(existingCollection.Id)
-            .Returns(existingCollection);
-
         sutProvider.GetDependency<IAuthorizationService>()
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(),
                 existingCollection,
@@ -859,7 +808,7 @@ public class CollectionsControllerTests
             .Returns(AuthorizationResult.Success());
 
         // Act
-        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection.Id, collectionRequest);
+        await sutProvider.Sut.Put(existingCollection.OrganizationId, existingCollection, collectionRequest);
 
         // Assert
         await sutProvider.GetDependency<IUpdateCollectionCommand>()


### PR DESCRIPTION
## 🎟️ Tracking
[PM-42319](https://bitwarden.atlassian.net/browse/PM-42319)

## 📔 Objective
Adding an InjectCollectionAttribute that will retrieve the collection and validate that the route in the url matches the organization.  This is then used with the authorization logic to make sure they have access to it. Added a few other checks to validate orgid in route is used to validate against collections being retrieved/acted upon.


[PM-42319]: https://bitwarden.atlassian.net/browse/PM-42319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ