### PR TITLE
Add the PAM access-notification mailer

### DIFF
--- a/bitwarden_license/src/Services/Pam/Services/AccessMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/AccessMailNotifier.cs
@@ -25,7 +25,7 @@ public class AccessMailNotifier : IAccessMailNotifier
         _logger = logger;
     }
 
-    private bool Enabled => _featureService.IsEnabled(FeatureFlagKeys.PamEmailNotifications);
+    private bool Enabled => _featureService.IsEnabled(FeatureFlagKeys.Pam);
 
     public async Task SendToUserAsync<TView>(Guid recipientUserId, Func<string, BaseMail<TView>> buildMail)
         where TView : BaseMailView

--- a/bitwarden_license/src/Services/Pam/Services/AccessMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/AccessMailNotifier.cs
@@ -1,0 +1,107 @@
+﻿using Bit.Core;
+using Bit.Core.Platform.Mail.Mailer;
+using Bit.Core.Repositories;
+using Bitwarden.Server.Sdk.Features;
+
+namespace Bit.Services.Pam.Services;
+
+public class AccessMailNotifier : IAccessMailNotifier
+{
+    private readonly IMailer _mailer;
+    private readonly IUserRepository _userRepository;
+    private readonly IFeatureService _featureService;
+    private readonly ILogger<AccessMailNotifier> _logger;
+
+    public AccessMailNotifier(
+        IMailer mailer,
+        IUserRepository userRepository,
+        IFeatureService featureService,
+        ILogger<AccessMailNotifier> logger)
+    {
+        _mailer = mailer;
+        _userRepository = userRepository;
+        _featureService = featureService;
+        _logger = logger;
+    }
+
+    private bool Enabled => _featureService.IsEnabled(FeatureFlagKeys.PamEmailNotifications);
+
+    public async Task SendToUserAsync<TView>(Guid recipientUserId, Func<string, BaseMail<TView>> buildMail)
+        where TView : BaseMailView
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        try
+        {
+            var recipient = await _userRepository.GetByIdAsync(recipientUserId);
+            await SendOneAsync(recipientUserId, recipient?.Email, buildMail);
+        }
+        catch (Exception ex)
+        {
+            LogFailure(ex, recipientUserId);
+        }
+    }
+
+    public async Task SendToUsersAsync<TView>(
+        IEnumerable<Guid> recipientUserIds,
+        Func<string, BaseMail<TView>> buildMail)
+        where TView : BaseMailView
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        var userIds = recipientUserIds.Distinct().ToList();
+        if (userIds.Count == 0)
+        {
+            return;
+        }
+
+        IEnumerable<KeyValuePair<Guid, string?>> addresses;
+        try
+        {
+            addresses = (await _userRepository.GetManyAsync(userIds))
+                .Select(u => new KeyValuePair<Guid, string?>(u.Id, u.Email))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            // The read covers every recipient, so its failure is the whole batch's failure and there is no
+            // per-recipient id worth naming.
+            _logger.LogError(ex, "PAM access mail: failed to resolve {RecipientCount} recipients.", userIds.Count);
+            return;
+        }
+
+        foreach (var (userId, email) in addresses)
+        {
+            try
+            {
+                await SendOneAsync(userId, email, buildMail);
+            }
+            catch (Exception ex)
+            {
+                LogFailure(ex, userId);
+            }
+        }
+    }
+
+    private async Task SendOneAsync<TView>(Guid userId, string? email, Func<string, BaseMail<TView>> buildMail)
+        where TView : BaseMailView
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            _logger.LogWarning("PAM access mail: no deliverable address for user {UserId}; nothing sent.", userId);
+            return;
+        }
+
+        await _mailer.SendEmail(buildMail(email));
+    }
+
+    private void LogFailure(Exception ex, Guid userId) =>
+        // Ids only. The recipient's address is the one thing this type always holds and must never record.
+        _logger.LogError(ex, "PAM access mail to user {UserId} could not be sent.", userId);
+}

--- a/bitwarden_license/src/Services/Pam/Services/AccessMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/AccessMailNotifier.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core;
+using Bit.Core.Entities;
 using Bit.Core.Platform.Mail.Mailer;
 using Bit.Core.Repositories;
 using Bitwarden.Server.Sdk.Features;
