### PR TITLE
Email the requester when their access request is decided

### DIFF
--- a/bitwarden_license/src/Services/Pam/OrganizationFeatures/Commands/DecideAccessRequestCommand.cs
+++ b/bitwarden_license/src/Services/Pam/OrganizationFeatures/Commands/DecideAccessRequestCommand.cs
@@ -15,6 +15,7 @@ public class DecideAccessRequestCommand : IDecideAccessRequestCommand
     private readonly IApproverCollectionAccessQuery _approverCollectionAccessQuery;
     private readonly IApproverInboxNotifier _approverInboxNotifier;
     private readonly IRequesterNotifier _requesterNotifier;
+    private readonly IRequesterMailNotifier _requesterMailNotifier;
     private readonly IAccessAuditEventEmitter _accessAuditEventEmitter;
     private readonly TimeProvider _timeProvider;
 
@@ -23,6 +24,7 @@ public class DecideAccessRequestCommand : IDecideAccessRequestCommand
         IApproverCollectionAccessQuery approverCollectionAccessQuery,
         IApproverInboxNotifier approverInboxNotifier,
         IRequesterNotifier requesterNotifier,
+        IRequesterMailNotifier requesterMailNotifier,
         IAccessAuditEventEmitter accessAuditEventEmitter,
         TimeProvider timeProvider)
     {
@@ -30,6 +32,7 @@ public class DecideAccessRequestCommand : IDecideAccessRequestCommand
         _approverCollectionAccessQuery = approverCollectionAccessQuery;
         _approverInboxNotifier = approverInboxNotifier;
         _requesterNotifier = requesterNotifier;
+        _requesterMailNotifier = requesterMailNotifier;
         _accessAuditEventEmitter = accessAuditEventEmitter;
         _timeProvider = timeProvider;
     }
@@ -133,6 +136,10 @@ public class DecideAccessRequestCommand : IDecideAccessRequestCommand
         // Tell the requester their request was resolved, so their "My requests" view flips to approved/denied and
         // an approval becomes activatable without a manual refresh.
         await _requesterNotifier.NotifyRequesterAsync(request.RequesterId);
+
+        // The same news out of band, to the requester alone: the push only lands on a client that is already open,
+        // and the approver is the actor here rather than an audience.
+        await _requesterMailNotifier.NotifyDecisionAsync(request, approved);
 
         // The client repaints the row from Status, ResolvedAt, and the single Decisions element (verdict + comment),
         // so those must be accurate; the approver's denormalized name/email is resolved on the next read. Project

--- a/bitwarden_license/src/Services/Pam/Services/IRequesterMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/IRequesterMailNotifier.cs
@@ -1,0 +1,30 @@
+﻿using Bit.Pam.Entities;
+
+namespace Bit.Services.Pam.Services;
+
+/// <summary>
+/// Emails a requester the verdict on their pending access request — the out-of-band twin of the
+/// <c>RefreshAccessRequest</c> push that <see cref="IRequesterNotifier" /> sends. The push only reaches a client that
+/// is already open, so without this the answer someone is blocked on is visible nowhere but the web vault they would
+/// have to keep watching.
+/// </summary>
+/// <remarks>
+/// The requester is the only recipient. The approver is the actor — they just pressed the button — and mailing
+/// someone about their own action is the noise that gets a notification channel muted, so the approver's identity is
+/// not a parameter here and cannot reach a recipient list.
+///
+/// Like <see cref="IAccessMailNotifier" />, it never throws: the call sits inside the command that records the
+/// decision, and a mail outage must not fail an approval that has already been written.
+/// </remarks>
+public interface IRequesterMailNotifier
+{
+    /// <summary>
+    /// Tells <paramref name="request" />'s requester that it was resolved.
+    /// </summary>
+    /// <param name="request">The request just resolved. Its <c>Action</c> may not be stamped yet at the call site.</param>
+    /// <param name="approved">
+    /// The verdict, passed rather than read from <paramref name="request" /> for that reason. It selects one of the
+    /// mail's two bodies; an approval is a startable approval, not access already granted.
+    /// </param>
+    Task NotifyDecisionAsync(AccessRequest request, bool approved);
+}

--- a/bitwarden_license/src/Services/Pam/Services/IRequesterMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/IRequesterMailNotifier.cs
@@ -3,28 +3,20 @@
 namespace Bit.Services.Pam.Services;
 
 /// <summary>
-/// Emails a requester the verdict on their pending access request — the out-of-band twin of the
-/// <c>RefreshAccessRequest</c> push that <see cref="IRequesterNotifier" /> sends. The push only reaches a client that
-/// is already open, so without this the answer someone is blocked on is visible nowhere but the web vault they would
-/// have to keep watching.
+/// Emails a requester the verdict on their pending access request: the out-of-band twin of the
+/// <c>RefreshAccessRequest</c> push from <see cref="IRequesterNotifier" />, which only reaches a client that is
+/// already open.
 /// </summary>
 /// <remarks>
-/// The requester is the only recipient. The approver is the actor — they just pressed the button — and mailing
-/// someone about their own action is the noise that gets a notification channel muted, so the approver's identity is
-/// not a parameter here and cannot reach a recipient list.
+/// The requester is the only recipient. The approver just pressed the button, so their identity is not a parameter
+/// here and cannot reach a recipient list.
 ///
 /// Like <see cref="IAccessMailNotifier" />, it never throws: the call sits inside the command that records the
 /// decision, and a mail outage must not fail an approval that has already been written.
 /// </remarks>
 public interface IRequesterMailNotifier
 {
-    /// <summary>
-    /// Tells <paramref name="request" />'s requester that it was resolved.
-    /// </summary>
     /// <param name="request">The request just resolved. Its <c>Action</c> may not be stamped yet at the call site.</param>
-    /// <param name="approved">
-    /// The verdict, passed rather than read from <paramref name="request" /> for that reason. It selects one of the
-    /// mail's two bodies; an approval is a startable approval, not access already granted.
-    /// </param>
+    /// <param name="approved">The verdict, passed rather than read from <paramref name="request" /> for that reason.</param>
     Task NotifyDecisionAsync(AccessRequest request, bool approved);
 }

