### PR TITLE
[PM-41270] refactor: add GroupsAuthorizationService and wire it into GroupsController

### DIFF
--- a/src/Api/AdminConsole/Authorization/AuthorizationHandlerCollectionExtensions.cs
+++ b/src/Api/AdminConsole/Authorization/AuthorizationHandlerCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Api.AdminConsole.Authorization.Groups;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -21,5 +22,6 @@ public static class AuthorizationHandlerCollectionExtensions
         ]);
 
         services.TryAddScoped<ICollectionAuthorizationService, CollectionAuthorizationService>();
+        services.TryAddScoped<IGroupsAuthorizationService, GroupsAuthorizationService>();
     }
 }

--- a/src/Api/AdminConsole/Authorization/Groups/GroupsAuthorizationResult.cs
+++ b/src/Api/AdminConsole/Authorization/Groups/GroupsAuthorizationResult.cs
@@ -1,0 +1,20 @@
+﻿namespace Bit.Api.AdminConsole.Authorization.Groups;
+
+/// <summary>
+/// The authorization decision for saving a group.
+/// </summary>
+/// <param name="CanAddSelfToGroup">
+/// False if the caller is adding themselves to the group and is not allowed to.
+/// </param>
+/// <param name="UnauthorizedPostedCollectionIds">
+/// Posted collections the caller cannot give the group access to. Collections that do not exist, or that belong to
+/// another organization, are also listed here.
+/// </param>
+/// <param name="UnauthorizedCurrentCollectionIds">
+/// Collections the group already has access to that the caller cannot change. Save these unchanged, so that the
+/// caller does not remove access they cannot see.
+/// </param>
+public record GroupsAuthorizationResult(
+    bool CanAddSelfToGroup,
+    IReadOnlySet<Guid> UnauthorizedPostedCollectionIds,
+    IReadOnlySet<Guid> UnauthorizedCurrentCollectionIds);

--- a/src/Api/AdminConsole/Authorization/Groups/GroupsAuthorizationService.cs
+++ b/src/Api/AdminConsole/Authorization/Groups/GroupsAuthorizationService.cs
@@ -1,0 +1,63 @@
+﻿using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Context;
+using Bit.Core.Repositories;
+
+namespace Bit.Api.AdminConsole.Authorization.Groups;
+
+public class GroupsAuthorizationService(
+    ICurrentContext currentContext,
+    IGroupRepository groupRepository,
+    IOrganizationUserRepository organizationUserRepository,
+    IOrganizationAbilityCacheService organizationAbilityCacheService,
+    ICollectionAuthorizationService collectionAuthorizationService) : IGroupsAuthorizationService
+{
+    public async Task<GroupsAuthorizationResult> AuthorizeSaveAsync(
+        Guid organizationId,
+        Guid? groupId,
+        IReadOnlyCollection<Guid> postedCollectionIds,
+        IReadOnlyCollection<Guid> currentCollectionIds,
+        IReadOnlyCollection<Guid> postedUserIds)
+    {
+        var authorizedPostedCollectionIds =
+            await collectionAuthorizationService.AuthorizeModifyGroupAccessManyAsync(organizationId, postedCollectionIds);
+        var authorizedCurrentCollectionIds =
+            await collectionAuthorizationService.AuthorizeModifyGroupAccessManyAsync(organizationId, currentCollectionIds);
+
+        return new GroupsAuthorizationResult(
+            await CanAddSelfToGroupAsync(organizationId, groupId, postedUserIds),
+            postedCollectionIds.Except(authorizedPostedCollectionIds).ToHashSet(),
+            currentCollectionIds.Except(authorizedCurrentCollectionIds).ToHashSet());
+    }
+
+    private async Task<bool> CanAddSelfToGroupAsync(
+        Guid organizationId,
+        Guid? groupId,
+        IReadOnlyCollection<Guid> postedUserIds)
+    {
+        // Creating a group has never had this rule. It is not watertight on update either: a caller can create an
+        // empty group with themselves in it, then add collections through update as an existing member.
+        if (groupId is null)
+        {
+            return true;
+        }
+
+        var organizationAbility = await organizationAbilityCacheService.GetOrganizationAbilityAsync(organizationId);
+        if (organizationAbility is { AllowAdminAccessToAllCollectionItems: true } || !currentContext.UserId.HasValue)
+        {
+            return true;
+        }
+
+        // A provider is not an organization member, so it has no organization user to add.
+        var callerOrganizationUser =
+            await organizationUserRepository.GetByOrganizationAsync(organizationId, currentContext.UserId.Value);
+        if (callerOrganizationUser is null || !postedUserIds.Contains(callerOrganizationUser.Id))
+        {
+            return true;
+        }
+
+        var currentGroupUserIds = await groupRepository.GetManyUserIdsByIdAsync(groupId.Value);
+        return currentGroupUserIds.Contains(callerOrganizationUser.Id);
+    }
+}