@@ -61,12 +62,10 @@ public class AccessMailNotifier : IAccessMailNotifier
             return;
         }
 
-        IEnumerable<KeyValuePair<Guid, string?>> addresses;
+        List<User> recipients;
         try
         {
-            addresses = (await _userRepository.GetManyAsync(userIds))
-                .Select(u => new KeyValuePair<Guid, string?>(u.Id, u.Email))
-                .ToList();
+            recipients = (await _userRepository.GetManyAsync(userIds)).ToList();
         }
         catch (Exception ex)
         {
@@ -76,15 +75,15 @@ public class AccessMailNotifier : IAccessMailNotifier
             return;
         }
 
-        foreach (var (userId, email) in addresses)
+        foreach (var recipient in recipients)
         {
             try
             {
-                await SendOneAsync(userId, email, buildMail);
+                await SendOneAsync(recipient.Id, recipient.Email, buildMail);
             }
             catch (Exception ex)
             {
-                LogFailure(ex, userId);
+                LogFailure(ex, recipient.Id);
             }
         }
     }

--- a/bitwarden_license/src/Services/Pam/Services/IAccessMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/IAccessMailNotifier.cs
@@ -1,0 +1,43 @@
+﻿using Bit.Core.Platform.Mail.Mailer;
+
+namespace Bit.Services.Pam.Services;
+
+/// <summary>
+/// Sends PAM's access-lifecycle emails — the out-of-band half of the notification story that
+/// <see cref="IApproverInboxNotifier" /> and <see cref="IRequesterNotifier" /> cover in-band. Their pushes only
+/// reach a client that happens to be open, so an approver with nothing running never learns a request is waiting;
+/// this delivers the same news to a mailbox. Fired from the access-request and lease commands alongside the
+/// matching push.
+/// </summary>
+/// <remarks>
+/// Two contracts bind every implementation, and both exist because a send sits inside a command that grants or
+/// ends access to a vault item.
+///
+/// It never throws. <c>Mailer.SendEmail</c> reaches <c>IMailDeliveryService</c> with no queue in between, so a
+/// propagating failure would fail the enclosing access-request command: an upstream mail outage would stop people
+/// getting access to their own items. A failed send is logged and swallowed; the request still succeeds and the
+/// push still lands.
+///
+/// It sends nothing while <see cref="Bit.Core.FeatureFlagKeys.PamEmailNotifications" /> is off, which is the
+/// absent-flag default and the only state self-host sees.
+/// </remarks>
+public interface IAccessMailNotifier
+{
+    /// <summary>
+    /// Resolves <paramref name="recipientUserId" />'s address and sends the mail <paramref name="buildMail" />
+    /// returns for it. The address is supplied to the factory rather than known to the caller, so a caller never
+    /// has to load a user to send them mail.
+    /// </summary>
+    /// <param name="recipientUserId">The user to deliver to. Nothing is sent if they no longer exist.</param>
+    /// <param name="buildMail">Builds the mail for one resolved address; called at most once.</param>
+    Task SendToUserAsync<TView>(Guid recipientUserId, Func<string, BaseMail<TView>> buildMail)
+        where TView : BaseMailView;
+
+    /// <summary>
+    /// The <see cref="SendToUserAsync{TView}" /> contract for several recipients, resolved in one read. Each gets
+    /// their own message: a shared <c>ToEmails</c> would disclose an organization's approvers to one another.
+    /// One recipient failing does not stop the rest.
+    /// </summary>
+    Task SendToUsersAsync<TView>(IEnumerable<Guid> recipientUserIds, Func<string, BaseMail<TView>> buildMail)
+        where TView : BaseMailView;
+}

--- a/bitwarden_license/src/Services/Pam/Services/IAccessMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/IAccessMailNotifier.cs
@@ -18,8 +18,9 @@ namespace Bit.Services.Pam.Services;
 /// getting access to their own items. A failed send is logged and swallowed; the request still succeeds and the
 /// push still lands.
 ///