--- a/bitwarden_license/src/Services/Pam/Services/RequesterMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/RequesterMailNotifier.cs
@@ -32,8 +32,8 @@ public class RequesterMailNotifier : IRequesterMailNotifier
     public async Task NotifyDecisionAsync(AccessRequest request, bool approved)
     {
         // Duplicates the guard inside IAccessMailNotifier to keep the organization read off every decision in the
-        // flag-off state — which is every decision on self-host, and every decision in cloud until the flag is on.
-        if (!_featureService.IsEnabled(FeatureFlagKeys.PamEmailNotifications))
+        // flag-off state — which is every decision on self-host.
+        if (!_featureService.IsEnabled(FeatureFlagKeys.Pam))
         {
             return;
         }

--- a/bitwarden_license/src/Services/Pam/Services/RequesterMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/RequesterMailNotifier.cs
@@ -32,7 +32,7 @@ public class RequesterMailNotifier : IRequesterMailNotifier
     public async Task NotifyDecisionAsync(AccessRequest request, bool approved)
     {
         // Duplicates the guard inside IAccessMailNotifier to keep the organization read off every decision in the
-        // flag-off state — which is every decision on self-host.
+        // flag-off state, which is every decision on self-host.
         if (!_featureService.IsEnabled(FeatureFlagKeys.Pam))
         {
             return;

--- a/bitwarden_license/src/Services/Pam/Services/RequesterMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/RequesterMailNotifier.cs
@@ -1,0 +1,72 @@
+﻿using Bit.Core;
+using Bit.Core.Pam.Models.Mail.AccessRequestDecided;
+using Bit.Core.Repositories;
+using Bit.Core.Settings;
+using Bit.Pam.Entities;
+using Bitwarden.Server.Sdk.Features;
+
+namespace Bit.Services.Pam.Services;
+
+public class RequesterMailNotifier : IRequesterMailNotifier
+{
+    private readonly IAccessMailNotifier _accessMailNotifier;
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly IGlobalSettings _globalSettings;
+    private readonly IFeatureService _featureService;
+    private readonly ILogger<RequesterMailNotifier> _logger;
+
+    public RequesterMailNotifier(
+        IAccessMailNotifier accessMailNotifier,
+        IOrganizationRepository organizationRepository,
+        IGlobalSettings globalSettings,
+        IFeatureService featureService,
+        ILogger<RequesterMailNotifier> logger)
+    {
+        _accessMailNotifier = accessMailNotifier;
+        _organizationRepository = organizationRepository;
+        _globalSettings = globalSettings;
+        _featureService = featureService;
+        _logger = logger;
+    }
+
+    public async Task NotifyDecisionAsync(AccessRequest request, bool approved)
+    {
+        // Duplicates the guard inside IAccessMailNotifier to keep the organization read off every decision in the
+        // flag-off state — which is every decision on self-host, and every decision in cloud until the flag is on.
+        if (!_featureService.IsEnabled(FeatureFlagKeys.PamEmailNotifications))
+        {
+            return;
+        }
+
+        try
+        {
+            var organization = await _organizationRepository.GetByIdAsync(request.OrganizationId);
+            if (organization is null)
+            {
+                _logger.LogWarning(
+                    "PAM decision mail for access request {AccessRequestId}: organization could not be resolved; nothing sent.",
+                    request.Id);
+                return;
+            }
+
+            var view = new AccessRequestDecidedView
+            {
+                WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
+                AccessRequestId = request.Id,
+                OrganizationName = organization.Name,
+                Approved = approved,
+                NotBefore = request.NotBefore,
+                NotAfter = request.NotAfter,
+            };
+
+            await _accessMailNotifier.SendToUserAsync(
+                request.RequesterId, email => new AccessRequestDecidedMail(email, view));
+        }
+        catch (Exception ex)
+        {
+            // Ids only: not the requester's address, and never the request's reason or the approver's comment.
+            _logger.LogError(ex,
+                "PAM decision mail for access request {AccessRequestId} could not be sent.", request.Id);
+        }
+    }
+}

--- a/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
@@ -89,6 +89,7 @@ public static class ServiceCollectionExtensions
 
         services.TryAddScoped<IAccessMailNotifier, AccessMailNotifier>();
         services.TryAddScoped<IApproverMailNotifier, ApproverMailNotifier>();
+        services.TryAddScoped<IRequesterMailNotifier, RequesterMailNotifier>();
 
         // Runs on every connector-facing route (see PamEndpointsExtensions.WithPamAccessConnectorMachineDefaults).
         // Its

--- a/bitwarden_license/test/Services/Pam.Test/Commands/DecideAccessRequestCommandTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Commands/DecideAccessRequestCommandTests.cs
@@ -95,6 +95,8 @@ public class DecideAccessRequestCommandTests
             .ResolveWithDecisionAsync(default!, default!, default, default);
         await sutProvider.GetDependency<IRequesterNotifier>().DidNotReceiveWithAnyArgs()
             .NotifyRequesterAsync(default);
+        await sutProvider.GetDependency<IRequesterMailNotifier>().DidNotReceiveWithAnyArgs()
+            .NotifyDecisionAsync(default!, default);
     }
 
     [Theory, BitAutoData]
@@ -168,6 +170,8 @@ public class DecideAccessRequestCommandTests
             .NotifyCollectionApproversAsync(request.CollectionId);
         await sutProvider.GetDependency<IRequesterNotifier>().Received(1)
             .NotifyRequesterAsync(request.RequesterId);
+        await sutProvider.GetDependency<IRequesterMailNotifier>().Received(1)
+            .NotifyDecisionAsync(request, true);
     }
 
     [Theory]
@@ -234,6 +238,8 @@ public class DecideAccessRequestCommandTests
         // A denial reaches the requester too (their "My requests" view flips to denied).
         await sutProvider.GetDependency<IRequesterNotifier>().Received(1)
             .NotifyRequesterAsync(request.RequesterId);
+        await sutProvider.GetDependency<IRequesterMailNotifier>().Received(1)
+            .NotifyDecisionAsync(request, false);
     }
 
     private static AccessDecisionSubmission Approve(string? comment = null) =>

--- a/bitwarden_license/test/Services/Pam.Test/Commands/DecideAccessRequestCommandTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Commands/DecideAccessRequestCommandTests.cs
@@ -235,7 +235,6 @@ public class DecideAccessRequestCommandTests
                 d.Comment == "use the read replica instead"),
             AccessRequestAction.Denied,
             _now);
-        // A denial reaches the requester too (their "My requests" view flips to denied).
         await sutProvider.GetDependency<IRequesterNotifier>().Received(1)
             .NotifyRequesterAsync(request.RequesterId);
         await sutProvider.GetDependency<IRequesterMailNotifier>().Received(1)

--- a/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
@@ -71,10 +71,7 @@ public class RequesterMailNotifierTests
         Assert.Equal($"{_vaultUrl}/pam/requests/{request.Id}", mail.View.Url);
     }
 
