### PR TITLE
[PM-41448] refactor: add OrganizationUserAuthorizationService and wire it into OrganizationUsersController

### DIFF
--- a/src/Api/AdminConsole/Authorization/AuthorizationHandlerCollectionExtensions.cs
+++ b/src/Api/AdminConsole/Authorization/AuthorizationHandlerCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Api.AdminConsole.Authorization.Collections;
 using Bit.Api.AdminConsole.Authorization.Groups;
+using Bit.Api.AdminConsole.Authorization.OrganizationUsers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -23,5 +24,6 @@ public static class AuthorizationHandlerCollectionExtensions
 
         services.TryAddScoped<ICollectionAuthorizationService, CollectionAuthorizationService>();
         services.TryAddScoped<IGroupsAuthorizationService, GroupsAuthorizationService>();
+        services.TryAddScoped<IOrganizationUserAuthorizationService, OrganizationUserAuthorizationService>();
     }
 }

--- a/src/Api/AdminConsole/Authorization/OrganizationUsers/IOrganizationUserAuthorizationService.cs
+++ b/src/Api/AdminConsole/Authorization/OrganizationUsers/IOrganizationUserAuthorizationService.cs
@@ -1,0 +1,24 @@
+﻿namespace Bit.Api.AdminConsole.Authorization.OrganizationUsers;
+
+/// <summary>
+/// Decides what the caller can change when they save an organization user.
+/// </summary>
+public interface IOrganizationUserAuthorizationService
+{
+    /// <summary>
+    /// Determines if the caller can save the organization user's collection access and their groups.
+    /// </summary>
+    /// <param name="organizationId">The ID of the organization that the user belongs to.</param>
+    /// <param name="organizationUserId">
+    /// The ID of the organization user to update, or null when the user is being invited.
+    /// </param>
+    /// <param name="postedCollectionIds">The IDs of the collections the client sent.</param>
+    /// <param name="currentCollectionIds">
+    /// The IDs of the collections the organization user can already reach. Empty when the user is being invited.
+    /// </param>
+    Task<OrganizationUserAuthorizationResult> AuthorizeSaveAsync(
+        Guid organizationId,
+        Guid? organizationUserId,
+        IReadOnlyCollection<Guid> postedCollectionIds,
+        IReadOnlyCollection<Guid> currentCollectionIds);
+}

--- a/src/Api/AdminConsole/Authorization/OrganizationUsers/OrganizationUserAuthorizationResult.cs
+++ b/src/Api/AdminConsole/Authorization/OrganizationUsers/OrganizationUserAuthorizationResult.cs
@@ -1,0 +1,24 @@
+﻿namespace Bit.Api.AdminConsole.Authorization.OrganizationUsers;
+
+/// <summary>
+/// The authorization decision for saving an organization user.
+/// </summary>
+/// <param name="CanAddSelfToCollection">
+/// False if the caller is giving themselves access to a collection they cannot already reach.
+/// </param>
+/// <param name="CanEditOwnGroups">
+/// False if the caller cannot change their own group membership. Save no group changes in that case.
+/// </param>
+/// <param name="UnauthorizedPostedCollectionIds">
+/// Posted collections the caller cannot give the organization user access to. Collections that do not exist, or
+/// that belong to another organization, are also listed here.
+/// </param>
+/// <param name="UnauthorizedCurrentCollectionIds">
+/// Collections the organization user can already reach that the caller cannot change. Save these unchanged, so
+/// that the caller does not remove access they cannot see.
+/// </param>
+public record OrganizationUserAuthorizationResult(
+    bool CanAddSelfToCollection,
+    bool CanEditOwnGroups,
+    IReadOnlySet<Guid> UnauthorizedPostedCollectionIds,
+    IReadOnlySet<Guid> UnauthorizedCurrentCollectionIds);