--- a/src/Api/AdminConsole/Authorization/Groups/IGroupsAuthorizationService.cs
+++ b/src/Api/AdminConsole/Authorization/Groups/IGroupsAuthorizationService.cs
@@ -1,0 +1,24 @@
+﻿namespace Bit.Api.AdminConsole.Authorization.Groups;
+
+/// <summary>
+/// Decides what the caller can change when they save a group.
+/// </summary>
+public interface IGroupsAuthorizationService
+{
+    /// <summary>
+    /// Determines if the caller can save the group's collection access and its members.
+    /// </summary>
+    /// <param name="organizationId">The ID of the organization that owns the group.</param>
+    /// <param name="groupId">The ID of the group to update, or null when the group is being created.</param>
+    /// <param name="postedCollectionIds">The IDs of the collections the client sent.</param>
+    /// <param name="currentCollectionIds">
+    /// The IDs of the collections the group can already access. Empty when the group is being created.
+    /// </param>
+    /// <param name="postedUserIds">The organization user IDs the client sent.</param>
+    Task<GroupsAuthorizationResult> AuthorizeSaveAsync(
+        Guid organizationId,
+        Guid? groupId,
+        IReadOnlyCollection<Guid> postedCollectionIds,
+        IReadOnlyCollection<Guid> currentCollectionIds,
+        IReadOnlyCollection<Guid> postedUserIds);
+}

--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -3,15 +3,18 @@
 
 using Bit.Api.AdminConsole.Authorization;
 using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Api.AdminConsole.Authorization.Groups;
 using Bit.Api.AdminConsole.Authorization.Requirements;
 using Bit.Api.AdminConsole.Models.Request;
 using Bit.Api.AdminConsole.Models.Response;
 using Bit.Api.Models.Response;
+using Bit.Core;
 using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
 using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.AdminConsole.Services;
 using Bit.Core.Exceptions;
+using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
 using Bit.Core.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -34,6 +37,8 @@ public class GroupsController : Controller
     private readonly IUserService _userService;
     private readonly IOrganizationUserRepository _organizationUserRepository;
     private readonly ICollectionRepository _collectionRepository;
+    private readonly IGroupsAuthorizationService _groupsAuthorizationService;
+    private readonly Bitwarden.Server.Sdk.Features.IFeatureService _featureService;
 
     public GroupsController(
         IGroupRepository groupRepository,
@@ -46,7 +51,9 @@ public class GroupsController : Controller
         IOrganizationAbilityCacheService organizationAbilityCacheService,
         IUserService userService,
         IOrganizationUserRepository organizationUserRepository,
-        ICollectionRepository collectionRepository)
+        ICollectionRepository collectionRepository,
+        IGroupsAuthorizationService groupsAuthorizationService,
+        Bitwarden.Server.Sdk.Features.IFeatureService featureService)
     {
         _groupRepository = groupRepository;
         _groupService = groupService;
@@ -59,6 +66,8 @@ public class GroupsController : Controller
         _userService = userService;
         _organizationUserRepository = organizationUserRepository;
         _collectionRepository = collectionRepository;
+        _groupsAuthorizationService = groupsAuthorizationService;
+        _featureService = featureService;
     }
 
     [HttpGet("{id}")]