-    /// <summary>
-    /// The approver is the actor, not an audience: they pressed the button and already know the outcome. The
-    /// notifier is given no approver identity at all, so the only recipient it can reach is the requester.
-    /// </summary>
+    /// <summary>The notifier is given no approver identity at all, so the requester is the only reachable recipient.</summary>
     [Theory, BitAutoData]
     public async Task NotifyDecisionAsync_MailsTheRequesterAndNobodyElse(AccessRequest request)
     {

--- a/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
@@ -1,0 +1,168 @@
+﻿using Bit.Core;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Pam.Models.Mail.AccessRequestDecided;
+using Bit.Core.Platform.Mail.Mailer;
+using Bit.Core.Repositories;
+using Bit.Core.Settings;
+using Bit.Pam.Entities;
+using Bit.Services.Pam.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bitwarden.Server.Sdk.Features;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Bit.Services.Pam.Test.Services;
+
+[SutProviderCustomize]
+public class RequesterMailNotifierTests
+{
+    private const string _vaultUrl = "https://vault.example.com/#";
+    private const string _organizationName = "Contoso";
+
+    [Theory, BitAutoData]
+    public async Task NotifyDecisionAsync_FlagOff_ReadsNothingAndSendsNothing(AccessRequest request)
+    {
+        var sutProvider = Setup(flagOn: false);
+
+        await sutProvider.Sut.NotifyDecisionAsync(request, approved: true);
+
+        await sutProvider.GetDependency<IOrganizationRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(default);
+        await sutProvider.GetDependency<IAccessMailNotifier>().DidNotReceiveWithAnyArgs()
+            .SendToUserAsync(default, (Func<string, BaseMail<AccessRequestDecidedView>>)default!);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyDecisionAsync_Approved_SendsTheApprovedVerdictAndTheWindow(AccessRequest request)
+    {
+        request.NotBefore = new DateTime(2026, 9, 1, 8, 30, 0, DateTimeKind.Utc);
+        request.NotAfter = new DateTime(2026, 9, 1, 17, 0, 0, DateTimeKind.Utc);
+
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, request);
+        var recorder = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyDecisionAsync(request, approved: true);
+
+        var (recipientId, mail) = Assert.Single(recorder.Sent);
+        Assert.Equal(request.RequesterId, recipientId);
+        Assert.True(mail.View.Approved);
+        Assert.Equal("Your access request was approved", mail.Subject);
+        Assert.Equal(_organizationName, mail.View.OrganizationName);
+        Assert.Equal("1 Sep 2026 at 08:30 UTC", mail.View.WindowStart);
+        Assert.Equal("1 Sep 2026 at 17:00 UTC", mail.View.WindowEnd);
+        Assert.Equal($"{_vaultUrl}/privileged-controls/requests/{request.Id}", mail.View.Url);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyDecisionAsync_Denied_SendsTheDeniedVerdictToTheSameAddress(AccessRequest request)
+    {
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, request);
+        var recorder = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyDecisionAsync(request, approved: false);
+
+        var (recipientId, mail) = Assert.Single(recorder.Sent);
+        Assert.Equal(request.RequesterId, recipientId);
+        Assert.False(mail.View.Approved);
+        Assert.Equal("Your access request was denied", mail.Subject);
+        Assert.Equal($"{_vaultUrl}/privileged-controls/requests/{request.Id}", mail.View.Url);
+    }
+
+    /// <summary>
+    /// The approver is the actor, not an audience: they pressed the button and already know the outcome. The
+    /// notifier is given no approver identity at all, so the only recipient it can reach is the requester.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task NotifyDecisionAsync_MailsTheRequesterAndNobodyElse(AccessRequest request)
+    {
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, request);
+        var recorder = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyDecisionAsync(request, approved: true);
+
+        var (recipientId, _) = Assert.Single(recorder.Sent);
+        Assert.Equal(request.RequesterId, recipientId);
+        await sutProvider.GetDependency<IAccessMailNotifier>().DidNotReceiveWithAnyArgs()
+            .SendToUsersAsync(default!, (Func<string, BaseMail<AccessRequestDecidedView>>)default!);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyDecisionAsync_UnknownOrganization_SendsNothing(AccessRequest request)
+    {
+        var sutProvider = Setup();
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(request.OrganizationId)
+            .Returns((Organization?)null);
+        var recorder = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyDecisionAsync(request, approved: true);
+
+        Assert.Empty(recorder.Sent);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyDecisionAsync_SendFails_DoesNotPropagate(AccessRequest request)
+    {
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, request);
+        sutProvider.GetDependency<IAccessMailNotifier>()
+            .SendToUserAsync(Arg.Any<Guid>(), Arg.Any<Func<string, BaseMail<AccessRequestDecidedView>>>())
+            .ThrowsAsync(new InvalidOperationException("delivery service unavailable"));
+
+        var exception = await Record.ExceptionAsync(() => sutProvider.Sut.NotifyDecisionAsync(request, approved: true));
+
+        Assert.Null(exception);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyDecisionAsync_OrganizationReadFails_DoesNotPropagate(AccessRequest request)
+    {
+        var sutProvider = Setup();
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(request.OrganizationId)
+            .ThrowsAsync(new TimeoutException("database unavailable"));
+
+        var exception = await Record.ExceptionAsync(() => sutProvider.Sut.NotifyDecisionAsync(request, approved: false));
+
+        Assert.Null(exception);
+    }
+
+    private static SutProvider<RequesterMailNotifier> Setup(bool flagOn = true)
+    {
+        var sutProvider = new SutProvider<RequesterMailNotifier>().Create();
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PamEmailNotifications)
+            .Returns(flagOn);
+        sutProvider.GetDependency<IGlobalSettings>().BaseServiceUri.VaultWithHash.Returns(_vaultUrl);
+
+        return sutProvider;
+    }
+
+    private static void SetupOrganization(SutProvider<RequesterMailNotifier> sutProvider, AccessRequest request) =>
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(request.OrganizationId)
+            .Returns(new Organization { Id = request.OrganizationId, Name = _organizationName });
+
+    private static MailRecorder RecordMail(SutProvider<RequesterMailNotifier> sutProvider)
+    {
+        var recorder = new MailRecorder();
+
+        sutProvider.GetDependency<IAccessMailNotifier>()
+            .When(x => x.SendToUserAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<Func<string, BaseMail<AccessRequestDecidedView>>>()))
+            .Do(call => recorder.Sent.Add((
+                call.Arg<Guid>(),
+                (AccessRequestDecidedMail)call.Arg<Func<string, BaseMail<AccessRequestDecidedView>>>()(
+                    "requester@example.com"))));
+
+        return recorder;
+    }
+
+    private sealed class MailRecorder
+    {
+        public List<(Guid RecipientId, AccessRequestDecidedMail Mail)> Sent { get; } = [];
+    }
+}

--- a/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
@@ -52,7 +52,7 @@ public class RequesterMailNotifierTests
         Assert.Equal(_organizationName, mail.View.OrganizationName);
         Assert.Equal("1 Sep 2026 at 08:30 UTC", mail.View.WindowStart);
         Assert.Equal("1 Sep 2026 at 17:00 UTC", mail.View.WindowEnd);
-        Assert.Equal($"{_vaultUrl}/privileged-controls/requests/{request.Id}", mail.View.Url);
+        Assert.Equal($"{_vaultUrl}/pam/requests/{request.Id}", mail.View.Url);
     }
 
     [Theory, BitAutoData]
@@ -68,7 +68,7 @@ public class RequesterMailNotifierTests
         Assert.Equal(request.RequesterId, recipientId);
         Assert.False(mail.View.Approved);
         Assert.Equal("Your access request was denied", mail.Subject);
-        Assert.Equal($"{_vaultUrl}/privileged-controls/requests/{request.Id}", mail.View.Url);
+        Assert.Equal($"{_vaultUrl}/pam/requests/{request.Id}", mail.View.Url);
     }
 
     /// <summary>