--- a/src/Api/AdminConsole/Authorization/OrganizationUsers/OrganizationUserAuthorizationService.cs
+++ b/src/Api/AdminConsole/Authorization/OrganizationUsers/OrganizationUserAuthorizationService.cs
@@ -1,0 +1,55 @@
+﻿using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.Context;
+using Bit.Core.Repositories;
+
+namespace Bit.Api.AdminConsole.Authorization.OrganizationUsers;
+
+public class OrganizationUserAuthorizationService(
+    ICurrentContext currentContext,
+    IOrganizationUserRepository organizationUserRepository,
+    IOrganizationAbilityCacheService organizationAbilityCacheService,
+    ICollectionAuthorizationService collectionAuthorizationService) : IOrganizationUserAuthorizationService
+{
+    public async Task<OrganizationUserAuthorizationResult> AuthorizeSaveAsync(
+        Guid organizationId,
+        Guid? organizationUserId,
+        IReadOnlyCollection<Guid> postedCollectionIds,
+        IReadOnlyCollection<Guid> currentCollectionIds)
+    {
+        var authorizedPostedCollectionIds =
+            await collectionAuthorizationService.AuthorizeModifyUserAccessManyAsync(organizationId, postedCollectionIds);
+        var authorizedCurrentCollectionIds =
+            await collectionAuthorizationService.AuthorizeModifyUserAccessManyAsync(organizationId, currentCollectionIds);
+
+        var isEditingOwnMembership = await IsEditingOwnMembershipAsync(organizationId, organizationUserId);
+
+        return new OrganizationUserAuthorizationResult(
+            CanAddSelfToCollection: !isEditingOwnMembership || postedCollectionIds.All(currentCollectionIds.Contains),
+            CanEditOwnGroups: !isEditingOwnMembership,
+            postedCollectionIds.Except(authorizedPostedCollectionIds).ToHashSet(),
+            currentCollectionIds.Except(authorizedCurrentCollectionIds).ToHashSet());
+    }
+
+    /// <summary>
+    /// True when the caller is editing their own membership of an organization that does not let admins reach every
+    /// collection item. Such a caller cannot give themselves new collection access, or change their own groups.
+    /// </summary>
+    private async Task<bool> IsEditingOwnMembershipAsync(Guid organizationId, Guid? organizationUserId)
+    {
+        // An invited user has no organization user yet, and the caller is never the user they invite.
+        if (organizationUserId is null || !currentContext.UserId.HasValue)
+        {
+            return false;
+        }
+
+        var organizationAbility = await organizationAbilityCacheService.GetOrganizationAbilityAsync(organizationId);
+        if (organizationAbility is { AllowAdminAccessToAllCollectionItems: true })
+        {
+            return false;
+        }
+
+        var targetOrganizationUser = await organizationUserRepository.GetByIdAsync(organizationUserId.Value);
+        return targetOrganizationUser?.UserId == currentContext.UserId.Value;
+    }
+}

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -6,6 +6,7 @@ using System.Net;
 using Bit.Api.AdminConsole.Attributes;
 using Bit.Api.AdminConsole.Authorization;
 using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Api.AdminConsole.Authorization.OrganizationUsers;
 using Bit.Api.AdminConsole.Authorization.Requirements;
 using Bit.Api.AdminConsole.Models.Request.Organizations;
 using Bit.Api.AdminConsole.Models.Response.Organizations;
@@ -97,6 +98,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     private readonly Bitwarden.Server.Sdk.Features.IFeatureService _featureService;
     private readonly V2_UpdateUserCommand.IUpdateOrganizationUserCommand _updateOrganizationUserCommandVNext;
     private readonly IGlobalSettings _globalSettings;
+    private readonly IOrganizationUserAuthorizationService _organizationUserAuthorizationService;
 
     public OrganizationUsersController(IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository,
@@ -135,7 +137,8 @@ public class OrganizationUsersController : BaseAdminConsoleController
         IGetOrganizationInviteCommand getOrganizationInviteCommand,
         Bitwarden.Server.Sdk.Features.IFeatureService featureService,
         V2_UpdateUserCommand.IUpdateOrganizationUserCommand updateOrganizationUserCommandVNext,
-        IGlobalSettings globalSettings)
+        IGlobalSettings globalSettings,
+        IOrganizationUserAuthorizationService organizationUserAuthorizationService)
     {
         _organizationRepository = organizationRepository;
         _organizationUserRepository = organizationUserRepository;
@@ -175,6 +178,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
         _featureService = featureService;
         _updateOrganizationUserCommandVNext = updateOrganizationUserCommandVNext;
         _globalSettings = globalSettings;
+        _organizationUserAuthorizationService = organizationUserAuthorizationService;
     }
 
     [HttpGet("{id}")]
