### PR TITLE
[PM-28941] test: Bump Azurite to 3.37.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,11 +3,27 @@
   extends: ["github>bitwarden/renovate-config"], // Extends our default configuration for pinned dependencies
   enabledManagers: [
     "cargo",
+    "custom.regex",
     "dockerfile",
     "docker-compose",
     "github-actions",
     "npm",
     "nuget",
+  ],
+  customManagers: [
+    {
+      customType: "regex",
+      description: "Azurite test container image pinned in DataProtectionServicesTests.cs",
+      managerFilePatterns: [
+        "/^test/SharedWeb\\.Test/DataProtectionServicesTests\\.cs$/",
+      ],
+      // currentDigest is captured so Renovate rewrites the digest alongside the
+      // tag. Bumping the tag alone would leave a digest that no longer resolves.
+      matchStrings: [
+        '"(?<depName>mcr\\.microsoft\\.com/azure-storage/azurite):(?<currentValue>[^"@]+)@(?<currentDigest>sha256:[a-f0-9]{64})"',
+      ],
+      datasourceTemplate: "docker",
+    },
   ],
   packageRules: [
     // ==================== Team Ownership Rules ====================
@@ -117,6 +133,12 @@
     {
       matchUpdateTypes: ["lockFileMaintenance"],
       description: "Platform owns lock file maintenance",
+      commitMessagePrefix: "[deps] Platform:",
+      reviewers: ["team:team-platform-dev"],
+    },
+    {
+      matchPackageNames: ["mcr.microsoft.com/azure-storage/azurite"],
+      description: "Platform owned test container image",
       commitMessagePrefix: "[deps] Platform:",
       reviewers: ["team:team-platform-dev"],
     },

--- a/test/SharedWeb.Test/DataProtectionServicesTests.cs
+++ b/test/SharedWeb.Test/DataProtectionServicesTests.cs
@@ -17,7 +17,7 @@ namespace Bit.SharedWeb.Test.DataProtectionServicesTests;
 public class DataProtectionServicesTests
 {
     private const string AzuriteImage =
-        "mcr.microsoft.com/azure-storage/azurite:3.36.0@sha256:76b8127d608fab8287a14a4bfeb9a5502cdcffb4bf1e86f09f324ebb0e70edba";
+        "mcr.microsoft.com/azure-storage/azurite:3.37.0@sha256:830430c1da1a2d537e08f3e6764dd1f5ae00cf0346bcaf625b968ec3f0971fd5";
 
     // Created using:
     // using var rsa = RSA.Create(2048);
@@ -857,16 +857,6 @@ PZBRQ4YxBFDFaGycVn8CAgfQ");
     private static IContainer CreateAzuriteContainer() =>
         new ContainerBuilder(AzuriteImage)
             .WithPortBinding(10000, true)
-            // The container's CMD is reproduced here in order to add `--skipApiVersionCheck` due
-            // to the Azure.Storage deps upgraded in bitwarden/server#6656 not being fully
-            // compatible with the latest Azurite image.
-            .WithCommand(
-                "azurite",
-                "-l", "/data",
-                "--blobHost", "0.0.0.0",
-                "--queueHost", "0.0.0.0",
-                "--tableHost", "0.0.0.0",
-                "--skipApiVersionCheck")
             .Build();
 
     private static async Task RunTestAsync(Func<TestSetupContext, Task> testSetup, Action<TestRunContext> test)


### PR DESCRIPTION
## 🎟️ Tracking

Stacked on #6656.

## 📔 Objective

Azurite 3.37.0 has been published, making the `--skipApiVersionCheck` workaround
in #6656 unnecessary.