@@ -126,10 +135,25 @@ public class GroupsController : Controller
         // Check the user has permission to grant access to the collections for the new group
         if (model.Collections?.Any() == true)
         {
-            var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
-            var authorized =
-                (await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.ModifyGroupAccess))
-                .Succeeded;
+            bool authorized;
+            if (_featureService.IsEnabled(FeatureFlagKeys.AuthorizationServices))
+            {
+                var authorizationResult = await _groupsAuthorizationService.AuthorizeSaveAsync(
+                    orgId,
+                    groupId: null,
+                    model.Collections.Select(c => c.Id).ToList(),
+                    currentCollectionIds: [],
+                    model.Users?.ToList() ?? []);
+                authorized = authorizationResult.UnauthorizedPostedCollectionIds.Count == 0;
+            }
+            else
+            {
+                var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
+                authorized =
+                    (await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.ModifyGroupAccess))
+                    .Succeeded;
+            }
+
             if (!authorized)
             {
                 throw new NotFoundException();
@@ -153,6 +177,57 @@ public class GroupsController : Controller
             throw new NotFoundException();
         }
 
+        var readonlyCollectionIds = _featureService.IsEnabled(FeatureFlagKeys.AuthorizationServices)
+            ? await AuthorizeGroupSaveAsync(orgId, id, model, currentAccess)
+            : await AuthorizeGroupSaveWithHandlerAsync(orgId, id, model, currentAccess);
+
+        // The client only sends collections that the saving user has permissions to edit.
+        // We need to combine these with collections that the user doesn't have permissions for, so that we don't
+        // accidentally overwrite those
+        var editedCollectionAccess = model.Collections
+            .Select(c => c.ToSelectionReadOnly());
+        var readonlyCollectionAccess = currentAccess
+            .Where(ca => readonlyCollectionIds.Contains(ca.Id));
+        var collectionsToSave = editedCollectionAccess
+            .Concat(readonlyCollectionAccess)
+            .ToList();
+
+        var organization = await _organizationRepository.GetByIdAsync(orgId);
+
+        await _updateGroupCommand.UpdateGroupAsync(model.ToGroup(group), organization, collectionsToSave, model.Users);
+        return new GroupResponseModel(group);
+    }
+
+    /// <summary>
+    /// Authorizes the group save and returns the IDs of the group's current collections that the caller cannot
+    /// change.
+    /// </summary>
+    private async Task<IReadOnlySet<Guid>> AuthorizeGroupSaveAsync(Guid orgId, Guid id, GroupRequestModel model,
+        ICollection<CollectionAccessSelection> currentAccess)
+    {
+        var authorizationResult = await _groupsAuthorizationService.AuthorizeSaveAsync(
+            orgId,
+            id,
+            model.Collections.Select(c => c.Id).ToList(),
+            currentAccess.Select(ca => ca.Id).ToList(),
+            model.Users?.ToList() ?? []);
+
+        if (!authorizationResult.CanAddSelfToGroup)
+        {
+            throw new BadRequestException("You cannot add yourself to groups.");
+        }
+
+        if (authorizationResult.UnauthorizedPostedCollectionIds.Count > 0)
+        {
+            throw new NotFoundException();
+        }
+
+        return authorizationResult.UnauthorizedCurrentCollectionIds;
+    }
+
+    private async Task<IReadOnlySet<Guid>> AuthorizeGroupSaveWithHandlerAsync(Guid orgId, Guid id,
+        GroupRequestModel model, ICollection<CollectionAccessSelection> currentAccess)
+    {
         // Authorization check:
         // If admins are not allowed access to all collections, you cannot add yourself to a group.
         // No error is thrown for this, we just don't update groups.
@@ -183,9 +258,6 @@ public class GroupsController : Controller
             }
         }
 
-        // The client only sends collections that the saving user has permissions to edit.
-        // We need to combine these with collections that the user doesn't have permissions for, so that we don't
-        // accidentally overwrite those
         var currentCollections = await _collectionRepository
             .GetManyByManyIdsAsync(currentAccess.Select(cas => cas.Id));
 
@@ -199,18 +271,7 @@ public class GroupsController : Controller
             }
         }
 
-        var editedCollectionAccess = model.Collections
-            .Select(c => c.ToSelectionReadOnly());
-        var readonlyCollectionAccess = currentAccess
-            .Where(ca => readonlyCollectionIds.Contains(ca.Id));
-        var collectionsToSave = editedCollectionAccess
-            .Concat(readonlyCollectionAccess)
-            .ToList();
-
-        var organization = await _organizationRepository.GetByIdAsync(orgId);
-
-        await _updateGroupCommand.UpdateGroupAsync(model.ToGroup(group), organization, collectionsToSave, model.Users);
-        return new GroupResponseModel(group);
+        return readonlyCollectionIds;
     }
 
     [HttpPost("{id}")]