--- a/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
@@ -134,7 +134,7 @@ public class RequesterMailNotifierTests
         var sutProvider = new SutProvider<RequesterMailNotifier>().Create();
 
         sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PamEmailNotifications)
+            .IsEnabled(FeatureFlagKeys.Pam)
             .Returns(flagOn);
         sutProvider.GetDependency<IGlobalSettings>().BaseServiceUri.VaultWithHash.Returns(_vaultUrl);
 

--- a/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/RequesterMailNotifierTests.cs
@@ -41,11 +41,11 @@ public class RequesterMailNotifierTests
 
         var sutProvider = Setup();
         SetupOrganization(sutProvider, request);
-        var recorder = RecordMail(sutProvider);
+        var sent = RecordMail(sutProvider);
 
         await sutProvider.Sut.NotifyDecisionAsync(request, approved: true);
 
-        var (recipientId, mail) = Assert.Single(recorder.Sent);
+        var (recipientId, mail) = Assert.Single(sent);
         Assert.Equal(request.RequesterId, recipientId);
         Assert.True(mail.View.Approved);
         Assert.Equal("Your access request was approved", mail.Subject);
@@ -60,11 +60,11 @@ public class RequesterMailNotifierTests
     {
         var sutProvider = Setup();
         SetupOrganization(sutProvider, request);
-        var recorder = RecordMail(sutProvider);
+        var sent = RecordMail(sutProvider);
 
         await sutProvider.Sut.NotifyDecisionAsync(request, approved: false);
 
-        var (recipientId, mail) = Assert.Single(recorder.Sent);
+        var (recipientId, mail) = Assert.Single(sent);
         Assert.Equal(request.RequesterId, recipientId);
         Assert.False(mail.View.Approved);
         Assert.Equal("Your access request was denied", mail.Subject);
@@ -80,11 +80,11 @@ public class RequesterMailNotifierTests
     {
         var sutProvider = Setup();
         SetupOrganization(sutProvider, request);
-        var recorder = RecordMail(sutProvider);
+        var sent = RecordMail(sutProvider);
 
         await sutProvider.Sut.NotifyDecisionAsync(request, approved: true);
 
-        var (recipientId, _) = Assert.Single(recorder.Sent);
+        var (recipientId, _) = Assert.Single(sent);
         Assert.Equal(request.RequesterId, recipientId);
         await sutProvider.GetDependency<IAccessMailNotifier>().DidNotReceiveWithAnyArgs()
             .SendToUsersAsync(default!, (Func<string, BaseMail<AccessRequestDecidedView>>)default!);
@@ -96,11 +96,11 @@ public class RequesterMailNotifierTests
         var sutProvider = Setup();
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(request.OrganizationId)
             .Returns((Organization?)null);
-        var recorder = RecordMail(sutProvider);
+        var sent = RecordMail(sutProvider);
 
         await sutProvider.Sut.NotifyDecisionAsync(request, approved: true);
 
-        Assert.Empty(recorder.Sent);
+        Assert.Empty(sent);
     }
 
     [Theory, BitAutoData]
@@ -145,24 +145,20 @@ public class RequesterMailNotifierTests
         sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(request.OrganizationId)
             .Returns(new Organization { Id = request.OrganizationId, Name = _organizationName });
 
-    private static MailRecorder RecordMail(SutProvider<RequesterMailNotifier> sutProvider)
+    private static List<(Guid RecipientId, AccessRequestDecidedMail Mail)> RecordMail(
+        SutProvider<RequesterMailNotifier> sutProvider)
     {
-        var recorder = new MailRecorder();
+        List<(Guid RecipientId, AccessRequestDecidedMail Mail)> sent = [];
 
         sutProvider.GetDependency<IAccessMailNotifier>()
             .When(x => x.SendToUserAsync(
                 Arg.Any<Guid>(),
                 Arg.Any<Func<string, BaseMail<AccessRequestDecidedView>>>()))
-            .Do(call => recorder.Sent.Add((
+            .Do(call => sent.Add((
                 call.Arg<Guid>(),
                 (AccessRequestDecidedMail)call.Arg<Func<string, BaseMail<AccessRequestDecidedView>>>()(
                     "requester@example.com"))));
 
-        return recorder;
-    }
-
-    private sealed class MailRecorder
-    {
-        public List<(Guid RecipientId, AccessRequestDecidedMail Mail)> Sent { get; } = [];
+        return sent;
     }
 }

--- a/src/Core/MailTemplates/Mjml/emails/Pam/AccessRequestDecidedView.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/Pam/AccessRequestDecidedView.mjml
@@ -17,7 +17,7 @@
           </mj-text>
           <mj-text padding="0px 0px 16px 0px" font-weight="400" line-height="24px">
             {{#if Approved}}An approver has approved your access request in <b>{{OrganizationName}}</b>. Your access
-            has not started yet &mdash; open the request and start it once the access window below
+            has not started yet. Open the request and start it once the access window below
             opens.{{else}}An approver has declined your access request in <b>{{OrganizationName}}</b>. No access was
             granted.{{/if}}
           </mj-text>

--- a/src/Core/MailTemplates/Mjml/emails/Pam/AccessRequestDecidedView.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/Pam/AccessRequestDecidedView.mjml
@@ -17,8 +17,8 @@
           </mj-text>
           <mj-text padding="0px 0px 16px 0px" font-weight="400" line-height="24px">
             {{#if Approved}}An approver has approved your access request in <b>{{OrganizationName}}</b>. Your access
-            has not started yet &mdash; open the request and start it when you are ready to use
-            it.{{else}}An approver has declined your access request in <b>{{OrganizationName}}</b>. No access was
+            has not started yet &mdash; open the request and start it once the access window below
+            opens.{{else}}An approver has declined your access request in <b>{{OrganizationName}}</b>. No access was
             granted.{{/if}}
           </mj-text>
           <mj-text padding="0px 0px 24px 0px" font-weight="400" line-height="24px">
@@ -35,9 +35,10 @@
             >{{#if Approved}}Start access{{else}}View the request{{/if}}</mj-button
           >
           <mj-text padding="0px" font-size="12px" font-weight="400" line-height="24px">
-            {{#if Approved}}Starting access is what grants it. If you do not start it before the window above ends,
-            the approval lapses and you will need to ask again.{{else}}Any comment the approver left is on the
-            request. The item and the reason you gave are not included in this email.{{/if}}
+            {{#if Approved}}Starting access is what grants it, and you cannot start it before the window above
+            begins. If you do not start it before that window ends, the approval lapses and you will need to ask
+            again.{{else}}Any comment the approver left is on the request. The item and the reason you gave are not
+            included in this email.{{/if}}
           </mj-text>
         </mj-column>
       </mj-section>

--- a/src/Core/MailTemplates/Mjml/emails/Pam/AccessRequestDecidedView.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/Pam/AccessRequestDecidedView.mjml
@@ -1,0 +1,51 @@
+<mjml>
+  <mj-head>
+    <mj-include path="../../components/head.mjml" />
+  </mj-head>
+  <mj-body>
+    <!-- Blue Header Section -->
+    <mj-wrapper css-class="border-fix" padding="20px 24px 0px 24px">
+      <mj-bw-simple-hero />
+    </mj-wrapper>
+
+    <!-- Main Content -->
+    <mj-wrapper padding="0px 25px">
+      <mj-section background-color="#fff" padding="24px 0px">
+        <mj-column padding="0px 25px">
+          <mj-text padding="0px 0px 16px 0px" font-weight="600" font-size="18px" line-height="28px">
+            {{#if Approved}}Your access request was approved{{else}}Your access request was denied{{/if}}
+          </mj-text>
+          <mj-text padding="0px 0px 16px 0px" font-weight="400" line-height="24px">
+            {{#if Approved}}An approver has approved your access request in <b>{{OrganizationName}}</b>. Your access
+            has not started yet &mdash; open the request and start it when you are ready to use
+            it.{{else}}An approver has declined your access request in <b>{{OrganizationName}}</b>. No access was
+            granted.{{/if}}
+          </mj-text>
+          <mj-text padding="0px 0px 24px 0px" font-weight="400" line-height="24px">
+            <b>{{#if Approved}}Approved access window{{else}}Requested access window{{/if}}</b><br />
+            {{WindowStart}} &ndash; {{WindowEnd}}
+          </mj-text>
+          <mj-button
+            padding="0px 0px 24px 0px"
+            inner-padding="12px 24px"
+            border-radius="20px"
+            font-weight="600"
+            align="left"
+            href="{{{Url}}}"
+            >{{#if Approved}}Start access{{else}}View the request{{/if}}</mj-button
+          >
+          <mj-text padding="0px" font-size="12px" font-weight="400" line-height="24px">
+            {{#if Approved}}Starting access is what grants it. If you do not start it before the window above ends,
+            the approval lapses and you will need to ask again.{{else}}Any comment the approver left is on the
+            request. The item and the reason you gave are not included in this email.{{/if}}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+
+    <!-- Footer -->
+    <mj-wrapper padding-top="15px">
+      <mj-include path="../../components/footer.mjml" />
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.cs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.cs
@@ -49,12 +49,12 @@ public class AccessRequestDecidedView : BaseMailView
 
     /// <summary>
     /// The requester's own view of this one request, which is both where an approval is started and where a denial
-    /// is read. The user-scoped PAM pages mount at <c>privileged-controls</c>
+    /// is read. The user-scoped PAM pages mount at <c>pam</c>
     /// (<c>apps/web/src/app/oss-routing.module.ts:687</c>) and the request page is <c>requests/:id</c> beneath it
     /// (<c>access-requests-routing.module.ts:47</c>). The organization-scoped admin surface under
     /// <c>/organizations/:organizationId/pam</c> is a different route tree and does not serve this page.
     /// </summary>
-    public string Url => $"{WebVaultUrl}/privileged-controls/requests/{AccessRequestId}";
+    public string Url => $"{WebVaultUrl}/pam/requests/{AccessRequestId}";
 
     private static string Format(DateTime instant) => instant.ToString(_windowFormat, CultureInfo.InvariantCulture);
 }

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.cs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.cs
@@ -1,0 +1,78 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Bit.Core.Platform.Mail.Mailer;
+
+namespace Bit.Core.Pam.Models.Mail.AccessRequestDecided;
+
+/// <summary>
+/// The requester's answer: their pending access request was approved or denied. One view with one template behind
+/// it, branching on <see cref="Approved" /> — the two verdicts share every other field, and splitting them would let
+/// the shared half drift.
+/// </summary>
+/// <remarks>
+/// Bounded by zero knowledge in the same way <c>AccessRequestPendingView</c> is: the collection and cipher are named
+/// only by ciphertext the server cannot read. The approver's comment is left out for the same reason
+/// <c>AccessRequest.Reason</c> is — free text that would name the system being accessed, rendered into an HTML mail
+/// body. <see cref="Url" /> carries the recipient to all of it.
+/// </remarks>
+public class AccessRequestDecidedView : BaseMailView
+{
+    /// <summary>
+    /// UTC is spelled out in the rendered string. There is no per-recipient timezone on this path, so an
+    /// unqualified instant would be read as local time and would misstate when an approval stops being startable.
+    /// </summary>
+    private const string _windowFormat = "d MMM yyyy 'at' HH:mm 'UTC'";
+
+    public required string WebVaultUrl { get; init; }
+
+    public required Guid AccessRequestId { get; init; }
+
+    /// <summary>Plaintext, unlike the collection and cipher names this mail deliberately omits.</summary>
+    public required string OrganizationName { get; init; }
+
+    /// <summary>
+    /// The verdict, and the only field the two bodies disagree on. An approval is not access: it is a startable
+    /// approval until the requester activates it (<c>ActivateAccessRequestCommand</c> is what mints the lease), so
+    /// the approved body must not say access has begun.
+    /// </summary>
+    public required bool Approved { get; init; }
+
+    /// <summary>The start of the decided window, in UTC — <c>AccessRequest.NotBefore</c> is normalised before storage.</summary>
+    public required DateTime NotBefore { get; init; }
+
+    /// <summary>The end of the decided window, in UTC — <c>AccessRequest.NotAfter</c> is normalised before storage.</summary>
+    public required DateTime NotAfter { get; init; }
+
+    public string WindowStart => Format(NotBefore);
+
+    public string WindowEnd => Format(NotAfter);
+
+    /// <summary>
+    /// The requester's own view of this one request, which is both where an approval is started and where a denial
+    /// is read. The user-scoped PAM pages mount at <c>privileged-controls</c>
+    /// (<c>apps/web/src/app/oss-routing.module.ts:687</c>) and the request page is <c>requests/:id</c> beneath it
+    /// (<c>access-requests-routing.module.ts:47</c>). The organization-scoped admin surface under
+    /// <c>/organizations/:organizationId/pam</c> is a different route tree and does not serve this page.
+    /// </summary>
+    public string Url => $"{WebVaultUrl}/privileged-controls/requests/{AccessRequestId}";
+
+    private static string Format(DateTime instant) => instant.ToString(_windowFormat, CultureInfo.InvariantCulture);
+}
+
+public class AccessRequestDecidedMail : BaseMail<AccessRequestDecidedView>
+{
+    /// <summary>
+    /// Takes the view rather than being object-initialised like its neighbours because the subject carries the
+    /// verdict, and <see cref="Subject" /> is a stored property that cannot derive from <see cref="BaseMail{T}.View" />.
+    /// The alternative — a constant subject — drops the answer from the one line a blocked requester reads first.
+    /// </summary>
+    [SetsRequiredMembers]
+    public AccessRequestDecidedMail(string toEmail, AccessRequestDecidedView view)
+    {
+        ToEmails = [toEmail];
+        View = view;
+        Subject = view.Approved ? "Your access request was approved" : "Your access request was denied";
+    }
+
+    public override string Subject { get; set; }
+}

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.cs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.cs
@@ -5,21 +5,20 @@ using Bit.Core.Platform.Mail.Mailer;
 namespace Bit.Core.Pam.Models.Mail.AccessRequestDecided;
 
 /// <summary>
-/// The requester's answer: their pending access request was approved or denied. One view with one template behind
-/// it, branching on <see cref="Approved" /> — the two verdicts share every other field, and splitting them would let
-/// the shared half drift.
+/// The requester's answer: their pending access request was approved or denied. One view and one template branching
+/// on <see cref="Approved" />, since splitting the two verdicts would let their shared half drift.
 /// </summary>
 /// <remarks>
 /// Bounded by zero knowledge in the same way <c>AccessRequestPendingView</c> is: the collection and cipher are named
-/// only by ciphertext the server cannot read. The approver's comment is left out for the same reason
-/// <c>AccessRequest.Reason</c> is — free text that would name the system being accessed, rendered into an HTML mail
-/// body. <see cref="Url" /> carries the recipient to all of it.
+/// only by ciphertext the server cannot read. The approver's comment is withheld for the same reason
+/// <c>AccessRequest.Reason</c> is, being free text that would name the system being accessed.
+/// <see cref="Url" /> carries the recipient to all of it.
 /// </remarks>
 public class AccessRequestDecidedView : BaseMailView
 {
     /// <summary>
-    /// UTC is spelled out in the rendered string. There is no per-recipient timezone on this path, so an
-    /// unqualified instant would be read as local time and would misstate when an approval stops being startable.
+    /// UTC is spelled out in the rendered string: there is no per-recipient timezone on this path, so an unqualified
+    /// instant would be read as local time and misstate when an approval stops being startable.
     /// </summary>
     private const string _windowFormat = "d MMM yyyy 'at' HH:mm 'UTC'";
 
@@ -27,20 +26,16 @@ public class AccessRequestDecidedView : BaseMailView
 
     public required Guid AccessRequestId { get; init; }
 
-    /// <summary>Plaintext, unlike the collection and cipher names this mail deliberately omits.</summary>
     public required string OrganizationName { get; init; }
 
     /// <summary>
-    /// The verdict, and the only field the two bodies disagree on. An approval is not access: it is a startable
-    /// approval until the requester activates it (<c>ActivateAccessRequestCommand</c> is what mints the lease), so
-    /// the approved body must not say access has begun.
+    /// An approval is not access: it stays a startable approval until the requester activates it
+    /// (<c>ActivateAccessRequestCommand</c> mints the lease), so the approved body must not say access has begun.
     /// </summary>
     public required bool Approved { get; init; }
 
-    /// <summary>The start of the decided window, in UTC — <c>AccessRequest.NotBefore</c> is normalised before storage.</summary>
     public required DateTime NotBefore { get; init; }
 
-    /// <summary>The end of the decided window, in UTC — <c>AccessRequest.NotAfter</c> is normalised before storage.</summary>
     public required DateTime NotAfter { get; init; }
 
     public string WindowStart => Format(NotBefore);
@@ -48,10 +43,9 @@ public class AccessRequestDecidedView : BaseMailView
     public string WindowEnd => Format(NotAfter);
 
     /// <summary>
-    /// The requester's own view of this one request, which is both where an approval is started and where a denial
-    /// is read. The user-scoped PAM pages mount at <c>pam</c>
-    /// (<c>apps/web/src/app/oss-routing.module.ts:687</c>) and the request page is <c>requests/:id</c> beneath it
-    /// (<c>access-requests-routing.module.ts:47</c>). The organization-scoped admin surface under
+    /// Where an approval is started and where a denial is read. The user-scoped PAM pages mount at <c>pam</c>
+    /// (<c>apps/web/src/app/oss-routing.module.ts:687</c>) with the request page at <c>requests/:id</c> beneath it
+    /// (<c>access-requests-routing.module.ts:47</c>). The organization-scoped tree under
     /// <c>/organizations/:organizationId/pam</c> is a different route tree and does not serve this page.
     /// </summary>
     public string Url => $"{WebVaultUrl}/pam/requests/{AccessRequestId}";
@@ -64,7 +58,6 @@ public class AccessRequestDecidedMail : BaseMail<AccessRequestDecidedView>
     /// <summary>
     /// Takes the view rather than being object-initialised like its neighbours because the subject carries the
     /// verdict, and <see cref="Subject" /> is a stored property that cannot derive from <see cref="BaseMail{T}.View" />.
-    /// The alternative — a constant subject — drops the answer from the one line a blocked requester reads first.
     /// </summary>
     [SetsRequiredMembers]
     public AccessRequestDecidedMail(string toEmail, AccessRequestDecidedView view)

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.html.hbs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.html.hbs
@@ -196,7 +196,7 @@
                 <td align="left" style="font-size:0px;padding:0px 0px 16px 0px;word-break:break-word;">
                   
       <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">{{#if Approved}}An approver has approved your access request in <b>{{OrganizationName}}</b>. Your access
-            has not started yet &mdash; open the request and start it once the access window below
+            has not started yet. Open the request and start it once the access window below
             opens.{{else}}An approver has declined your access request in <b>{{OrganizationName}}</b>. No access was
             granted.{{/if}}</div>
     

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.html.hbs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.html.hbs
@@ -1,0 +1,519 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 24px 0px 24px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:612px;" width="612" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:612px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:572px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 25px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:610px;" width="610" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:610px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:24px 0px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:610px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+        <tbody>
+          <tr>
+            <td style="vertical-align:top;padding:0px 25px;">
+              
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 0px 16px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:18px;font-weight:600;line-height:28px;text-align:left;color:#1B2029;">{{#if Approved}}Your access request was approved{{else}}Your access request was denied{{/if}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 0px 16px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">{{#if Approved}}An approver has approved your access request in <b>{{OrganizationName}}</b>. Your access
+            has not started yet &mdash; open the request and start it when you are ready to use
+            it.{{else}}An approver has declined your access request in <b>{{OrganizationName}}</b>. No access was
+            granted.{{/if}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 0px 24px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><b>{{#if Approved}}Approved access window{{else}}Requested access window{{/if}}</b><br>
+            {{WindowStart}} &ndash; {{WindowEnd}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 0px 24px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#175ddc" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#175ddc;" valign="middle">
+              <a href="{{{Url}}}" style="display:inline-block;background:#175ddc;color:#ffffff;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                {{#if Approved}}Start access{{else}}View the request{{/if}}
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">{{#if Approved}}Starting access is what grants it. If you do not start it before the window above ends,
+            the approval lapses and you will need to ask again.{{else}}Any comment the approver left is on the
+            request. The item and the reason you gave are not included in this email.{{/if}}</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;padding-top:15px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102,
+        Santa Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration: none; color: #175ddc; font-weight: 400">bitwarden.com</a>
+        |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration: none; color: #175ddc; font-weight: 400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.html.hbs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.html.hbs
@@ -196,8 +196,8 @@
                 <td align="left" style="font-size:0px;padding:0px 0px 16px 0px;word-break:break-word;">
                   
       <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">{{#if Approved}}An approver has approved your access request in <b>{{OrganizationName}}</b>. Your access
-            has not started yet &mdash; open the request and start it when you are ready to use
-            it.{{else}}An approver has declined your access request in <b>{{OrganizationName}}</b>. No access was
+            has not started yet &mdash; open the request and start it once the access window below
+            opens.{{else}}An approver has declined your access request in <b>{{OrganizationName}}</b>. No access was
             granted.{{/if}}</div>
     
                 </td>
@@ -233,9 +233,10 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0px;word-break:break-word;">
                   
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">{{#if Approved}}Starting access is what grants it. If you do not start it before the window above ends,
-            the approval lapses and you will need to ask again.{{else}}Any comment the approver left is on the
-            request. The item and the reason you gave are not included in this email.{{/if}}</div>
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">{{#if Approved}}Starting access is what grants it, and you cannot start it before the window above
+            begins. If you do not start it before that window ends, the approval lapses and you will need to ask
+            again.{{else}}Any comment the approver left is on the request. The item and the reason you gave are not
+            included in this email.{{/if}}</div>
     
                 </td>
               </tr>

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.text.hbs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.text.hbs
@@ -1,12 +1,12 @@
 {{#if Approved}}Your access request was approved
 
-An approver has approved your access request in {{OrganizationName}}. Your access has not started yet - open the request and start it when you are ready to use it.
+An approver has approved your access request in {{OrganizationName}}. Your access has not started yet - open the request and start it once the access window below opens.
 
 Approved access window: {{WindowStart}} - {{WindowEnd}}
 
 Start access: {{Url}}
 
-Starting access is what grants it. If you do not start it before the window above ends, the approval lapses and you will need to ask again.
+Starting access is what grants it, and you cannot start it before the window above begins. If you do not start it before that window ends, the approval lapses and you will need to ask again.
 {{else}}Your access request was denied
 
 An approver has declined your access request in {{OrganizationName}}. No access was granted.

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.text.hbs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.text.hbs
@@ -1,6 +1,6 @@
 {{#if Approved}}Your access request was approved
 
-An approver has approved your access request in {{OrganizationName}}. Your access has not started yet - open the request and start it once the access window below opens.
+An approver has approved your access request in {{OrganizationName}}. Your access has not started yet. Open the request and start it once the access window below opens.
 
 Approved access window: {{WindowStart}} - {{WindowEnd}}
 

--- a/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.text.hbs
+++ b/src/Core/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedView.text.hbs
@@ -1,0 +1,19 @@
+{{#if Approved}}Your access request was approved
+
+An approver has approved your access request in {{OrganizationName}}. Your access has not started yet - open the request and start it when you are ready to use it.
+
+Approved access window: {{WindowStart}} - {{WindowEnd}}
+
+Start access: {{Url}}
+
+Starting access is what grants it. If you do not start it before the window above ends, the approval lapses and you will need to ask again.
+{{else}}Your access request was denied
+
+An approver has declined your access request in {{OrganizationName}}. No access was granted.
+
+Requested access window: {{WindowStart}} - {{WindowEnd}}
+
+View the request: {{Url}}
+
+Any comment the approver left is on the request. The item and the reason you gave are not included in this email.
+{{/if}}

--- a/test/Core.Test/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedViewTests.cs
+++ b/test/Core.Test/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedViewTests.cs
@@ -31,7 +31,7 @@ public class AccessRequestDecidedViewTests
             Assert.Contains("Contoso", body);
             Assert.Contains("1 Sep 2026 at 08:30 UTC", body);
             Assert.Contains("1 Sep 2026 at 17:00 UTC", body);
-            Assert.Contains($"https://vault.example.com/#/privileged-controls/requests/{_requestId}", body);
+            Assert.Contains($"https://vault.example.com/#/pam/requests/{_requestId}", body);
             Assert.DoesNotContain("declined", body);
             Assert.DoesNotContain("was denied", body);
         }
@@ -47,7 +47,7 @@ public class AccessRequestDecidedViewTests
             Assert.Contains("was denied", body);
             Assert.Contains("declined", body);
             Assert.Contains("No access was granted", body);
-            Assert.Contains($"https://vault.example.com/#/privileged-controls/requests/{_requestId}", body);
+            Assert.Contains($"https://vault.example.com/#/pam/requests/{_requestId}", body);
             Assert.DoesNotContain("approved", body);
             Assert.DoesNotContain("Start access", body);
         }
@@ -79,7 +79,7 @@ public class AccessRequestDecidedViewTests
     [Fact]
     public void Url_TargetsTheRequestersOwnRequestPage() =>
         Assert.Equal(
-            $"https://vault.example.com/#/privileged-controls/requests/{_requestId}",
+            $"https://vault.example.com/#/pam/requests/{_requestId}",
             View(approved: true).Url);
 
     [Theory]

--- a/test/Core.Test/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedViewTests.cs
+++ b/test/Core.Test/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedViewTests.cs
@@ -1,0 +1,109 @@
+﻿using System.Text.RegularExpressions;
+using Bit.Core.Pam.Models.Mail.AccessRequestDecided;
+using Bit.Core.Platform.Mail.Mailer;
+using Bit.Core.Settings;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Pam.Models.Mail.AccessRequestDecided;
+
+public class AccessRequestDecidedViewTests
+{
+    private static readonly Guid _requestId = Guid.Parse("2c9a4f10-7b6e-4d33-9c21-5a8e0f1d3b47");
+
+    /// <summary>
+    /// <see cref="HandlebarMailRenderer" /> resolves both templates from the view's full class name and only fails
+    /// when a mail is actually sent, which no other spec in this feature reaches. This is the spec that catches a
+    /// misnamed or misplaced <c>.hbs</c>.
+    /// </summary>
+    [Fact]
+    public async Task RenderAsync_Approved_SaysApprovedAndDoesNotClaimAccessHasStarted()
+    {
+        var (html, text) = await RenderAsync(View(approved: true));
+
+        foreach (var body in new[] { Reflow(html), Reflow(text) })
+        {
+            Assert.Contains("was approved", body);
+            Assert.Contains("has not started yet", body);
+            Assert.Contains("Start access", body);
+            Assert.Contains("Contoso", body);
+            Assert.Contains("1 Sep 2026 at 08:30 UTC", body);
+            Assert.Contains("1 Sep 2026 at 17:00 UTC", body);
+            Assert.Contains($"https://vault.example.com/#/privileged-controls/requests/{_requestId}", body);
+            Assert.DoesNotContain("declined", body);
+            Assert.DoesNotContain("was denied", body);
+        }
+    }
+
+    [Fact]
+    public async Task RenderAsync_Denied_SaysDeclinedAndOffersNoAccessToStart()
+    {
+        var (html, text) = await RenderAsync(View(approved: false));
+
+        foreach (var body in new[] { Reflow(html), Reflow(text) })
+        {
+            Assert.Contains("was denied", body);
+            Assert.Contains("declined", body);
+            Assert.Contains("No access was granted", body);
+            Assert.Contains($"https://vault.example.com/#/privileged-controls/requests/{_requestId}", body);
+            Assert.DoesNotContain("approved", body);
+            Assert.DoesNotContain("Start access", body);
+        }
+    }
+
+    /// <summary>
+    /// The approver's comment is free text that may name the very system being accessed, so it is linked to rather
+    /// than rendered — the same call the request's reason gets. Nothing on the view can carry it.
+    /// </summary>
+    [Fact]
+    public void View_HasNoPlaceToCarryTheApproverComment() =>
+        Assert.DoesNotContain(
+            typeof(AccessRequestDecidedView).GetProperties(),
+            property => property.Name.Contains("Comment", StringComparison.OrdinalIgnoreCase)
+                || property.Name.Contains("Reason", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// An organization name is member-supplied text, so the HTML body must escape it rather than interpolate it raw.
+    /// </summary>
+    [Fact]
+    public async Task RenderAsync_EscapesTheOrganizationNameInTheHtmlBody()
+    {
+        var (html, _) = await RenderAsync(View(approved: true, organizationName: "<script>alert(1)</script>"));
+
+        Assert.DoesNotContain("<script>alert(1)</script>", html);
+        Assert.Contains("&lt;script&gt;", html);
+    }
+
+    [Fact]
+    public void Url_TargetsTheRequestersOwnRequestPage() =>
+        Assert.Equal(
+            $"https://vault.example.com/#/privileged-controls/requests/{_requestId}",
+            View(approved: true).Url);
+
+    [Theory]
+    [InlineData(true, "Your access request was approved")]
+    [InlineData(false, "Your access request was denied")]
+    public void Subject_CarriesTheVerdict(bool approved, string expected) =>
+        Assert.Equal(expected, new AccessRequestDecidedMail("requester@acme.com", View(approved)).Subject);
+
+    private static AccessRequestDecidedView View(bool approved, string organizationName = "Contoso") => new()
+    {
+        WebVaultUrl = "https://vault.example.com/#",
+        AccessRequestId = _requestId,
+        OrganizationName = organizationName,
+        Approved = approved,
+        NotBefore = new DateTime(2026, 9, 1, 8, 30, 0, DateTimeKind.Utc),
+        NotAfter = new DateTime(2026, 9, 1, 17, 0, 0, DateTimeKind.Utc),
+    };
+
+    /// <summary>
+    /// Both templates wrap their copy across source lines, so a sentence these specs assert on is not contiguous in
+    /// the rendered output. Collapsing runs of whitespace keeps them about the wording rather than the line breaks.
+    /// </summary>
+    private static string Reflow(string body) => Regex.Replace(body, @"\s+", " ");
+
+    private static Task<(string html, string txt)> RenderAsync(BaseMailView view) =>
+        new HandlebarMailRenderer(Substitute.For<ILogger<HandlebarMailRenderer>>(), new GlobalSettings())
+            .RenderAsync(view);
+}

--- a/test/Core.Test/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedViewTests.cs
+++ b/test/Core.Test/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedViewTests.cs
@@ -12,11 +12,7 @@ public class AccessRequestDecidedViewTests
 {
     private static readonly Guid _requestId = Guid.Parse("2c9a4f10-7b6e-4d33-9c21-5a8e0f1d3b47");
 
-    /// <summary>
-    /// <see cref="HandlebarMailRenderer" /> resolves both templates from the view's full class name and only fails
-    /// when a mail is actually sent, which no other spec in this feature reaches. This is the spec that catches a
-    /// misnamed or misplaced <c>.hbs</c>.
-    /// </summary>
+    /// <summary>The only spec that renders, so the only one that catches a misnamed or misplaced <c>.hbs</c>.</summary>
     [Fact]
     public async Task RenderAsync_Approved_SaysApprovedAndDoesNotClaimAccessHasStarted()
     {
@@ -53,10 +49,7 @@ public class AccessRequestDecidedViewTests
         }
     }
 
-    /// <summary>
-    /// The approver's comment is free text that may name the very system being accessed, so it is linked to rather
-    /// than rendered — the same call the request's reason gets. Nothing on the view can carry it.
-    /// </summary>
+    /// <summary>The comment is free text that may name the system being accessed, so it is linked to, not rendered.</summary>
     [Fact]
     public void View_HasNoPlaceToCarryTheApproverComment() =>
         Assert.DoesNotContain(
@@ -64,9 +57,6 @@ public class AccessRequestDecidedViewTests
             property => property.Name.Contains("Comment", StringComparison.OrdinalIgnoreCase)
                 || property.Name.Contains("Reason", StringComparison.OrdinalIgnoreCase));
 
-    /// <summary>
-    /// An organization name is member-supplied text, so the HTML body must escape it rather than interpolate it raw.
-    /// </summary>
     [Fact]
     public async Task RenderAsync_EscapesTheOrganizationNameInTheHtmlBody()
     {
@@ -98,10 +88,7 @@ public class AccessRequestDecidedViewTests
         NotAfter = new DateTime(2026, 9, 1, 17, 0, 0, DateTimeKind.Utc),
     };
 
-    /// <summary>
-    /// Both templates wrap their copy across source lines, so a sentence these specs assert on is not contiguous in
-    /// the rendered output. Collapsing runs of whitespace keeps them about the wording rather than the line breaks.
-    /// </summary>
+    /// <summary>Both templates wrap copy across source lines; collapsing whitespace keeps the specs about wording.</summary>
     private static string Reflow(string body) => Regex.Replace(body, @"\s+", " ");
 
     private static Task<(string html, string txt)> RenderAsync(BaseMailView view) =>

--- a/test/Core.Test/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedViewTests.cs
+++ b/test/Core.Test/Pam/Models/Mail/AccessRequestDecided/AccessRequestDecidedViewTests.cs
@@ -26,6 +26,7 @@ public class AccessRequestDecidedViewTests
         {
             Assert.Contains("was approved", body);
             Assert.Contains("has not started yet", body);
+            Assert.Contains("cannot start it before the window above begins", body);
             Assert.Contains("Start access", body);
             Assert.Contains("Contoso", body);
             Assert.Contains("1 Sep 2026 at 08:30 UTC", body);


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42817

## 📔 Objective

Emails the requester when their pending access request is approved or denied. They are blocked on that answer and currently have nothing to watch but the web vault.

- One mail class, two bodies. The approved body says access has **not** started and that the approval lapses if unused: approval records a verdict, and `ActivateAccessRequestCommand` is what mints the lease.
- Sent to the requester only. The approver is the actor and is never a recipient.
- The approver's comment is not included, for the same reason as the request reason: free text into an HTML body, and it may name the system. It stays on the request.

Third of four in a stack on `pam/uat`. Sits on the approver notification PR.

## 📸 Screenshots