-/// It sends nothing while <see cref="Bit.Core.FeatureFlagKeys.PamEmailNotifications" /> is off, which is the
-/// absent-flag default and the only state self-host sees.
+/// It sends nothing while <see cref="Bit.Core.FeatureFlagKeys.Pam" /> is off, which is the absent-flag default
+/// and the only state self-host sees. PAM's own flag is the only switch: there is no separate one that silences
+/// the mail while the rest of PAM keeps running.
 /// </remarks>
 public interface IAccessMailNotifier
 {

--- a/bitwarden_license/src/Services/Pam/Services/IAccessMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/IAccessMailNotifier.cs
@@ -3,34 +3,24 @@
 namespace Bit.Services.Pam.Services;
 
 /// <summary>
-/// Sends PAM's access-lifecycle emails — the out-of-band half of the notification story that
-/// <see cref="IApproverInboxNotifier" /> and <see cref="IRequesterNotifier" /> cover in-band. Their pushes only
-/// reach a client that happens to be open, so an approver with nothing running never learns a request is waiting;
-/// this delivers the same news to a mailbox. Fired from the access-request and lease commands alongside the
-/// matching push.
+/// Sends PAM's access-lifecycle emails: the out-of-band counterpart to the in-band pushes from
+/// <see cref="IApproverInboxNotifier" /> and <see cref="IRequesterNotifier" />, which only reach a client that
+/// happens to be open.
 /// </summary>
 /// <remarks>
-/// Two contracts bind every implementation, and both exist because a send sits inside a command that grants or
-/// ends access to a vault item.
+/// Implementations never throw. <c>Mailer.SendEmail</c> reaches <c>IMailDeliveryService</c> with no queue in
+/// between, so a propagating failure would fail the enclosing access-request command and a mail outage would stop
+/// people getting access to their own items. A failed send is logged and swallowed.
 ///
-/// It never throws. <c>Mailer.SendEmail</c> reaches <c>IMailDeliveryService</c> with no queue in between, so a
-/// propagating failure would fail the enclosing access-request command: an upstream mail outage would stop people
-/// getting access to their own items. A failed send is logged and swallowed; the request still succeeds and the
-/// push still lands.
-///
-/// It sends nothing while <see cref="Bit.Core.FeatureFlagKeys.Pam" /> is off, which is the absent-flag default
-/// and the only state self-host sees. PAM's own flag is the only switch: there is no separate one that silences
-/// the mail while the rest of PAM keeps running.
+/// Nothing is sent while <see cref="Bit.Core.FeatureFlagKeys.Pam" /> is off, which is the absent-flag default and
+/// the only state self-host sees.
 /// </remarks>
 public interface IAccessMailNotifier
 {
     /// <summary>
-    /// Resolves <paramref name="recipientUserId" />'s address and sends the mail <paramref name="buildMail" />
-    /// returns for it. The address is supplied to the factory rather than known to the caller, so a caller never
-    /// has to load a user to send them mail.
+    /// Resolves <paramref name="recipientUserId" />'s address and hands it to <paramref name="buildMail" />, so a
+    /// caller never has to load a user to send them mail. Nothing is sent if the user no longer exists.
     /// </summary>
-    /// <param name="recipientUserId">The user to deliver to. Nothing is sent if they no longer exist.</param>
-    /// <param name="buildMail">Builds the mail for one resolved address; called at most once.</param>
     Task SendToUserAsync<TView>(Guid recipientUserId, Func<string, BaseMail<TView>> buildMail)
         where TView : BaseMailView;
 

--- a/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
@@ -76,8 +76,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IRequestLeaseExtensionCommand, RequestLeaseExtensionCommand>();
         services.AddScoped<IRevokeAccessLeaseCommand, RevokeAccessLeaseCommand>();
 
-        // Supporting reads for the write path: who may approve for a collection, and the per-cipher
-        // single-active-lease guard applied at activation.
         services.AddScoped<IApproverCollectionAccessQuery, ApproverCollectionAccessQuery>();
         services.AddScoped<ISingleActiveLeaseEvaluator, SingleActiveLeaseEvaluator>();
 

--- a/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
@@ -97,6 +97,10 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IRequesterNotifier, RequesterNotifier>();
         services.AddScoped<IAccessAuditEventEmitter, AccessAuditEventEmitter>();
 
+        // The out-of-band side channel: the same news as the pushes, delivered to a mailbox. Self-gates on
+        // FeatureFlagKeys.PamEmailNotifications and never throws, so a command may call it unconditionally.
+        services.TryAddScoped<IAccessMailNotifier, AccessMailNotifier>();
+
         // Runs on every connector-facing route (see PamEndpointsExtensions.WithPamAccessConnectorMachineDefaults).
         // Its
         // parameterless constructor would let AddEndpointFilter<T>() construct it unregistered, as

--- a/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
@@ -25,13 +25,10 @@ public static class ServiceCollectionExtensions
 {
     /// <summary>
     /// Registers PAM's commercial services, including credential rotation. <paramref name="configuration"/> binds
-    /// <see cref="PamRotationOptions"/> from <c>globalSettings:pam:rotation</c> -- AddPamServices previously took no
-    /// configuration, so this is a new parameter on an existing call site (see <c>Startup.ConfigureServices</c>)
-    /// rather than a pre-existing pattern in this file.
+    /// <see cref="PamRotationOptions"/> from <c>globalSettings:pam:rotation</c>.
     /// </summary>
     public static IServiceCollection AddPamServices(this IServiceCollection services, IConfiguration configuration)
     {
-        // Minimal API endpoint handlers. The endpoints (see PamEndpointsExtensions) resolve these from DI.
         services.AddScoped<LeaseEndpointsHandler>();
         services.AddScoped<AccessRequestEndpointsHandler>();
         services.AddScoped<AccessRuleEndpointsHandler>();
@@ -53,10 +50,8 @@ public static class ServiceCollectionExtensions
         // Rule evaluation engine. Pure and stateless, so a singleton is safe.
         services.AddSingleton<IAccessRuleEngine, AccessRuleEngine>();
 
-        // Resolves the access rule governing a cipher for a caller, then evaluates it via the engine.
         services.AddScoped<IGoverningRuleResolver, GoverningRuleResolver>();
 
-        // AccessRule write path.
         services.TryAddSingleton(TimeProvider.System);
         services.AddSingleton<IAccessRuleValidator, AccessRuleValidator>();
         services.AddScoped<IAccessRuleWriteValidator, AccessRuleWriteValidator>();
@@ -64,8 +59,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUpdateAccessRuleCommand, UpdateAccessRuleCommand>();
         services.AddScoped<IDeleteAccessRuleCommand, DeleteAccessRuleCommand>();
 
-        // Read models behind the approver inbox, the lease surfaces, and the per-cipher pre-check and access-state
-        // snapshot.
         services.AddScoped<IAccessPreCheckQuery, AccessPreCheckQuery>();
         services.AddScoped<IGetCipherAccessStateQuery, GetCipherAccessStateQuery>();
         services.AddScoped<IGetAccessRequestDetailsQuery, GetAccessRequestDetailsQuery>();
@@ -76,7 +69,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IListLeaseHistoryQuery, ListLeaseHistoryQuery>();
         services.AddScoped<IListAccessAuditTrailQuery, ListAccessAuditTrailQuery>();
 
-        // Access-request and lease write path.
         services.AddScoped<ISubmitAccessRequestCommand, SubmitAccessRequestCommand>();
         services.AddScoped<IDecideAccessRequestCommand, DecideAccessRequestCommand>();
         services.AddScoped<IActivateAccessRequestCommand, ActivateAccessRequestCommand>();
@@ -125,7 +117,6 @@ public static class ServiceCollectionExtensions
         // Stateless and cheap to construct; shared across the process like IAccessRuleEngine.
         services.AddSingleton<IRotationScheduleCalculator, RotationScheduleCalculator>();
 
-        // Admin commands
         services.AddScoped<IRegisterAccessConnectorCommand, RegisterAccessConnectorCommand>();
         services.AddScoped<ISetAccessConnectorStatusCommand, SetAccessConnectorStatusCommand>();
         services.AddScoped<IDeleteAccessConnectorCommand, DeleteAccessConnectorCommand>();
@@ -144,7 +135,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITriggerRotationCommand, TriggerRotationCommand>();
         services.AddScoped<IRecordManualRotationCommand, RecordManualRotationCommand>();
 
-        // Dispatch / daemon commands
         services.AddScoped<IOfferRotationCommand, OfferRotationCommand>();
         services.AddScoped<IHandleAccessGrantEndedCommand, HandleAccessGrantEndedCommand>();
         services.AddScoped<IClaimRotationJobCommand, ClaimRotationJobCommand>();
@@ -152,7 +142,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IReportRotationFailedCommand, ReportRotationFailedCommand>();
         services.AddScoped<ISubmitCipherUpdateCommand, SubmitCipherUpdateCommand>();
 
-        // Read queries
         services.AddScoped<IGetRotationConfigDetailsQuery, GetRotationConfigDetailsQuery>();
         services.AddScoped<IListAccessConnectorsQuery, ListAccessConnectorsQuery>();
         services.AddScoped<IGetAccessConnectorDetailsQuery, GetAccessConnectorDetailsQuery>();

--- a/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
@@ -97,8 +97,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IRequesterNotifier, RequesterNotifier>();
         services.AddScoped<IAccessAuditEventEmitter, AccessAuditEventEmitter>();
 
-        // The out-of-band side channel: the same news as the pushes, delivered to a mailbox. Self-gates on
-        // FeatureFlagKeys.PamEmailNotifications and never throws, so a command may call it unconditionally.
         services.TryAddScoped<IAccessMailNotifier, AccessMailNotifier>();
 
         // Runs on every connector-facing route (see PamEndpointsExtensions.WithPamAccessConnectorMachineDefaults).

--- a/bitwarden_license/test/Services/Pam.Test/Services/AccessMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/AccessMailNotifierTests.cs
@@ -1,0 +1,167 @@
+﻿using Bit.Core;
+using Bit.Core.Entities;
+using Bit.Core.Platform.Mail.Mailer;
+using Bit.Core.Repositories;
+using Bit.Services.Pam.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bitwarden.Server.Sdk.Features;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Bit.Services.Pam.Test.Services;
+
+[SutProviderCustomize]
+public class AccessMailNotifierTests
+{
+    /// <summary>
+    /// A stand-in for the mails later milestones will send. The notifier is a seam over <see cref="IMailer" /> and
+    /// is deliberately indifferent to which mail travels through it, so the specs supply their own rather than
+    /// coupling to a shipped one.
+    /// </summary>
+    private class TestMailView : BaseMailView;
+
+    private class TestMail : BaseMail<TestMailView>
+    {
+        public override string Subject { get; set; } = "Access request";
+    }
+
+    private static Func<string, BaseMail<TestMailView>> Build() =>
+        email => new TestMail { ToEmails = [email], View = new TestMailView() };
+
+    private static void EnableFlag(SutProvider<AccessMailNotifier> sutProvider) =>
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PamEmailNotifications)
+            .Returns(true);
+
+    [Theory, BitAutoData]
+    public async Task SendToUserAsync_FlagOff_SendsNothingAndReadsNoUser(
+        SutProvider<AccessMailNotifier> sutProvider, Guid userId)
+    {
+        await sutProvider.Sut.SendToUserAsync(userId, Build());
+
+        await sutProvider.GetDependency<IMailer>().DidNotReceiveWithAnyArgs()
+            .SendEmail(Arg.Any<BaseMail<TestMailView>>());
+        await sutProvider.GetDependency<IUserRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendToUserAsync_FlagOn_SendsToTheResolvedAddress(
+        SutProvider<AccessMailNotifier> sutProvider, User user)
+    {
+        EnableFlag(sutProvider);
+        sutProvider.GetDependency<IUserRepository>().GetByIdAsync(user.Id).Returns(user);
+
+        await sutProvider.Sut.SendToUserAsync(user.Id, Build());
+
+        await sutProvider.GetDependency<IMailer>().Received(1)
+            .SendEmail(Arg.Is<BaseMail<TestMailView>>(m => m.ToEmails.Single() == user.Email));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendToUserAsync_MailerThrows_DoesNotPropagate(
+        SutProvider<AccessMailNotifier> sutProvider, User user)
+    {
+        EnableFlag(sutProvider);
+        sutProvider.GetDependency<IUserRepository>().GetByIdAsync(user.Id).Returns(user);
+        sutProvider.GetDependency<IMailer>()
+            .SendEmail(Arg.Any<BaseMail<TestMailView>>())
+            .ThrowsAsync(new InvalidOperationException("delivery service unavailable"));
+
+        var exception = await Record.ExceptionAsync(() => sutProvider.Sut.SendToUserAsync(user.Id, Build()));
+
+        Assert.Null(exception);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendToUserAsync_UserReadThrows_DoesNotPropagate(
+        SutProvider<AccessMailNotifier> sutProvider, Guid userId)
+    {
+        EnableFlag(sutProvider);
+        sutProvider.GetDependency<IUserRepository>().GetByIdAsync(userId)
+            .ThrowsAsync(new TimeoutException("database unavailable"));
+
+        var exception = await Record.ExceptionAsync(() => sutProvider.Sut.SendToUserAsync(userId, Build()));
+
+        Assert.Null(exception);
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendToUserAsync_UnknownUser_SendsNothing(
+        SutProvider<AccessMailNotifier> sutProvider, Guid userId)
+    {
+        EnableFlag(sutProvider);
+        sutProvider.GetDependency<IUserRepository>().GetByIdAsync(userId).Returns((User?)null);
+
+        await sutProvider.Sut.SendToUserAsync(userId, Build());
+
+        await sutProvider.GetDependency<IMailer>().DidNotReceiveWithAnyArgs()
+            .SendEmail(Arg.Any<BaseMail<TestMailView>>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendToUsersAsync_FlagOff_SendsNothing(
+        SutProvider<AccessMailNotifier> sutProvider, Guid userA, Guid userB)
+    {
+        await sutProvider.Sut.SendToUsersAsync([userA, userB], Build());
+
+        await sutProvider.GetDependency<IMailer>().DidNotReceiveWithAnyArgs()
+            .SendEmail(Arg.Any<BaseMail<TestMailView>>());
+        await sutProvider.GetDependency<IUserRepository>().DidNotReceiveWithAnyArgs()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendToUsersAsync_FlagOn_SendsOneMailPerRecipient(
+        SutProvider<AccessMailNotifier> sutProvider, User userA, User userB)
+    {
+        EnableFlag(sutProvider);
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([userA, userB]);
+
+        await sutProvider.Sut.SendToUsersAsync([userA.Id, userB.Id], Build());
+
+        await sutProvider.GetDependency<IMailer>().Received(1)
+            .SendEmail(Arg.Is<BaseMail<TestMailView>>(m => m.ToEmails.Single() == userA.Email));
+        await sutProvider.GetDependency<IMailer>().Received(1)
+            .SendEmail(Arg.Is<BaseMail<TestMailView>>(m => m.ToEmails.Single() == userB.Email));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendToUsersAsync_OneRecipientFails_TheRestStillReceive(
+        SutProvider<AccessMailNotifier> sutProvider, User failing, User succeeding)
+    {
+        EnableFlag(sutProvider);
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([failing, succeeding]);
+        sutProvider.GetDependency<IMailer>()
+            .SendEmail(Arg.Is<BaseMail<TestMailView>>(m => m.ToEmails.Single() == failing.Email))
+            .ThrowsAsync(new InvalidOperationException("delivery service unavailable"));
+
+        var exception = await Record.ExceptionAsync(
+            () => sutProvider.Sut.SendToUsersAsync([failing.Id, succeeding.Id], Build()));
+
+        Assert.Null(exception);
+        await sutProvider.GetDependency<IMailer>().Received(1)
+            .SendEmail(Arg.Is<BaseMail<TestMailView>>(m => m.ToEmails.Single() == succeeding.Email));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SendToUsersAsync_RecipientReadThrows_DoesNotPropagate(
+        SutProvider<AccessMailNotifier> sutProvider, Guid userA, Guid userB)
+    {
+        EnableFlag(sutProvider);
+        sutProvider.GetDependency<IUserRepository>()
+            .GetManyAsync(Arg.Any<IEnumerable<Guid>>())
+            .ThrowsAsync(new TimeoutException("database unavailable"));
+
+        var exception = await Record.ExceptionAsync(() => sutProvider.Sut.SendToUsersAsync([userA, userB], Build()));
+
+        Assert.Null(exception);
+        await sutProvider.GetDependency<IMailer>().DidNotReceiveWithAnyArgs()
+            .SendEmail(Arg.Any<BaseMail<TestMailView>>());
+    }
+}

--- a/bitwarden_license/test/Services/Pam.Test/Services/AccessMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/AccessMailNotifierTests.cs
@@ -32,7 +32,7 @@ public class AccessMailNotifierTests
 
     private static void EnableFlag(SutProvider<AccessMailNotifier> sutProvider) =>
         sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PamEmailNotifications)
+            .IsEnabled(FeatureFlagKeys.Pam)
             .Returns(true);
 
     [Theory, BitAutoData]

--- a/bitwarden_license/test/Services/Pam.Test/Services/AccessMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/AccessMailNotifierTests.cs
@@ -15,11 +15,7 @@ namespace Bit.Services.Pam.Test.Services;
 [SutProviderCustomize]
 public class AccessMailNotifierTests
 {
-    /// <summary>
-    /// A stand-in for the mails later milestones will send. The notifier is a seam over <see cref="IMailer" /> and
-    /// is deliberately indifferent to which mail travels through it, so the specs supply their own rather than
-    /// coupling to a shipped one.
-    /// </summary>
+    /// <summary>Stands in for a shipped mail; the notifier is indifferent to which mail travels through it.</summary>
     private class TestMailView : BaseMailView;
 
     private class TestMail : BaseMail<TestMailView>

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -320,17 +320,6 @@ public static partial class FeatureFlagKeys
     /// </summary>
     public const string PamDisableSqlAuditLogging = "pm-42480-disable-pam-sql-audit-logging";
 
-    /// <summary>
-    /// Gates every email PAM sends. Off — the absent-flag default, and the only state self-host ever sees — PAM
-    /// works exactly as it does without it, notifying through the SignalR refresh pushes alone.
-    ///
-    /// The <c>pm-00000</c> prefix is a placeholder — no LaunchDarkly flag exists under this key, so
-    /// <c>IsEnabled</c> returns the absent-flag default no matter what is toggled upstream, and mail stays off.
-    /// Substitute the notification ticket's number before the first caller merges; renaming after the flag is
-    /// created under the placeholder is a coordinated migration.
-    /// </summary>
-    public const string PamEmailNotifications = "pm-00000-pam-email-notifications";
-
     /* VFO */
     public const string VFO1Foundation = "vfo1-foundation";
 

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -323,6 +323,11 @@ public static partial class FeatureFlagKeys
     /// <summary>
     /// Gates every email PAM sends. Off — the absent-flag default, and the only state self-host ever sees — PAM
     /// works exactly as it does without it, notifying through the SignalR refresh pushes alone.
+    ///
+    /// The <c>pm-00000</c> prefix is a placeholder — no LaunchDarkly flag exists under this key, so
+    /// <c>IsEnabled</c> returns the absent-flag default no matter what is toggled upstream, and mail stays off.
+    /// Substitute the notification ticket's number before the first caller merges; renaming after the flag is
+    /// created under the placeholder is a coordinated migration.
     /// </summary>
     public const string PamEmailNotifications = "pm-00000-pam-email-notifications";
 

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -320,6 +320,12 @@ public static partial class FeatureFlagKeys
     /// </summary>
     public const string PamDisableSqlAuditLogging = "pm-42480-disable-pam-sql-audit-logging";
 
+    /// <summary>
+    /// Gates every email PAM sends. Off — the absent-flag default, and the only state self-host ever sees — PAM
+    /// works exactly as it does without it, notifying through the SignalR refresh pushes alone.
+    /// </summary>
+    public const string PamEmailNotifications = "pm-00000-pam-email-notifications";
+
     /* VFO */
     public const string VFO1Foundation = "vfo1-foundation";
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42817

## 📔 Objective

Adds the delivery seam PAM's email notifications send through. No email is sent by this PR: it is plumbing the three notification PRs above it consume.

- `IAccessMailNotifier` resolves recipient addresses and sends via `IMailer`, gated on `FeatureFlagKeys.Pam`.
- **It never throws.** `Mailer.SendEmail` reaches `IMailDeliveryService` with no queue in between, so a send that propagated would fail the enclosing access-request command: a mail outage would stop people getting access to their own vault items. Every send and every user read is caught and logged.
- The batch overload sends one message per recipient rather than one with many `ToEmails`, so an organization's approvers are not disclosed to each other.
- Logs carry user ids only, never an address.
- `IAccessMailNotifier` has no caller until the PR above this one. Registered, tested, and deliberately dormant.

Bottom of a four PR stack on `pam/uat`. Nothing sits below it.

## 📸 Screenshots