@@ -311,10 +315,24 @@ public class OrganizationUsersController : BaseAdminConsoleController
         // Check the user has permission to grant access to the collections for the new user
         if (model.Collections?.Any() == true)
         {
-            var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
-            var authorized =
-                (await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.ModifyUserAccess))
-                .Succeeded;
+            bool authorized;
+            if (_featureService.IsEnabled(FeatureFlagKeys.AuthorizationServices))
+            {
+                var authorizationResult = await _organizationUserAuthorizationService.AuthorizeSaveAsync(
+                    orgId,
+                    organizationUserId: null,
+                    model.Collections.Select(c => c.Id).ToList(),
+                    currentCollectionIds: []);
+                authorized = authorizationResult.UnauthorizedPostedCollectionIds.Count == 0;
+            }
+            else
+            {
+                var collections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(a => a.Id));
+                authorized =
+                    (await _authorizationService.AuthorizeAsync(User, collections, BulkCollectionOperations.ModifyUserAccess))
+                    .Succeeded;
+            }
+
             if (!authorized)
             {
                 throw new NotFoundException();
@@ -446,16 +464,43 @@ public class OrganizationUsersController : BaseAdminConsoleController
         var userId = _userService.GetProperUserId(User).Value;
         var editingSelf = userId == organizationUser.UserId;
 
-        // Authorization check:
-        // If admins are not allowed access to all collections, you cannot add yourself to a group.
-        // No error is thrown for this, we just don't update groups.
-        var groupsToSave = editingSelf && !organization.AllowAdminAccessToAllCollectionItems
-            ? null
-            : model.Groups;
+        IEnumerable<Guid> groupsToSave;
+        List<CollectionAccessSelection> collectionAccessToSave;
+        if (_featureService.IsEnabled(FeatureFlagKeys.AuthorizationServices))
+        {
+            var authorizationResult = await _organizationUserAuthorizationService.AuthorizeSaveAsync(
+                organization.Id,
+                id,
+                model.Collections.Select(c => c.Id).ToList(),
+                currentAccess.Select(ca => ca.Id).ToList());
+
+            if (!authorizationResult.CanAddSelfToCollection)
+            {
+                throw new BadRequestException("You cannot add yourself to a collection.");
+            }
+
+            if (authorizationResult.UnauthorizedPostedCollectionIds.Count > 0)
+            {
+                throw new NotFoundException();
+            }
+
+            // No error is thrown when the caller cannot edit their own groups, we just don't update groups.
+            groupsToSave = authorizationResult.CanEditOwnGroups ? model.Groups : null;
+            collectionAccessToSave = await BuildCollectionAccessToSaveAsync(
+                model, currentAccess, authorizationResult.UnauthorizedCurrentCollectionIds);
+        }
+        else
+        {
+            // Authorization check:
+            // If admins are not allowed access to all collections, you cannot add yourself to a group.
+            // No error is thrown for this, we just don't update groups.
+            groupsToSave = editingSelf && !organization.AllowAdminAccessToAllCollectionItems
+                ? null
+                : model.Groups;
+            collectionAccessToSave = await GetAuthorizedCollectionsToSaveAsync(model, currentAccess, editingSelf, organization);
+        }
 
         var existingUserType = organizationUser.Type;
-
-        var collectionAccessToSave = await GetAuthorizedCollectionsToSaveAsync(model, currentAccess, editingSelf, organization);
 
         if (_featureService.IsEnabled(FeatureFlagKeys.ChangeMemberEmailNoMp))
         {
@@ -488,6 +533,32 @@ public class OrganizationUsersController : BaseAdminConsoleController
             collectionAccessToSave, groupsToSave, model.DefaultUserCollectionName);
 
         return TypedResults.Ok();
+    }
+
+    /// <summary>
+    /// Resolves the collection access to persist for an organization user update, keeping the collections the
+    /// saving user is not allowed to change.
+    /// </summary>
+    private async Task<List<CollectionAccessSelection>> BuildCollectionAccessToSaveAsync(
+        OrganizationUserUpdateRequestModel model,
+        ICollection<CollectionAccessSelection> currentAccess,
+        IReadOnlySet<Guid> readonlyCollectionIds)
+    {
+        // The collection entities are read here to find the default collections. That is a business rule rather
+        // than an authorization check, so it stays in the controller.
+        var postedCollections = await _collectionRepository.GetManyByManyIdsAsync(model.Collections.Select(c => c.Id));
+        var currentCollections = await _collectionRepository.GetManyByManyIdsAsync(currentAccess.Select(cas => cas.Id));
+
+        var defaultCollectionIds = postedCollections
+            .Concat(currentCollections)
+            .Where(c => c.Type == CollectionType.DefaultUserCollection)
+            .Select(c => c.Id)
+            .ToHashSet();
+
+        return model.Collections.Select(c => c.ToSelectionReadOnly())
+            .Concat(currentAccess.Where(ca => readonlyCollectionIds.Contains(ca.Id)))
+            .Where(ac => !defaultCollectionIds.Contains(ac.Id)) // Remove default collections
+            .ToList();
     }
 
     /// <summary>