--- a/test/Api.Test/AdminConsole/Authorization/GroupsAuthorizationServiceTests.cs
+++ b/test/Api.Test/AdminConsole/Authorization/GroupsAuthorizationServiceTests.cs
@@ -1,0 +1,174 @@
+﻿using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Api.AdminConsole.Authorization.Groups;
+using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Context;
+using Bit.Core.Entities;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Authorization;
+
+[SutProviderCustomize]
+public class GroupsAuthorizationServiceTests
+{
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_ReturnsThePostedCollectionsTheCallerCannotModify(
+        SutProvider<GroupsAuthorizationService> sutProvider,
+        Guid organizationId, Guid groupId, Guid authorizedCollectionId, Guid unauthorizedCollectionId)
+    {
+        List<Guid> postedCollectionIds = [authorizedCollectionId, unauthorizedCollectionId];
+        SetupGroupAccess(sutProvider, organizationId, postedCollectionIds, [authorizedCollectionId]);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, groupId, postedCollectionIds, [], []);
+
+        Assert.Equal([unauthorizedCollectionId], result.UnauthorizedPostedCollectionIds);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_ReturnsTheCurrentCollectionsTheCallerCannotModify(
+        SutProvider<GroupsAuthorizationService> sutProvider,
+        Guid organizationId, Guid groupId, Guid authorizedCollectionId, Guid unauthorizedCollectionId)
+    {
+        List<Guid> currentCollectionIds = [authorizedCollectionId, unauthorizedCollectionId];
+        SetupGroupAccess(sutProvider, organizationId, currentCollectionIds, [authorizedCollectionId]);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, groupId, [], currentCollectionIds, []);
+
+        Assert.Equal([unauthorizedCollectionId], result.UnauthorizedCurrentCollectionIds);
+    }
+
+    /// <summary>
+    /// A collection that does not exist, or that belongs to another organization, is left out of the authorization
+    /// service's result. The caller must see it as unauthorized rather than as silently ignored.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenAPostedCollectionDoesNotExist_ReportsItAsUnauthorized(
+        SutProvider<GroupsAuthorizationService> sutProvider,
+        Guid organizationId, Guid groupId, Guid unknownCollectionId)
+    {
+        List<Guid> postedCollectionIds = [unknownCollectionId];
+        SetupGroupAccess(sutProvider, organizationId, postedCollectionIds, []);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, groupId, postedCollectionIds, [], []);
+
+        Assert.Equal([unknownCollectionId], result.UnauthorizedPostedCollectionIds);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenCreatingAGroup_CanAddSelf(
+        SutProvider<GroupsAuthorizationService> sutProvider, Guid organizationId, Guid callerUserId)
+    {
+        SetupSelfAsPostedMember(sutProvider, organizationId, callerUserId,
+            allowAdminAccessToAllCollectionItems: false, callerIsAlreadyInGroup: false, out var postedUserIds);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, null, [], [], postedUserIds);
+
+        Assert.True(result.CanAddSelfToGroup);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenAddingSelfToAGroup_CannotAddSelf(
+        SutProvider<GroupsAuthorizationService> sutProvider, Guid organizationId, Guid groupId, Guid callerUserId)
+    {
+        SetupSelfAsPostedMember(sutProvider, organizationId, callerUserId,
+            allowAdminAccessToAllCollectionItems: false, callerIsAlreadyInGroup: false, out var postedUserIds);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, groupId, [], [], postedUserIds);
+
+        Assert.False(result.CanAddSelfToGroup);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenAlreadyInTheGroup_CanAddSelf(
+        SutProvider<GroupsAuthorizationService> sutProvider, Guid organizationId, Guid groupId, Guid callerUserId)
+    {
+        SetupSelfAsPostedMember(sutProvider, organizationId, callerUserId,
+            allowAdminAccessToAllCollectionItems: false, callerIsAlreadyInGroup: true, out var postedUserIds);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, groupId, [], [], postedUserIds);
+
+        Assert.True(result.CanAddSelfToGroup);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenAdminAccessToAllCollectionItemsIsAllowed_CanAddSelf(
+        SutProvider<GroupsAuthorizationService> sutProvider, Guid organizationId, Guid groupId, Guid callerUserId)
+    {
+        SetupSelfAsPostedMember(sutProvider, organizationId, callerUserId,
+            allowAdminAccessToAllCollectionItems: true, callerIsAlreadyInGroup: false, out var postedUserIds);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, groupId, [], [], postedUserIds);
+
+        Assert.True(result.CanAddSelfToGroup);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenTheCallerIsNotAnOrganizationMember_CanAddSelf(
+        SutProvider<GroupsAuthorizationService> sutProvider, Guid organizationId, Guid groupId, Guid callerUserId)
+    {
+        SetupOrganizationAbility(sutProvider, organizationId, allowAdminAccessToAllCollectionItems: false);
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(callerUserId);
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(organizationId, callerUserId).ReturnsNull();
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, groupId, [], [], [Guid.NewGuid()]);
+
+        Assert.True(result.CanAddSelfToGroup);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenNotAddingSelf_CanAddSelf(
+        SutProvider<GroupsAuthorizationService> sutProvider, Guid organizationId, Guid groupId, Guid callerUserId,
+        OrganizationUser callerOrganizationUser, Guid otherOrganizationUserId)
+    {
+        SetupOrganizationAbility(sutProvider, organizationId, allowAdminAccessToAllCollectionItems: false);
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(callerUserId);
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(organizationId, callerUserId).Returns(callerOrganizationUser);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, groupId, [], [],
+            [otherOrganizationUserId]);
+
+        Assert.True(result.CanAddSelfToGroup);
+        await sutProvider.GetDependency<IGroupRepository>().DidNotReceiveWithAnyArgs()
+            .GetManyUserIdsByIdAsync(default);
+    }
+
+    private static void SetupGroupAccess(SutProvider<GroupsAuthorizationService> sutProvider, Guid organizationId,
+        IReadOnlyCollection<Guid> requestedCollectionIds, HashSet<Guid> authorizedCollectionIds) =>
+        sutProvider.GetDependency<ICollectionAuthorizationService>()
+            .AuthorizeModifyGroupAccessManyAsync(organizationId,
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(requestedCollectionIds)))
+            .Returns(authorizedCollectionIds);
+
+    private static void SetupOrganizationAbility(SutProvider<GroupsAuthorizationService> sutProvider,
+        Guid organizationId, bool allowAdminAccessToAllCollectionItems) =>
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility
+            {
+                Id = organizationId,
+                AllowAdminAccessToAllCollectionItems = allowAdminAccessToAllCollectionItems,
+            });
+
+    private static void SetupSelfAsPostedMember(SutProvider<GroupsAuthorizationService> sutProvider,
+        Guid organizationId, Guid callerUserId, bool allowAdminAccessToAllCollectionItems,
+        bool callerIsAlreadyInGroup, out List<Guid> postedUserIds)
+    {
+        var callerOrganizationUser = new OrganizationUser { Id = Guid.NewGuid(), OrganizationId = organizationId };
+        postedUserIds = [callerOrganizationUser.Id];
+
+        SetupOrganizationAbility(sutProvider, organizationId, allowAdminAccessToAllCollectionItems);
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(callerUserId);
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(organizationId, callerUserId).Returns(callerOrganizationUser);
+        sutProvider.GetDependency<IGroupRepository>().GetManyUserIdsByIdAsync(Arg.Any<Guid>())
+            .Returns(callerIsAlreadyInGroup ? [callerOrganizationUser.Id] : new List<Guid>());
+    }
+}

