### PR TITLE
[PM-42605] refactor: wire PostBulkCollectionAccess into CollectionAuthorizationService

### DIFF
--- a/src/Api/AdminConsole/Controllers/CollectionsController.cs
+++ b/src/Api/AdminConsole/Controllers/CollectionsController.cs
@@ -243,10 +243,12 @@ public class CollectionsController : Controller
             throw new NotFoundException("One or more collections not found.");
         }
 
-        var result = await _authorizationService.AuthorizeAsync(User, collections,
-            new[] { BulkCollectionOperations.ModifyUserAccess, BulkCollectionOperations.ModifyGroupAccess });
+        var authorized = _featureService.IsEnabled(FeatureFlagKeys.AuthorizationServices)
+            ? await AuthorizeBulkCollectionAccessAsync(orgId, collections)
+            : (await _authorizationService.AuthorizeAsync(User, collections,
+                new[] { BulkCollectionOperations.ModifyUserAccess, BulkCollectionOperations.ModifyGroupAccess })).Succeeded;
 
-        if (!result.Succeeded)
+        if (!authorized)
         {
             throw new NotFoundException();
         }
@@ -255,6 +257,24 @@ public class CollectionsController : Controller
             collections,
             model.Users?.Select(u => u.ToSelectionReadOnly()).ToList(),
             model.Groups?.Select(g => g.ToSelectionReadOnly()).ToList());
+    }
+
+    /// <summary>
+    /// Determines if the caller can modify both the user access and the group access of every collection.
+    /// </summary>
+    private async Task<bool> AuthorizeBulkCollectionAccessAsync(Guid orgId, ICollection<Collection> collections)
+    {
+        // An empty result from the authorization service does not mean authorized.
+        if (collections.Count == 0)
+        {
+            return false;
+        }
+
+        var collectionIds = collections.Select(collection => collection.Id).ToList();
+        var authorizedForUserAccess = await _collectionAuthorizationService.AuthorizeModifyUserAccessManyAsync(orgId, collectionIds);
+        var authorizedForGroupAccess = await _collectionAuthorizationService.AuthorizeModifyGroupAccessManyAsync(orgId, collectionIds);
+
+        return collectionIds.All(id => authorizedForUserAccess.Contains(id) && authorizedForGroupAccess.Contains(id));
     }
 
     [HttpDelete("{id}")]

--- a/test/Api.Test/AdminConsole/Controllers/CollectionsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/CollectionsControllerTests.cs
@@ -685,6 +685,125 @@ public class CollectionsControllerTests
     }
 
     [Theory, BitAutoData]