--- a/test/Api.Test/AdminConsole/Authorization/OrganizationUserAuthorizationServiceTests.cs
+++ b/test/Api.Test/AdminConsole/Authorization/OrganizationUserAuthorizationServiceTests.cs
@@ -1,0 +1,172 @@
+﻿using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Api.AdminConsole.Authorization.OrganizationUsers;
+using Bit.Core.AdminConsole.AbilitiesCache;
+using Bit.Core.Context;
+using Bit.Core.Entities;
+using Bit.Core.Models.Data.Organizations;
+using Bit.Core.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Api.Test.AdminConsole.Authorization;
+
+[SutProviderCustomize]
+public class OrganizationUserAuthorizationServiceTests
+{
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_ReturnsThePostedCollectionsTheCallerCannotModify(
+        SutProvider<OrganizationUserAuthorizationService> sutProvider,
+        Guid organizationId, Guid organizationUserId, Guid authorizedCollectionId, Guid unauthorizedCollectionId)
+    {
+        List<Guid> postedCollectionIds = [authorizedCollectionId, unauthorizedCollectionId];
+        SetupUserAccess(sutProvider, organizationId, postedCollectionIds, [authorizedCollectionId]);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, organizationUserId,
+            postedCollectionIds, []);
+
+        Assert.Equal([unauthorizedCollectionId], result.UnauthorizedPostedCollectionIds);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_ReturnsTheCurrentCollectionsTheCallerCannotModify(
+        SutProvider<OrganizationUserAuthorizationService> sutProvider,
+        Guid organizationId, Guid organizationUserId, Guid authorizedCollectionId, Guid unauthorizedCollectionId)
+    {
+        List<Guid> currentCollectionIds = [authorizedCollectionId, unauthorizedCollectionId];
+        SetupUserAccess(sutProvider, organizationId, currentCollectionIds, [authorizedCollectionId]);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, organizationUserId, [],
+            currentCollectionIds);
+
+        Assert.Equal([unauthorizedCollectionId], result.UnauthorizedCurrentCollectionIds);
+    }
+
+    /// <summary>
+    /// A collection that does not exist, or that belongs to another organization, is left out of the authorization
+    /// service's result. The caller must see it as unauthorized rather than as silently ignored.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenAPostedCollectionDoesNotExist_ReportsItAsUnauthorized(
+        SutProvider<OrganizationUserAuthorizationService> sutProvider,
+        Guid organizationId, Guid organizationUserId, Guid unknownCollectionId)
+    {
+        List<Guid> postedCollectionIds = [unknownCollectionId];
+        SetupUserAccess(sutProvider, organizationId, postedCollectionIds, []);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, organizationUserId,
+            postedCollectionIds, []);
+
+        Assert.Equal([unknownCollectionId], result.UnauthorizedPostedCollectionIds);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenInvitingAUser_CanAddSelfAndEditGroups(
+        SutProvider<OrganizationUserAuthorizationService> sutProvider, Guid organizationId, Guid callerUserId,
+        Guid postedCollectionId)
+    {
+        SetupOrganizationAbility(sutProvider, organizationId, allowAdminAccessToAllCollectionItems: false);
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(callerUserId);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, null, [postedCollectionId], []);
+
+        Assert.True(result.CanAddSelfToCollection);
+        Assert.True(result.CanEditOwnGroups);
+        await sutProvider.GetDependency<IOrganizationUserRepository>().DidNotReceiveWithAnyArgs()
+            .GetByIdAsync(default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenEditingSelfAndAddingANewCollection_CannotAddSelfToCollection(
+        SutProvider<OrganizationUserAuthorizationService> sutProvider, Guid organizationId, Guid callerUserId,
+        OrganizationUser targetOrganizationUser, Guid currentCollectionId, Guid newCollectionId)
+    {
+        SetupEditingSelf(sutProvider, organizationId, callerUserId, targetOrganizationUser,
+            allowAdminAccessToAllCollectionItems: false);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, targetOrganizationUser.Id,
+            [currentCollectionId, newCollectionId], [currentCollectionId]);
+
+        Assert.False(result.CanAddSelfToCollection);
+        Assert.False(result.CanEditOwnGroups);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenEditingSelfWithoutAddingACollection_CanAddSelfToCollection(
+        SutProvider<OrganizationUserAuthorizationService> sutProvider, Guid organizationId, Guid callerUserId,
+        OrganizationUser targetOrganizationUser, Guid currentCollectionId)
+    {
+        SetupEditingSelf(sutProvider, organizationId, callerUserId, targetOrganizationUser,
+            allowAdminAccessToAllCollectionItems: false);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, targetOrganizationUser.Id,
+            [currentCollectionId], [currentCollectionId]);
+
+        Assert.True(result.CanAddSelfToCollection);
+        // Editing your own membership still blocks group changes, even when no collection is added.
+        Assert.False(result.CanEditOwnGroups);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenEditingSelfAndAdminAccessIsAllowed_CanAddSelfAndEditGroups(
+        SutProvider<OrganizationUserAuthorizationService> sutProvider, Guid organizationId, Guid callerUserId,
+        OrganizationUser targetOrganizationUser, Guid newCollectionId)
+    {
+        SetupEditingSelf(sutProvider, organizationId, callerUserId, targetOrganizationUser,
+            allowAdminAccessToAllCollectionItems: true);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, targetOrganizationUser.Id,
+            [newCollectionId], []);
+
+        Assert.True(result.CanAddSelfToCollection);
+        Assert.True(result.CanEditOwnGroups);
+    }
+
+    [Theory, BitAutoData]
+    public async Task AuthorizeSaveAsync_WhenEditingAnotherUser_CanAddSelfAndEditGroups(
+        SutProvider<OrganizationUserAuthorizationService> sutProvider, Guid organizationId, Guid callerUserId,
+        OrganizationUser targetOrganizationUser, Guid newCollectionId)
+    {
+        SetupOrganizationAbility(sutProvider, organizationId, allowAdminAccessToAllCollectionItems: false);
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(callerUserId);
+        targetOrganizationUser.UserId = Guid.NewGuid();
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetByIdAsync(targetOrganizationUser.Id)
+            .Returns(targetOrganizationUser);
+
+        var result = await sutProvider.Sut.AuthorizeSaveAsync(organizationId, targetOrganizationUser.Id,
+            [newCollectionId], []);
+
+        Assert.True(result.CanAddSelfToCollection);
+        Assert.True(result.CanEditOwnGroups);
+    }
+
+    private static void SetupUserAccess(SutProvider<OrganizationUserAuthorizationService> sutProvider,
+        Guid organizationId, IReadOnlyCollection<Guid> requestedCollectionIds,
+        HashSet<Guid> authorizedCollectionIds) =>
+        sutProvider.GetDependency<ICollectionAuthorizationService>()
+            .AuthorizeModifyUserAccessManyAsync(organizationId,
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(requestedCollectionIds)))
+            .Returns(authorizedCollectionIds);
+
+    private static void SetupOrganizationAbility(SutProvider<OrganizationUserAuthorizationService> sutProvider,
+        Guid organizationId, bool allowAdminAccessToAllCollectionItems) =>
+        sutProvider.GetDependency<IOrganizationAbilityCacheService>()
+            .GetOrganizationAbilityAsync(organizationId)
+            .Returns(new OrganizationAbility
+            {
+                Id = organizationId,
+                AllowAdminAccessToAllCollectionItems = allowAdminAccessToAllCollectionItems,
+            });
+
+    private static void SetupEditingSelf(SutProvider<OrganizationUserAuthorizationService> sutProvider,
+        Guid organizationId, Guid callerUserId, OrganizationUser targetOrganizationUser,
+        bool allowAdminAccessToAllCollectionItems)
+    {
+        SetupOrganizationAbility(sutProvider, organizationId, allowAdminAccessToAllCollectionItems);
+        sutProvider.GetDependency<ICurrentContext>().UserId.Returns(callerUserId);
+        targetOrganizationUser.UserId = callerUserId;
+        sutProvider.GetDependency<IOrganizationUserRepository>().GetByIdAsync(targetOrganizationUser.Id)
+            .Returns(targetOrganizationUser);
+    }
+}