--- a/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/GroupsControllerTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Security.Claims;
 using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Api.AdminConsole.Authorization.Groups;
 using Bit.Api.AdminConsole.Controllers;
 using Bit.Api.AdminConsole.Models.Request;
+using Bit.Core;
 using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.OrganizationFeatures.Groups.Interfaces;
@@ -12,6 +14,7 @@ using Bit.Core.Exceptions;
 using Bit.Core.Models.Data;
 using Bit.Core.Models.Data.Organizations;
 using Bit.Core.Repositories;
+using Bit.Core.Services;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using Microsoft.AspNetCore.Authorization;
@@ -286,5 +289,246 @@ public class GroupsControllerTests
 
         await sutProvider.GetDependency<ICreateGroupCommand>().DidNotReceiveWithAnyArgs()
             .CreateGroupAsync(default, default, default, default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_GroupNotFound_ThrowsNotFound(Guid orgId, Guid id, GroupRequestModel model,
+        SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IGroupRepository>().GetByIdWithCollectionsAsync(id)
+            .Returns(new Tuple<Group?, ICollection<CollectionAccessSelection>>(null, new List<CollectionAccessSelection>()));
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Put(orgId, id, model));
+
+        await sutProvider.GetDependency<IUpdateGroupCommand>().DidNotReceiveWithAnyArgs()
+            .UpdateGroupAsync(default, default, default, default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_AddingSelfToGroup_WhenAdminAccessDisabled_ThrowsBadRequest(Organization organization,
+        Group group, GroupRequestModel model, OrganizationUser callerOrganizationUser, Guid userId,
+        SutProvider<GroupsController> sutProvider)
+    {
+        ArrangePut(sutProvider, organization, group, model, allowAdminAccessToAllCollectionItems: false);
+        model.Users = [callerOrganizationUser.Id];
+        sutProvider.GetDependency<IUserService>().GetProperUserId(Arg.Any<ClaimsPrincipal>()).Returns(userId);
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByOrganizationAsync(organization.Id, userId).Returns(callerOrganizationUser);
+        sutProvider.GetDependency<IGroupRepository>().GetManyUserIdsByIdAsync(group.Id).Returns(new List<Guid>());
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.Put(organization.Id, group.Id, model));
+
+        Assert.Equal("You cannot add yourself to groups.", exception.Message);
+        await sutProvider.GetDependency<IUpdateGroupCommand>().DidNotReceiveWithAnyArgs()
+            .UpdateGroupAsync(default, default, default, default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_NotAuthorizedForPostedCollection_ThrowsNotFound(Organization organization, Group group,
+        GroupRequestModel model, SutProvider<GroupsController> sutProvider)
+    {
+        ArrangePut(sutProvider, organization, group, model, allowAdminAccessToAllCollectionItems: true);
+        sutProvider.GetDependency<IAuthorizationService>()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<Collection>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Failed());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Put(organization.Id, group.Id, model));
+
+        await sutProvider.GetDependency<IUpdateGroupCommand>().DidNotReceiveWithAnyArgs()
+            .UpdateGroupAsync(default, default, default, default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_PreservesCurrentCollectionsTheCallerCannotEdit(Organization organization, Group group,
+        GroupRequestModel model, SutProvider<GroupsController> sutProvider)
+    {
+        var readonlyCollection = new Collection { Id = Guid.NewGuid(), OrganizationId = organization.Id };
+        var currentAccess = new List<CollectionAccessSelection>
+        {
+            new() { Id = readonlyCollection.Id, Manage = true },
+        };
+        ArrangePut(sutProvider, organization, group, model, allowAdminAccessToAllCollectionItems: true, currentAccess);
+
+        var postedCollections = model.Collections
+            .Select(c => new Collection { Id = c.Id, OrganizationId = organization.Id }).ToList();
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(Arg.Is<IEnumerable<Guid>>(ids => ids.Contains(readonlyCollection.Id)))
+            .Returns(new List<Collection> { readonlyCollection });
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(Arg.Is<IEnumerable<Guid>>(ids => !ids.Contains(readonlyCollection.Id)))
+            .Returns(postedCollections);
+
+        sutProvider.GetDependency<IAuthorizationService>()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<Collection>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Success());
+        sutProvider.GetDependency<IAuthorizationService>()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), readonlyCollection,
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Failed());
+
+        await sutProvider.Sut.Put(organization.Id, group.Id, model);
+
+        await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
+            Arg.Any<Group>(), organization,
+            Arg.Is<ICollection<CollectionAccessSelection>>(access => access.Any(a => a.Id == readonlyCollection.Id)),
+            Arg.Any<IEnumerable<Guid>>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_WithNewAuthorizationEnabled_PreservesUnauthorizedCurrentCollections(
+        Organization organization, Group group, GroupRequestModel model, Guid readonlyCollectionId,
+        SutProvider<GroupsController> sutProvider)
+    {
+        var currentAccess = new List<CollectionAccessSelection>
+        {
+            new() { Id = readonlyCollectionId, Manage = true },
+        };
+        ArrangePut(sutProvider, organization, group, model, allowAdminAccessToAllCollectionItems: true, currentAccess);
+        EnableNewAuthorization(sutProvider);
+        var postedCollectionIds = model.Collections.Select(c => c.Id).ToList();
+        sutProvider.GetDependency<IGroupsAuthorizationService>()
+            .AuthorizeSaveAsync(organization.Id, group.Id,
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(postedCollectionIds)),
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(new[] { readonlyCollectionId })),
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(model.Users)))
+            .Returns(new GroupsAuthorizationResult(true, new HashSet<Guid>(), new HashSet<Guid> { readonlyCollectionId }));
+
+        await sutProvider.Sut.Put(organization.Id, group.Id, model);
+
+        // The posted collections are saved, and the collection the caller cannot change is kept.
+        await sutProvider.GetDependency<IUpdateGroupCommand>().Received(1).UpdateGroupAsync(
+            Arg.Any<Group>(), organization,
+            Arg.Is<ICollection<CollectionAccessSelection>>(access => access.Select(a => a.Id).OrderBy(id => id)
+                .SequenceEqual(postedCollectionIds.Append(readonlyCollectionId).OrderBy(id => id))),
+            Arg.Any<IEnumerable<Guid>>());
+        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<Collection>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_WithNewAuthorizationEnabled_CannotAddSelfToGroup_ThrowsBadRequest(Organization organization,
+        Group group, GroupRequestModel model, SutProvider<GroupsController> sutProvider)
+    {
+        ArrangePut(sutProvider, organization, group, model, allowAdminAccessToAllCollectionItems: false);
+        EnableNewAuthorization(sutProvider);
+        // Match on the posted members, so that the rule stays covered if the controller stops passing them.
+        sutProvider.GetDependency<IGroupsAuthorizationService>()
+            .AuthorizeSaveAsync(organization.Id, group.Id, Arg.Any<IReadOnlyCollection<Guid>>(),
+                Arg.Any<IReadOnlyCollection<Guid>>(),
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(model.Users)))
+            .Returns(new GroupsAuthorizationResult(false, new HashSet<Guid>(), new HashSet<Guid>()));
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.Put(organization.Id, group.Id, model));
+
+        Assert.Equal("You cannot add yourself to groups.", exception.Message);
+        await sutProvider.GetDependency<IUpdateGroupCommand>().DidNotReceiveWithAnyArgs()
+            .UpdateGroupAsync(default, default, default, default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_WithNewAuthorizationEnabled_UnauthorizedPostedCollection_ThrowsNotFound(
+        Organization organization, Group group, GroupRequestModel model, Guid unauthorizedCollectionId,
+        SutProvider<GroupsController> sutProvider)
+    {
+        ArrangePut(sutProvider, organization, group, model, allowAdminAccessToAllCollectionItems: true);
+        EnableNewAuthorization(sutProvider);
+        var postedCollectionIds = model.Collections.Select(c => c.Id).ToList();
+        sutProvider.GetDependency<IGroupsAuthorizationService>()
+            .AuthorizeSaveAsync(organization.Id, group.Id,
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(postedCollectionIds)),
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(new GroupsAuthorizationResult(true, new HashSet<Guid> { unauthorizedCollectionId },
+                new HashSet<Guid>()));
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Put(organization.Id, group.Id, model));
+
+        await sutProvider.GetDependency<IUpdateGroupCommand>().DidNotReceiveWithAnyArgs()
+            .UpdateGroupAsync(default, default, default, default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Post_WithNewAuthorizationEnabled_Success(Organization organization,
+        GroupRequestModel model, SutProvider<GroupsController> sutProvider)
+    {
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+        EnableNewAuthorization(sutProvider);
+        var postedCollectionIds = model.Collections.Select(c => c.Id).ToList();
+        sutProvider.GetDependency<IGroupsAuthorizationService>()
+            .AuthorizeSaveAsync(organization.Id, null,
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(postedCollectionIds)),
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 0),
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(model.Users)))
+            .Returns(new GroupsAuthorizationResult(true, new HashSet<Guid>(), new HashSet<Guid>()));
+
+        await sutProvider.Sut.Post(organization.Id, model);
+
+        await sutProvider.GetDependency<ICreateGroupCommand>().Received(1).CreateGroupAsync(
+            Arg.Is<Group>(g => g.OrganizationId == organization.Id && g.Name == model.Name),
+            organization,
+            Arg.Is<ICollection<CollectionAccessSelection>>(access =>
+                access.Select(a => a.Id).SequenceEqual(postedCollectionIds)),
+            Arg.Any<IEnumerable<Guid>>());
+        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<IEnumerable<Collection>>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Post_WithNewAuthorizationEnabled_UnauthorizedPostedCollection_ThrowsNotFound(
+        Organization organization, GroupRequestModel model, Guid unauthorizedCollectionId,
+        SutProvider<GroupsController> sutProvider)
+    {
+        EnableNewAuthorization(sutProvider);
+        sutProvider.GetDependency<IGroupsAuthorizationService>()
+            .AuthorizeSaveAsync(organization.Id, null, Arg.Any<IReadOnlyCollection<Guid>>(),
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<IReadOnlyCollection<Guid>>())
+            .Returns(new GroupsAuthorizationResult(true, new HashSet<Guid> { unauthorizedCollectionId },
+                new HashSet<Guid>()));
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Post(organization.Id, model));
+
+        await sutProvider.GetDependency<ICreateGroupCommand>().DidNotReceiveWithAnyArgs()
+            .CreateGroupAsync(default, default, default, default);
+    }
+
+    private static void EnableNewAuthorization(SutProvider<GroupsController> sutProvider) =>
+        sutProvider.GetDependency<Bitwarden.Server.Sdk.Features.IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.AuthorizationServices)
+            .Returns(true);
+
+    private static void ArrangePut(SutProvider<GroupsController> sutProvider, Organization organization, Group group,
+        GroupRequestModel model, bool allowAdminAccessToAllCollectionItems,
+        ICollection<CollectionAccessSelection>? currentAccess = null)
+    {
+        group.OrganizationId = organization.Id;
+        sutProvider.GetDependency<IGroupRepository>().GetByIdWithCollectionsAsync(group.Id)
+            .Returns(new Tuple<Group?, ICollection<CollectionAccessSelection>>(
+                group, currentAccess ?? new List<CollectionAccessSelection>()));
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(organization.Id).Returns(organization);
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organization.Id)
+            .Returns(new OrganizationAbility
+            {
+                Id = organization.Id,
+                AllowAdminAccessToAllCollectionItems = allowAdminAccessToAllCollectionItems,
+            });
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(model.Collections.Select(c => new Collection { Id = c.Id, OrganizationId = organization.Id })
+                .ToList());
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41270