+    public async Task PostBulkCollectionAccess_WithNewAuthorizationEnabled_Success(User actingUser,
+        List<Collection> collections, Organization organization, SutProvider<CollectionsController> sutProvider)
+    {
+        collections.ForEach(c => c.OrganizationId = organization.Id);
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+        var model = BulkAccessModel(collections, userId, groupId);
+        IReadOnlySet<Guid> allCollectionIds = collections.Select(c => c.Id).ToHashSet();
+
+        ArrangeBulkCollectionAccess(sutProvider, actingUser, collections, model, newAuthorizationEnabled: true);
+        sutProvider.GetDependency<ICollectionAuthorizationService>()
+            .AuthorizeModifyUserAccessManyAsync(organization.Id, Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(allCollectionIds);
+        sutProvider.GetDependency<ICollectionAuthorizationService>()
+            .AuthorizeModifyGroupAccessManyAsync(organization.Id, Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(allCollectionIds);
+
+        await sutProvider.Sut.PostBulkCollectionAccess(organization.Id, model);
+
+        await sutProvider.GetDependency<IBulkAddCollectionAccessCommand>().Received(1)
+            .AddAccessAsync(
+                Arg.Is<ICollection<Collection>>(c => c.SequenceEqual(collections)),
+                Arg.Is<ICollection<CollectionAccessSelection>>(u => u.All(c => c.Id == userId && c.Manage)),
+                Arg.Is<ICollection<CollectionAccessSelection>>(g => g.All(c => c.Id == groupId && c.ReadOnly)));
+        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<IEnumerable<Collection>>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task PostBulkCollectionAccess_WithNewAuthorizationEnabled_UserAccessUnauthorizedForOneCollection_Throws(
+        User actingUser, List<Collection> collections, Organization organization,
+        SutProvider<CollectionsController> sutProvider)
+    {
+        collections.ForEach(c => c.OrganizationId = organization.Id);
+        var model = BulkAccessModel(collections, Guid.NewGuid(), Guid.NewGuid());
+        IReadOnlySet<Guid> allCollectionIds = collections.Select(c => c.Id).ToHashSet();
+        IReadOnlySet<Guid> authorizedForUserAccess = collections.Skip(1).Select(c => c.Id).ToHashSet();
+
+        ArrangeBulkCollectionAccess(sutProvider, actingUser, collections, model, newAuthorizationEnabled: true);
+        sutProvider.GetDependency<ICollectionAuthorizationService>()
+            .AuthorizeModifyUserAccessManyAsync(organization.Id, Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(authorizedForUserAccess);
+        sutProvider.GetDependency<ICollectionAuthorizationService>()
+            .AuthorizeModifyGroupAccessManyAsync(organization.Id, Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(allCollectionIds);
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => sutProvider.Sut.PostBulkCollectionAccess(organization.Id, model));
+        await sutProvider.GetDependency<IBulkAddCollectionAccessCommand>().DidNotReceiveWithAnyArgs()
+            .AddAccessAsync(default, default, default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task PostBulkCollectionAccess_WithNewAuthorizationEnabled_GroupAccessUnauthorizedForOneCollection_Throws(
+        User actingUser, List<Collection> collections, Organization organization,
+        SutProvider<CollectionsController> sutProvider)
+    {
+        collections.ForEach(c => c.OrganizationId = organization.Id);
+        var model = BulkAccessModel(collections, Guid.NewGuid(), Guid.NewGuid());
+        IReadOnlySet<Guid> allCollectionIds = collections.Select(c => c.Id).ToHashSet();
+        IReadOnlySet<Guid> authorizedForGroupAccess = collections.Skip(1).Select(c => c.Id).ToHashSet();
+
+        ArrangeBulkCollectionAccess(sutProvider, actingUser, collections, model, newAuthorizationEnabled: true);
+        sutProvider.GetDependency<ICollectionAuthorizationService>()
+            .AuthorizeModifyUserAccessManyAsync(organization.Id, Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(allCollectionIds);
+        sutProvider.GetDependency<ICollectionAuthorizationService>()
+            .AuthorizeModifyGroupAccessManyAsync(organization.Id, Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(authorizedForGroupAccess);
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => sutProvider.Sut.PostBulkCollectionAccess(organization.Id, model));
+        await sutProvider.GetDependency<IBulkAddCollectionAccessCommand>().DidNotReceiveWithAnyArgs()
+            .AddAccessAsync(default, default, default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task PostBulkCollectionAccess_WithNewAuthorizationEnabled_NoCollections_ThrowsNotFound(
+        User actingUser, Organization organization, SutProvider<CollectionsController> sutProvider)
+    {
+        var collections = new List<Collection>();
+        var model = BulkAccessModel(collections, Guid.NewGuid(), Guid.NewGuid());
+
+        ArrangeBulkCollectionAccess(sutProvider, actingUser, collections, model, newAuthorizationEnabled: true);
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => sutProvider.Sut.PostBulkCollectionAccess(organization.Id, model));
+        await sutProvider.GetDependency<ICollectionAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeModifyUserAccessManyAsync(default, default);
+        await sutProvider.GetDependency<ICollectionAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeModifyGroupAccessManyAsync(default, default);
+        await sutProvider.GetDependency<IBulkAddCollectionAccessCommand>().DidNotReceiveWithAnyArgs()
+            .AddAccessAsync(default, default, default);
+    }
+
+    private static BulkCollectionAccessRequestModel BulkAccessModel(IEnumerable<Collection> collections,
+        Guid userId, Guid groupId) =>
+        new()
+        {
+            CollectionIds = collections.Select(c => c.Id).ToList(),
+            Users = new[] { new SelectionReadOnlyRequestModel { Id = userId, Manage = true } },
+            Groups = new[] { new SelectionReadOnlyRequestModel { Id = groupId, ReadOnly = true } },
+        };
+
+    private static void ArrangeBulkCollectionAccess(SutProvider<CollectionsController> sutProvider, User actingUser,
+        List<Collection> collections, BulkCollectionAccessRequestModel model, bool newAuthorizationEnabled)
+    {
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(model.CollectionIds)
+            .Returns(collections);
+        sutProvider.GetDependency<ICurrentContext>()
+            .UserId.Returns(actingUser.Id);
+        sutProvider.GetDependency<Bitwarden.Server.Sdk.Features.IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.AuthorizationServices)
+            .Returns(newAuthorizationEnabled);
+    }
+
+    [Theory, BitAutoData]
     public async Task Put_With_NonNullName_DoesNotPreserveExistingName(Collection existingCollection, UpdateCollectionRequestModel collectionRequest,
         SutProvider<CollectionsController> sutProvider)
     {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42605

Stacked on #8211 (PM-12473). Review that one first — this PR only adds a caller.

## 📔 Objective

`CollectionsController.PostBulkCollectionAccess` was the last place in
`CollectionsController` still using `BulkCollectionAuthorizationHandler` for
collection access. This PR points it at `ICollectionAuthorizationService`,
which #8211 added, behind the same `pm-35160-authorization-services` flag.

The old call passed both `ModifyUserAccess` and `ModifyGroupAccess` to a
single `AuthorizeAsync`, so both operations had to succeed across the whole
collection set. The flag-on path intersects `AuthorizeModifyUserAccessManyAsync`
and `AuthorizeModifyGroupAccessManyAsync`, which is the same all-or-nothing
decision. This also gives those two methods their first caller.

Three things stay as they are:

- **The count pre-check.** It rejects unknown, cross-organization and duplicate
  collection ids with a 404. `ICollectionAuthorizationService` leaves such ids
  out of its result rather than failing on them, so removing this check would
  turn a rejection into a silent ignore.
- **The collection fetch.** `BulkAddCollectionAccessCommand.AddAccessAsync`
  takes the `Collection` entities and needs them for event logging and for its
  default-collection check. The authorization service resolves the same ids
  again, so this request reads collections twice. That is the cost of an
  authorization layer that fetches its own data, instead of threading
  pre-fetched entities into it — the pattern rejected on #8075.
- **The 404 on an empty request.** This one needs an explicit guard. The old
  handler fails an empty resource list, while the service returns an empty
  result, and "every id is authorized" is vacuously true over an empty list.
  Without the guard the flag-on path would fail open and reach the command.

No behavior change is expected on either path.

## 📸 Screenshots

N/A