--- a/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
+++ b/test/Api.Test/AdminConsole/Controllers/OrganizationUsersControllerTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Security.Claims;
 using Bit.Api.AdminConsole.Authorization;
 using Bit.Api.AdminConsole.Authorization.Collections;
+using Bit.Api.AdminConsole.Authorization.OrganizationUsers;
 using Bit.Api.AdminConsole.Controllers;
 using Bit.Api.AdminConsole.Models.Request.Organizations;
+using Bit.Api.Models.Request;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.AdminConsole.Models.Data.Organizations.Policies;
 using Bit.Core.AdminConsole.OrganizationFeatures.AccountRecovery;
@@ -1046,7 +1048,7 @@ public class OrganizationUsersControllerTests
         Organization organization, OrganizationUserUpdateRequestModel model, Guid userId,
         OrganizationUser organizationUser, SutProvider<OrganizationUsersController> sutProvider)
     {
-        PutSetup(sutProvider, organization, organizationUser, userId, featureEnabled: true);
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
 
         sutProvider.GetDependency<V2_UpdateUserCommand.IUpdateOrganizationUserCommand>()
             .UpdateUserAsync(Arg.Any<V2_UpdateUserCommand.UpdateOrganizationUserRequest>())
@@ -1069,7 +1071,7 @@ public class OrganizationUsersControllerTests
         Organization organization, OrganizationUserUpdateRequestModel model, Guid userId,
         OrganizationUser organizationUser, SutProvider<OrganizationUsersController> sutProvider)
     {
-        PutSetup(sutProvider, organization, organizationUser, userId, featureEnabled: true);
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
         model.Email = "new@claimed.example.com";
 
         V2_UpdateUserCommand.UpdateOrganizationUserRequest captured = null;
@@ -1090,7 +1092,7 @@ public class OrganizationUsersControllerTests
         Organization organization, OrganizationUserUpdateRequestModel model, Guid userId,
         OrganizationUser organizationUser, SutProvider<OrganizationUsersController> sutProvider)
     {
-        PutSetup(sutProvider, organization, organizationUser, userId, featureEnabled: true);
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
 
         sutProvider.GetDependency<V2_UpdateUserCommand.IUpdateOrganizationUserCommand>()
             .UpdateUserAsync(Arg.Any<V2_UpdateUserCommand.UpdateOrganizationUserRequest>())
@@ -1107,7 +1109,7 @@ public class OrganizationUsersControllerTests
         Organization organization, OrganizationUserUpdateRequestModel model, Guid userId,
         OrganizationUser organizationUser, SutProvider<OrganizationUsersController> sutProvider)
     {
-        PutSetup(sutProvider, organization, organizationUser, userId, featureEnabled: false);
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: false);
 
         var result = await sutProvider.Sut.Put(organization, organizationUser.Id, model);
 
@@ -1128,7 +1130,7 @@ public class OrganizationUsersControllerTests
         OrganizationUser organizationUser, Guid sharedCollectionId, Guid defaultCollectionId,
         SutProvider<OrganizationUsersController> sutProvider)
     {
-        PutSetup(sutProvider, organization, organizationUser, userId, featureEnabled: true);
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
 
         // The client posts no collections; the user currently has access to a shared and a default collection.
         model.Collections = [];
@@ -1170,7 +1172,7 @@ public class OrganizationUsersControllerTests
     }
 
     private static void PutSetup(SutProvider<OrganizationUsersController> sutProvider, Organization organization,
-        OrganizationUser organizationUser, Guid userId, bool featureEnabled)
+        OrganizationUser organizationUser, Guid userId, bool changeMemberEmailNoMpEnabled)
     {
         organizationUser.OrganizationId = organization.Id;
         organization.AllowAdminAccessToAllCollectionItems = true;
@@ -1186,6 +1188,271 @@ public class OrganizationUsersControllerTests
             .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<object>(), Arg.Any<IEnumerable<IAuthorizationRequirement>>())
             .Returns(AuthorizationResult.Success());
         sutProvider.GetDependency<Bitwarden.Server.Sdk.Features.IFeatureService>().IsEnabled(Bit.Core.FeatureFlagKeys.ChangeMemberEmailNoMp)