Third in the stack, after #8211 (PM-12473) and #8268 (PM-42605).

## 📔 Objective

`GroupsController` authorized collection access with `BulkCollectionAuthorizationHandler`
in three places: a bulk check in `Post`, and in `Put` a per-collection loop over
the posted collections plus a second loop over the group's current collections.
`Put` also held the inline check that a caller cannot add themselves to a group.

Behind `pm-35160-authorization-services` all four move into
`GroupsAuthorizationService`. It calls
`ICollectionAuthorizationService.AuthorizeModifyGroupAccessManyAsync` once for the
posted collections and once for the current ones, so both loops become two batched
calls. It does not call `CollectionRules` itself — `callerManagesCollection` and
`isOrphaned` belong to the collection, not to the group.

`Put` is restructured so both paths share one tail: each returns the set of current
collections the caller cannot change, and `collectionsToSave` is built once. The
flag-off branch is the old body moved unchanged.

### Behavior changes on the flag-on path

- **Unknown and cross-organization posted collection ids now return 404.** They used
  to be dropped by `GetManyByManyIdsAsync`, never authorized, and then written to the
  group anyway. This is the tightening PM-41270 asks for. `Post` gains the same check.
  The web client filters read-only selections out before submitting, so it cannot trip
  this.
- **The route `orgId` is now authoritative.** The old handler took its target
  organization from `resources.First().OrganizationId`, so a caller who managed a
  collection in another organization could have it written onto a group in this one.
- A null `OrganizationAbility` threw a `NullReferenceException` and now takes the
  restrictive branch. A null posted user list threw and is now treated as empty.

Creating a group keeps its current behavior of letting the caller add themselves.
`Post` has never had that rule, and it is not watertight on `Put` either — a caller
can create an empty group with themselves in it, then add collections as an existing
member. Unchanged here, and worth its own ticket.

### Tests

`Put` had no tests at all. Four flag-off characterization tests pin the existing
behavior first, including the self-add `BadRequestException` and the
preserve-unauthorized-access path. Nine service tests and five flag-on controller
tests follow.

## 📸 Screenshots

N/A