-            .Returns(featureEnabled);
+            .Returns(changeMemberEmailNoMpEnabled);
     }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_EditingSelf_AddingANewCollection_ThrowsBadRequest(Organization organization,
+        OrganizationUser organizationUser, Guid userId, OrganizationUserUpdateRequestModel model,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: false);
+        organization.AllowAdminAccessToAllCollectionItems = false;
+        organizationUser.UserId = userId;
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.Put(organization, organizationUser.Id, model));
+
+        Assert.Equal("You cannot add yourself to a collection.", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_EditingSelf_WhenAdminAccessDisabled_DoesNotSaveGroups(Organization organization,
+        OrganizationUser organizationUser, Guid userId, OrganizationUserUpdateRequestModel model,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
+        organization.AllowAdminAccessToAllCollectionItems = false;
+        organizationUser.UserId = userId;
+        model.Collections = [];
+        V2_UpdateUserCommand.UpdateOrganizationUserRequest? captured = null;
+        sutProvider.GetDependency<V2_UpdateUserCommand.IUpdateOrganizationUserCommand>()
+            .UpdateUserAsync(Arg.Do<V2_UpdateUserCommand.UpdateOrganizationUserRequest>(r => captured = r))
+            .Returns(new CommandResult(new None()));
+
+        await sutProvider.Sut.Put(organization, organizationUser.Id, model);
+
+        Assert.NotNull(captured);
+        Assert.Null(captured.NewGroups);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_NotAuthorizedForPostedCollections_ThrowsNotFound(Organization organization,
+        OrganizationUser organizationUser, Guid userId, OrganizationUserUpdateRequestModel model,
+        Collection postedCollection, SutProvider<OrganizationUsersController> sutProvider)
+    {
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
+        sutProvider.GetDependency<ICollectionRepository>().GetManyByManyIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(new List<Collection> { postedCollection });
+        sutProvider.GetDependency<IAuthorizationService>()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<IEnumerable<Collection>>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Failed());
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => sutProvider.Sut.Put(organization, organizationUser.Id, model));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_WithNewAuthorizationEnabled_CannotAddSelfToCollection_ThrowsBadRequest(
+        Organization organization, OrganizationUser organizationUser, Guid userId,
+        OrganizationUserUpdateRequestModel model, SutProvider<OrganizationUsersController> sutProvider)
+    {
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
+        EnableNewAuthorization(sutProvider);
+        ArrangeAuthorizationResult(sutProvider, organization, organizationUser, model,
+            new OrganizationUserAuthorizationResult(CanAddSelfToCollection: false, CanEditOwnGroups: true, new HashSet<Guid>(), new HashSet<Guid>()));
+
+        var exception = await Assert.ThrowsAsync<BadRequestException>(
+            () => sutProvider.Sut.Put(organization, organizationUser.Id, model));
+
+        Assert.Equal("You cannot add yourself to a collection.", exception.Message);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_WithNewAuthorizationEnabled_UnauthorizedPostedCollection_ThrowsNotFound(
+        Organization organization, OrganizationUser organizationUser, Guid userId, Guid unauthorizedCollectionId,
+        OrganizationUserUpdateRequestModel model, SutProvider<OrganizationUsersController> sutProvider)
+    {
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
+        EnableNewAuthorization(sutProvider);
+        ArrangeAuthorizationResult(sutProvider, organization, organizationUser, model,
+            new OrganizationUserAuthorizationResult(CanAddSelfToCollection: true, CanEditOwnGroups: true, new HashSet<Guid> { unauthorizedCollectionId },
+                new HashSet<Guid>()));
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => sutProvider.Sut.Put(organization, organizationUser.Id, model));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_WithNewAuthorizationEnabled_CannotEditOwnGroups_DoesNotSaveGroups(Organization organization,
+        OrganizationUser organizationUser, Guid userId, OrganizationUserUpdateRequestModel model,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
+        EnableNewAuthorization(sutProvider);
+        ArrangeAuthorizationResult(sutProvider, organization, organizationUser, model,
+            new OrganizationUserAuthorizationResult(CanAddSelfToCollection: true, CanEditOwnGroups: false, new HashSet<Guid>(), new HashSet<Guid>()));
+        V2_UpdateUserCommand.UpdateOrganizationUserRequest? captured = null;
+        sutProvider.GetDependency<V2_UpdateUserCommand.IUpdateOrganizationUserCommand>()
+            .UpdateUserAsync(Arg.Do<V2_UpdateUserCommand.UpdateOrganizationUserRequest>(r => captured = r))
+            .Returns(new CommandResult(new None()));
+
+        await sutProvider.Sut.Put(organization, organizationUser.Id, model);
+
+        Assert.NotNull(captured);
+        Assert.Null(captured.NewGroups);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Put_WithNewAuthorizationEnabled_SavesGroupsAndPreservesUnauthorizedCurrentCollections(
+        Organization organization, OrganizationUser organizationUser, Guid userId, Guid readonlyCollectionId,
+        OrganizationUserUpdateRequestModel model, SutProvider<OrganizationUsersController> sutProvider)
+    {
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
+        var currentAccess = new List<CollectionAccessSelection> { new() { Id = readonlyCollectionId, Manage = true } };
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdWithCollectionsAsync(organizationUser.Id)
+            .Returns(new Tuple<OrganizationUser?, ICollection<CollectionAccessSelection>>(organizationUser, currentAccess));
+        EnableNewAuthorization(sutProvider);
+        ArrangeAuthorizationResult(sutProvider, organization, organizationUser, model,
+            new OrganizationUserAuthorizationResult(CanAddSelfToCollection: true, CanEditOwnGroups: true, new HashSet<Guid>(),
+                new HashSet<Guid> { readonlyCollectionId }),
+            currentCollectionIds: [readonlyCollectionId]);
+        V2_UpdateUserCommand.UpdateOrganizationUserRequest? captured = null;
+        sutProvider.GetDependency<V2_UpdateUserCommand.IUpdateOrganizationUserCommand>()
+            .UpdateUserAsync(Arg.Do<V2_UpdateUserCommand.UpdateOrganizationUserRequest>(r => captured = r))
+            .Returns(new CommandResult(new None()));
+
+        await sutProvider.Sut.Put(organization, organizationUser.Id, model);
+
+        var postedCollectionIds = model.Collections.Select(c => c.Id).ToList();
+        Assert.NotNull(captured);
+        Assert.Same(model.Groups, captured.NewGroups);
+        // The posted collections are saved, and the collection the caller cannot change is kept.
+        Assert.Equal(
+            postedCollectionIds.Append(readonlyCollectionId).OrderBy(id => id),
+            captured.CollectionsToSave!.Select(c => c.Id).OrderBy(id => id));
+        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<Collection>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
+    }
+
+    /// <summary>
+    /// Covers the three things the saved access list must get right at once: the posted collections are saved, a
+    /// current collection the caller may change is dropped when it is not reposted, a current collection the caller
+    /// may not change is kept, and default collections are filtered out of both.
+    /// </summary>
+    [Theory]
+    [BitAutoData]
+    public async Task Put_WithNewAuthorizationEnabled_SavesPostedCollections_KeepsReadonly_DropsDefaultAndRemoved(
+        Organization organization, OrganizationUser organizationUser, Guid userId,
+        OrganizationUserUpdateRequestModel model, Guid postedCollectionId, Guid removedCollectionId,
+        Guid readonlyCollectionId, Guid defaultCollectionId, SutProvider<OrganizationUsersController> sutProvider)
+    {
+        PutSetup(sutProvider, organization, organizationUser, userId, changeMemberEmailNoMpEnabled: true);
+        model.Collections =
+        [
+            new SelectionReadOnlyRequestModel { Id = postedCollectionId },
+            new SelectionReadOnlyRequestModel { Id = defaultCollectionId },
+        ];
+        var currentAccess = new List<CollectionAccessSelection>
+        {
+            new() { Id = removedCollectionId },
+            new() { Id = readonlyCollectionId },
+        };
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetByIdWithCollectionsAsync(organizationUser.Id)
+            .Returns(new Tuple<OrganizationUser?, ICollection<CollectionAccessSelection>>(organizationUser, currentAccess));
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns(new List<Collection>
+            {
+                new() { Id = postedCollectionId, OrganizationId = organization.Id, Type = CollectionType.SharedCollection },
+                new() { Id = removedCollectionId, OrganizationId = organization.Id, Type = CollectionType.SharedCollection },
+                new() { Id = readonlyCollectionId, OrganizationId = organization.Id, Type = CollectionType.SharedCollection },
+                new() { Id = defaultCollectionId, OrganizationId = organization.Id, Type = CollectionType.DefaultUserCollection },
+            });
+
+        EnableNewAuthorization(sutProvider);
+        ArrangeAuthorizationResult(sutProvider, organization, organizationUser, model,
+            new OrganizationUserAuthorizationResult(CanAddSelfToCollection: true, CanEditOwnGroups: true, new HashSet<Guid>(),
+                new HashSet<Guid> { readonlyCollectionId }),
+            currentCollectionIds: [removedCollectionId, readonlyCollectionId]);
+
+        V2_UpdateUserCommand.UpdateOrganizationUserRequest? captured = null;
+        sutProvider.GetDependency<V2_UpdateUserCommand.IUpdateOrganizationUserCommand>()
+            .UpdateUserAsync(Arg.Do<V2_UpdateUserCommand.UpdateOrganizationUserRequest>(r => captured = r))
+            .Returns(new CommandResult(new None()));
+
+        await sutProvider.Sut.Put(organization, organizationUser.Id, model);
+
+        Assert.NotNull(captured);
+        Assert.Equal(
+            new[] { postedCollectionId, readonlyCollectionId }.OrderBy(id => id),
+            captured.CollectionsToSave!.Select(c => c.Id).OrderBy(id => id));
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Invite_WithNewAuthorizationEnabled_UnauthorizedPostedCollection_ThrowsNotFound(Guid orgId,
+        Guid unauthorizedCollectionId, OrganizationUserInviteRequestModel model,
+        SutProvider<OrganizationUsersController> sutProvider)
+    {
+        sutProvider.GetDependency<ICurrentContext>().ManageUsers(orgId).Returns(true);
+        EnableNewAuthorization(sutProvider);
+        var postedCollectionIds = model.Collections.Select(c => c.Id).ToList();
+        sutProvider.GetDependency<IOrganizationUserAuthorizationService>()
+            .AuthorizeSaveAsync(orgId, null,
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(postedCollectionIds)),
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 0))
+            .Returns(new OrganizationUserAuthorizationResult(true, true,
+                new HashSet<Guid> { unauthorizedCollectionId }, new HashSet<Guid>()));
+
+        await Assert.ThrowsAsync<NotFoundException>(() => sutProvider.Sut.Invite(orgId, model));
+
+        await sutProvider.GetDependency<IOrganizationService>().DidNotReceiveWithAnyArgs()
+            .InviteUsersAsync(default, default, default, default);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task Invite_WithNewAuthorizationEnabled_Success(Guid orgId, Guid userId,
+        OrganizationUserInviteRequestModel model, SutProvider<OrganizationUsersController> sutProvider)
+    {
+        sutProvider.GetDependency<ICurrentContext>().ManageUsers(orgId).Returns(true);
+        sutProvider.GetDependency<IUserService>().GetProperUserId(Arg.Any<ClaimsPrincipal>()).Returns(userId);
+        EnableNewAuthorization(sutProvider);
+        var postedCollectionIds = model.Collections.Select(c => c.Id).ToList();
+        sutProvider.GetDependency<IOrganizationUserAuthorizationService>()
+            .AuthorizeSaveAsync(orgId, null,
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(postedCollectionIds)),
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 0))
+            .Returns(new OrganizationUserAuthorizationResult(CanAddSelfToCollection: true, CanEditOwnGroups: true, new HashSet<Guid>(), new HashSet<Guid>()));
+
+        await sutProvider.Sut.Invite(orgId, model);
+
+        await sutProvider.GetDependency<IOrganizationService>().Received(1).InviteUsersAsync(
+            orgId, userId, Arg.Any<EventSystemUser?>(),
+            Arg.Any<IEnumerable<(OrganizationUserInvite, string?)>>());
+        await sutProvider.GetDependency<IAuthorizationService>().DidNotReceiveWithAnyArgs()
+            .AuthorizeAsync(Arg.Any<ClaimsPrincipal>(), Arg.Any<IEnumerable<Collection>>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>());
+    }
+
+    private static void EnableNewAuthorization(SutProvider<OrganizationUsersController> sutProvider) =>
+        sutProvider.GetDependency<Bitwarden.Server.Sdk.Features.IFeatureService>()
+            .IsEnabled(Bit.Core.FeatureFlagKeys.AuthorizationServices)
+            .Returns(true);
+
+    private static void ArrangeAuthorizationResult(SutProvider<OrganizationUsersController> sutProvider,
+        Organization organization, OrganizationUser organizationUser, OrganizationUserUpdateRequestModel model,
+        OrganizationUserAuthorizationResult result, IReadOnlyCollection<Guid>? currentCollectionIds = null)
+    {
+        var postedCollectionIds = model.Collections.Select(c => c.Id).ToList();
+        var expectedCurrentCollectionIds = currentCollectionIds ?? Array.Empty<Guid>();
+        sutProvider.GetDependency<IOrganizationUserAuthorizationService>()
+            .AuthorizeSaveAsync(organization.Id, organizationUser.Id,
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(postedCollectionIds)),
+                Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.SequenceEqual(expectedCurrentCollectionIds)))
+            .Returns(result);
+    }
+
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41448

Last of four, after #8211 (PM-12473), #8268 (PM-42605) and #8270 (PM-41270).

## 📔 Objective

`OrganizationUsersController` authorized collection access with
`BulkCollectionAuthorizationHandler` in three places: a bulk check in `Invite`, and
inside `GetAuthorizedCollectionsToSaveAsync` a bulk check on the posted collections
plus a per-collection loop over the user's current collections. `Put` also held two
inline rules — a caller cannot give themselves access to a new collection, and a
caller editing themselves cannot change their own groups.

Behind `pm-35160-authorization-services` all of that moves into
`OrganizationUserAuthorizationService`, which calls
`ICollectionAuthorizationService.AuthorizeModifyUserAccessManyAsync` once for the
posted collections and once for the current ones.

The service works out for itself whether the caller is editing their own membership.
It reads the target organization user rather than taking a flag from the controller,
so a controller change cannot silently disable the rule. That costs one indexed
primary-key read per update.

Default-collection filtering stays in the controller. It is a business rule rather
than an authorization check and it needs `Collection.Type`, so both collection reads
survive on the flag-on path, moved into `BuildCollectionAccessToSaveAsync`.

### Behavior changes on the flag-on path

- **The route `orgId` is now authoritative.** The old handler set
  `_targetOrganizationId = resources.First().OrganizationId`, authorizing against the
  resource's organization rather than the route's. This closes a cross-organization
  authorization gap and is the most valuable change here.
- **Partially unknown posted collection ids now return 404.** They used to be dropped
  silently while the rest were authorized. `Invite` gains the same check. The web
  client builds its list from collections fetched for that organization, so it cannot
  trip this. The public API `MembersController` does not use this controller.
- `AllowAdminAccessToAllCollectionItems` now comes from the organization ability
  cache rather than the bound `Organization` entity. The old path already read it
  from that cache for the collection decision in the same request, so this removes a
  mixed source rather than adding risk.

### Tests

The self-add `BadRequestException`, the null-groups path, and `Put` throwing
`NotFoundException` had no coverage. Flag-off characterization tests pin them first,
then eight service tests and nine flag-on controller tests follow. One test covers
the saved access list end to end: posted collections saved, a removed collection
dropped, an unauthorized current collection kept, and default collections filtered
out of both.

## 📸 Screenshots

N/A
