### PR TITLE
Email the lease holder when an operator revokes their access

### DIFF
--- a/bitwarden_license/src/Services/Pam/OrganizationFeatures/Commands/RevokeAccessLeaseCommand.cs
+++ b/bitwarden_license/src/Services/Pam/OrganizationFeatures/Commands/RevokeAccessLeaseCommand.cs
@@ -15,6 +15,7 @@ public class RevokeAccessLeaseCommand : IRevokeAccessLeaseCommand
     private readonly IApproverCollectionAccessQuery _approverCollectionAccessQuery;
     private readonly IApproverInboxNotifier _approverInboxNotifier;
     private readonly IRequesterNotifier _requesterNotifier;
+    private readonly ILeaseRevokedMailNotifier _leaseRevokedMailNotifier;
     private readonly IAccessAuditEventEmitter _accessAuditEventEmitter;
     private readonly IHandleAccessGrantEndedCommand _handleAccessGrantEndedCommand;
     private readonly TimeProvider _timeProvider;
@@ -25,6 +26,7 @@ public class RevokeAccessLeaseCommand : IRevokeAccessLeaseCommand
         IApproverCollectionAccessQuery approverCollectionAccessQuery,
         IApproverInboxNotifier approverInboxNotifier,
         IRequesterNotifier requesterNotifier,
+        ILeaseRevokedMailNotifier leaseRevokedMailNotifier,
         IAccessAuditEventEmitter accessAuditEventEmitter,
         IHandleAccessGrantEndedCommand handleAccessGrantEndedCommand,
         TimeProvider timeProvider,
@@ -34,6 +36,7 @@ public class RevokeAccessLeaseCommand : IRevokeAccessLeaseCommand
         _approverCollectionAccessQuery = approverCollectionAccessQuery;
         _approverInboxNotifier = approverInboxNotifier;
         _requesterNotifier = requesterNotifier;
+        _leaseRevokedMailNotifier = leaseRevokedMailNotifier;
         _accessAuditEventEmitter = accessAuditEventEmitter;
         _handleAccessGrantEndedCommand = handleAccessGrantEndedCommand;
         _timeProvider = timeProvider;
@@ -123,5 +126,10 @@ public class RevokeAccessLeaseCommand : IRevokeAccessLeaseCommand
         // Tell the lease holder their access ended, so an open cipher re-locks and the banner/badges drop the lease
         // — whether an operator revoked it or the holder ended it from another device.
         await _requesterNotifier.NotifyRequesterAsync(lease.RequesterId);
+
+        // The push above only reaches a client that is already open, so the mail is what a holder mid-task gets. The
+        // notifier is handed endAction and mails only a Revoked one -- a holder is never mailed about their own
+        // cancel, and keeping that rule inside the notifier means an edit here cannot drop it.
+        await _leaseRevokedMailNotifier.NotifyLeaseEndedAsync(lease, endAction);
     }
 }

--- a/bitwarden_license/src/Services/Pam/OrganizationFeatures/Commands/RevokeAccessLeaseCommand.cs
+++ b/bitwarden_license/src/Services/Pam/OrganizationFeatures/Commands/RevokeAccessLeaseCommand.cs
@@ -127,9 +127,8 @@ public class RevokeAccessLeaseCommand : IRevokeAccessLeaseCommand
         // — whether an operator revoked it or the holder ended it from another device.
         await _requesterNotifier.NotifyRequesterAsync(lease.RequesterId);
 
-        // The push above only reaches a client that is already open, so the mail is what a holder mid-task gets. The
-        // notifier is handed endAction and mails only a Revoked one -- a holder is never mailed about their own
-        // cancel, and keeping that rule inside the notifier means an edit here cannot drop it.
+        // The same news out of band: the push above only lands on a client that is already open. Every early end is
+        // handed over, and only a revocation is mailed -- a holder is not mailed about ending their own access.
         await _leaseRevokedMailNotifier.NotifyLeaseEndedAsync(lease, endAction);
     }
 }

--- a/bitwarden_license/src/Services/Pam/Services/ILeaseRevokedMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/ILeaseRevokedMailNotifier.cs
@@ -23,7 +23,7 @@ public interface ILeaseRevokedMailNotifier
     /// </summary>
     /// <remarks>
     /// Handed every early end rather than only the revocations so the rule that a holder is never mailed about
-    /// their own action lives in one place. Mailing someone "your access was ended" seconds after they ended it
+    /// their own action lives in one place. Mailing someone "your access was revoked" seconds after they ended it
     /// themselves is the kind of notification that teaches people to ignore the channel.
     /// </remarks>
     /// <param name="lease">The lease just ended. Its <c>Action</c> may not be stamped yet at the call site.</param>

--- a/bitwarden_license/src/Services/Pam/Services/ILeaseRevokedMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/ILeaseRevokedMailNotifier.cs
@@ -4,9 +4,8 @@ using Bit.Pam.Enums;
 namespace Bit.Services.Pam.Services;
 
 /// <summary>
-/// Emails a lease holder that an operator ended their active access — the out-of-band twin of the
-/// <c>RefreshAccessRequest</c> push that <see cref="IRequesterNotifier" /> sends on the same path. The push has
-/// already re-locked the item on any client that happened to be open; this tells the person mid-task why.
+/// Emails a lease holder that an operator ended their active access: the out-of-band twin of the
+/// <c>RefreshAccessRequest</c> push from <see cref="IRequesterNotifier" /> on the same path.
 /// </summary>
 /// <remarks>
 /// A courtesy, not a security control. The lease is dead server-side before anything here runs, so nothing this
@@ -19,13 +18,9 @@ public interface ILeaseRevokedMailNotifier
 {
     /// <summary>
     /// Tells <paramref name="lease" />'s holder that their access ended, but only when
-    /// <paramref name="endAction" /> is <see cref="AccessLeaseAction.Revoked" />.
+    /// <paramref name="endAction" /> is <see cref="AccessLeaseAction.Revoked" />. The name is neutral because this
+    /// is handed every early end, so the rule that a holder is never mailed about their own action lives here.
     /// </summary>
-    /// <remarks>
-    /// Handed every early end rather than only the revocations so the rule that a holder is never mailed about
-    /// their own action lives in one place. Mailing someone "your access was revoked" seconds after they ended it
-    /// themselves is the kind of notification that teaches people to ignore the channel.
-    /// </remarks>
     /// <param name="lease">The lease just ended. Its <c>Action</c> may not be stamped yet at the call site.</param>
     /// <param name="endAction">
     /// How it ended, passed rather than read from <paramref name="lease" /> for that reason:

--- a/bitwarden_license/src/Services/Pam/Services/ILeaseRevokedMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/ILeaseRevokedMailNotifier.cs
@@ -1,0 +1,36 @@
+﻿using Bit.Pam.Entities;
+using Bit.Pam.Enums;
+
+namespace Bit.Services.Pam.Services;
+
+/// <summary>
+/// Emails a lease holder that an operator ended their active access — the out-of-band twin of the
+/// <c>RefreshAccessRequest</c> push that <see cref="IRequesterNotifier" /> sends on the same path. The push has
+/// already re-locked the item on any client that happened to be open; this tells the person mid-task why.
+/// </summary>
+/// <remarks>
+/// A courtesy, not a security control. The lease is dead server-side before anything here runs, so nothing this
+/// type does or fails to do changes who holds access.
+///
+/// Like <see cref="IAccessMailNotifier" />, it never throws: the call sits at the end of the command that ended
+/// the lease, and a mail outage must not fail a revocation that has already been written.
+/// </remarks>
+public interface ILeaseRevokedMailNotifier
+{
+    /// <summary>
+    /// Tells <paramref name="lease" />'s holder that their access ended, but only when
+    /// <paramref name="endAction" /> is <see cref="AccessLeaseAction.Revoked" />.
+    /// </summary>
+    /// <remarks>
+    /// Handed every early end rather than only the revocations so the rule that a holder is never mailed about
+    /// their own action lives in one place. Mailing someone "your access was ended" seconds after they ended it
+    /// themselves is the kind of notification that teaches people to ignore the channel.
+    /// </remarks>
+    /// <param name="lease">The lease just ended. Its <c>Action</c> may not be stamped yet at the call site.</param>
+    /// <param name="endAction">
+    /// How it ended, passed rather than read from <paramref name="lease" /> for that reason:
+    /// <see cref="AccessLeaseAction.Revoked" /> for an operator, <see cref="AccessLeaseAction.Cancelled" /> for the
+    /// holder ending their own access.
+    /// </param>
+    Task NotifyLeaseEndedAsync(AccessLease lease, AccessLeaseAction endAction);
+}

--- a/bitwarden_license/src/Services/Pam/Services/LeaseRevokedMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/LeaseRevokedMailNotifier.cs
@@ -38,8 +38,8 @@ public class LeaseRevokedMailNotifier : ILeaseRevokedMailNotifier
         }
 
         // Duplicates the guard inside IAccessMailNotifier to keep the organization read off every revocation in the
-        // flag-off state — which is every revocation on self-host, and every one in cloud until the flag is on.
-        if (!_featureService.IsEnabled(FeatureFlagKeys.PamEmailNotifications))
+        // flag-off state — which is every revocation on self-host.
+        if (!_featureService.IsEnabled(FeatureFlagKeys.Pam))
         {
             return;
         }

--- a/bitwarden_license/src/Services/Pam/Services/LeaseRevokedMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/LeaseRevokedMailNotifier.cs
@@ -38,7 +38,7 @@ public class LeaseRevokedMailNotifier : ILeaseRevokedMailNotifier
         }
 
         // Duplicates the guard inside IAccessMailNotifier to keep the organization read off every revocation in the
-        // flag-off state — which is every revocation on self-host.
+        // flag-off state, which is every revocation on self-host.
         if (!_featureService.IsEnabled(FeatureFlagKeys.Pam))
         {
             return;

--- a/bitwarden_license/src/Services/Pam/Services/LeaseRevokedMailNotifier.cs
+++ b/bitwarden_license/src/Services/Pam/Services/LeaseRevokedMailNotifier.cs
@@ -1,0 +1,75 @@
+﻿using Bit.Core;
+using Bit.Core.Pam.Models.Mail.AccessLeaseRevoked;
+using Bit.Core.Repositories;
+using Bit.Core.Settings;
+using Bit.Pam.Entities;
+using Bit.Pam.Enums;
+using Bitwarden.Server.Sdk.Features;
+
+namespace Bit.Services.Pam.Services;
+
+public class LeaseRevokedMailNotifier : ILeaseRevokedMailNotifier
+{
+    private readonly IAccessMailNotifier _accessMailNotifier;
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly IGlobalSettings _globalSettings;
+    private readonly IFeatureService _featureService;
+    private readonly ILogger<LeaseRevokedMailNotifier> _logger;
+
+    public LeaseRevokedMailNotifier(
+        IAccessMailNotifier accessMailNotifier,
+        IOrganizationRepository organizationRepository,
+        IGlobalSettings globalSettings,
+        IFeatureService featureService,
+        ILogger<LeaseRevokedMailNotifier> logger)
+    {
+        _accessMailNotifier = accessMailNotifier;
+        _organizationRepository = organizationRepository;
+        _globalSettings = globalSettings;
+        _featureService = featureService;
+        _logger = logger;
+    }
+
+    public async Task NotifyLeaseEndedAsync(AccessLease lease, AccessLeaseAction endAction)
+    {
+        if (endAction != AccessLeaseAction.Revoked)
+        {
+            return;
+        }
+
+        // Duplicates the guard inside IAccessMailNotifier to keep the organization read off every revocation in the
+        // flag-off state — which is every revocation on self-host, and every one in cloud until the flag is on.
+        if (!_featureService.IsEnabled(FeatureFlagKeys.PamEmailNotifications))
+        {
+            return;
+        }
+
+        try
+        {
+            var organization = await _organizationRepository.GetByIdAsync(lease.OrganizationId);
+            if (organization is null)
+            {
+                _logger.LogWarning(
+                    "PAM lease-revoked mail for lease {AccessLeaseId}: organization could not be resolved; nothing sent.",
+                    lease.Id);
+                return;
+            }
+
+            var view = new AccessLeaseRevokedView
+            {
+                WebVaultUrl = _globalSettings.BaseServiceUri.VaultWithHash,
+                AccessRequestId = lease.AccessRequestId,
+                OrganizationName = organization.Name,
+                NotAfter = lease.NotAfter,
+            };
+
+            await _accessMailNotifier.SendToUserAsync(
+                lease.RequesterId, email => new AccessLeaseRevokedMail { ToEmails = [email], View = view });
+        }
+        catch (Exception ex)
+        {
+            // Ids only: not the holder's address, and never the reason the operator gave for revoking.
+            _logger.LogError(ex, "PAM lease-revoked mail for lease {AccessLeaseId} could not be sent.", lease.Id);
+        }
+    }
+}

--- a/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
+++ b/bitwarden_license/src/Services/Pam/Utilities/ServiceCollectionExtensions.cs
@@ -90,6 +90,7 @@ public static class ServiceCollectionExtensions
         services.TryAddScoped<IAccessMailNotifier, AccessMailNotifier>();
         services.TryAddScoped<IApproverMailNotifier, ApproverMailNotifier>();
         services.TryAddScoped<IRequesterMailNotifier, RequesterMailNotifier>();
+        services.TryAddScoped<ILeaseRevokedMailNotifier, LeaseRevokedMailNotifier>();
 
         // Runs on every connector-facing route (see PamEndpointsExtensions.WithPamAccessConnectorMachineDefaults).
         // Its

--- a/bitwarden_license/test/Services/Pam.Test/Commands/RevokeAccessLeaseCommandTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Commands/RevokeAccessLeaseCommandTests.cs
@@ -67,6 +67,8 @@ public class RevokeAccessLeaseCommandTests
             .NotifyCollectionApproversAsync(lease.CollectionId);
         await sutProvider.GetDependency<IRequesterNotifier>().Received(1)
             .NotifyRequesterAsync(lease.RequesterId);
+        await sutProvider.GetDependency<ILeaseRevokedMailNotifier>().Received(1)
+            .NotifyLeaseEndedAsync(lease, AccessLeaseAction.Cancelled);
     }
 
     [Theory, BitAutoData]
@@ -104,6 +106,8 @@ public class RevokeAccessLeaseCommandTests
             .NotifyCollectionApproversAsync(lease.CollectionId);
         await sutProvider.GetDependency<IRequesterNotifier>().Received(1)
             .NotifyRequesterAsync(lease.RequesterId);
+        await sutProvider.GetDependency<ILeaseRevokedMailNotifier>().Received(1)
+            .NotifyLeaseEndedAsync(lease, AccessLeaseAction.Revoked);
     }
 
     [Theory, BitAutoData]

--- a/bitwarden_license/test/Services/Pam.Test/Commands/RevokeAccessLeaseCommandTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Commands/RevokeAccessLeaseCommandTests.cs
@@ -45,14 +45,12 @@ public class RevokeAccessLeaseCommandTests
         var sutProvider = Setup();
         lease.Action = AccessLeaseAction.None;
         lease.NotAfter = _now.AddHours(1);
-        // The caller IS the lease's own holder, but cannot Manage the collection — they may still end their own access.
         sutProvider.GetDependency<IAccessLeaseRepository>().GetByIdAsync(lease.Id).Returns(lease);
         sutProvider.GetDependency<IApproverCollectionAccessQuery>()
             .CanManageCollectionAsync(lease.RequesterId, lease.CollectionId).Returns(false);
 
         await sutProvider.Sut.RevokeAsync(lease.RequesterId, lease.Id, "done with it");
 
-        // Settles to Cancelled (the holder ended their own access) with the holder recorded as the revoker.
         await sutProvider.GetDependency<IAccessLeaseRepository>().Received(1).RevokeAsync(
             lease,
             AccessLeaseAction.Cancelled,

--- a/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
@@ -38,7 +38,7 @@ public class LeaseRevokedMailNotifierTests
         Assert.Equal("Your access was ended", mail.Subject);
         Assert.Equal(_organizationName, mail.View.OrganizationName);
         Assert.Equal("1 Sep 2026 at 17:00 UTC", mail.View.ScheduledEnd);
-        Assert.Equal($"{_vaultUrl}/privileged-controls/requests/{lease.AccessRequestId}", mail.View.Url);
+        Assert.Equal($"{_vaultUrl}/pam/requests/{lease.AccessRequestId}", mail.View.Url);
     }
 
     /// <summary>

--- a/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
@@ -45,31 +45,22 @@ public class LeaseRevokedMailNotifierTests
     /// The point of the whole feature. A holder who ends their own access already knows, and a mail thirty seconds
     /// behind their own click is what teaches people to filter the channel.
     /// </summary>
-    [Theory, BitAutoData]
-    public async Task NotifyLeaseEndedAsync_Cancelled_ReadsNothingAndSendsNothing(AccessLease lease)
+    [Theory]
+    [BitAutoData(AccessLeaseAction.Cancelled)]
+    [BitAutoData(AccessLeaseAction.None)]
+    public async Task NotifyLeaseEndedAsync_NotRevoked_ReadsNothingAndSendsNothing(
+        AccessLeaseAction endAction, AccessLease lease)
     {
         var sutProvider = Setup();
         SetupOrganization(sutProvider, lease);
         var sent = RecordMail(sutProvider);
 
-        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.Cancelled);
+        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, endAction);
 
         Assert.Empty(sent);
         await sutProvider.GetDependency<IAccessMailNotifier>().DidNotReceiveWithAnyArgs()
             .SendToUserAsync(default, (Func<string, BaseMail<AccessLeaseRevokedView>>)default!);
         await sutProvider.GetDependency<IOrganizationRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(default);
-    }
-
-    [Theory, BitAutoData]
-    public async Task NotifyLeaseEndedAsync_NoEndRecorded_SendsNothing(AccessLease lease)
-    {
-        var sutProvider = Setup();
-        SetupOrganization(sutProvider, lease);
-        var sent = RecordMail(sutProvider);
-
-        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.None);
-
-        Assert.Empty(sent);
     }
 
     [Theory, BitAutoData]

--- a/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
@@ -1,0 +1,175 @@
+﻿using Bit.Core;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Pam.Models.Mail.AccessLeaseRevoked;
+using Bit.Core.Platform.Mail.Mailer;
+using Bit.Core.Repositories;
+using Bit.Core.Settings;
+using Bit.Pam.Entities;
+using Bit.Pam.Enums;
+using Bit.Services.Pam.Services;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Bitwarden.Server.Sdk.Features;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Bit.Services.Pam.Test.Services;
+
+[SutProviderCustomize]
+public class LeaseRevokedMailNotifierTests
+{
+    private const string _vaultUrl = "https://vault.example.com/#";
+    private const string _organizationName = "Contoso";
+
+    [Theory, BitAutoData]
+    public async Task NotifyLeaseEndedAsync_Revoked_MailsTheHolderWithTheWindowItCutShort(AccessLease lease)
+    {
+        lease.NotAfter = new DateTime(2026, 9, 1, 17, 0, 0, DateTimeKind.Utc);
+
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, lease);
+        var sent = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.Revoked);
+
+        var (recipientId, mail) = Assert.Single(sent);
+        Assert.Equal(lease.RequesterId, recipientId);
+        Assert.Equal("Your access was ended", mail.Subject);
+        Assert.Equal(_organizationName, mail.View.OrganizationName);
+        Assert.Equal("1 Sep 2026 at 17:00 UTC", mail.View.ScheduledEnd);
+        Assert.Equal($"{_vaultUrl}/privileged-controls/requests/{lease.AccessRequestId}", mail.View.Url);
+    }
+
+    /// <summary>
+    /// The point of the whole feature. A holder who ends their own access already knows, and a mail thirty seconds
+    /// behind their own click is what teaches people to filter the channel.
+    /// </summary>
+    [Theory, BitAutoData]
+    public async Task NotifyLeaseEndedAsync_Cancelled_ReadsNothingAndSendsNothing(AccessLease lease)
+    {
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, lease);
+        var sent = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.Cancelled);
+
+        Assert.Empty(sent);
+        await sutProvider.GetDependency<IAccessMailNotifier>().DidNotReceiveWithAnyArgs()
+            .SendToUserAsync(default, (Func<string, BaseMail<AccessLeaseRevokedView>>)default!);
+        await sutProvider.GetDependency<IOrganizationRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(default);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyLeaseEndedAsync_NoEndRecorded_SendsNothing(AccessLease lease)
+    {
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, lease);
+        var sent = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.None);
+
+        Assert.Empty(sent);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyLeaseEndedAsync_FlagOff_ReadsNothingAndSendsNothing(AccessLease lease)
+    {
+        var sutProvider = Setup(flagOn: false);
+
+        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.Revoked);
+
+        await sutProvider.GetDependency<IOrganizationRepository>().DidNotReceiveWithAnyArgs().GetByIdAsync(default);
+        await sutProvider.GetDependency<IAccessMailNotifier>().DidNotReceiveWithAnyArgs()
+            .SendToUserAsync(default, (Func<string, BaseMail<AccessLeaseRevokedView>>)default!);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyLeaseEndedAsync_MailsTheHolderAndNobodyElse(AccessLease lease)
+    {
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, lease);
+        var sent = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.Revoked);
+
+        var (recipientId, _) = Assert.Single(sent);
+        Assert.Equal(lease.RequesterId, recipientId);
+        await sutProvider.GetDependency<IAccessMailNotifier>().DidNotReceiveWithAnyArgs()
+            .SendToUsersAsync(default!, (Func<string, BaseMail<AccessLeaseRevokedView>>)default!);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyLeaseEndedAsync_UnknownOrganization_SendsNothing(AccessLease lease)
+    {
+        var sutProvider = Setup();
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(lease.OrganizationId)
+            .Returns((Organization?)null);
+        var sent = RecordMail(sutProvider);
+
+        await sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.Revoked);
+
+        Assert.Empty(sent);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyLeaseEndedAsync_SendFails_DoesNotPropagate(AccessLease lease)
+    {
+        var sutProvider = Setup();
+        SetupOrganization(sutProvider, lease);
+        sutProvider.GetDependency<IAccessMailNotifier>()
+            .SendToUserAsync(Arg.Any<Guid>(), Arg.Any<Func<string, BaseMail<AccessLeaseRevokedView>>>())
+            .ThrowsAsync(new InvalidOperationException("delivery service unavailable"));
+
+        var exception = await Record.ExceptionAsync(
+            () => sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.Revoked));
+
+        Assert.Null(exception);
+    }
+
+    [Theory, BitAutoData]
+    public async Task NotifyLeaseEndedAsync_OrganizationReadFails_DoesNotPropagate(AccessLease lease)
+    {
+        var sutProvider = Setup();
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(lease.OrganizationId)
+            .ThrowsAsync(new TimeoutException("database unavailable"));
+
+        var exception = await Record.ExceptionAsync(
+            () => sutProvider.Sut.NotifyLeaseEndedAsync(lease, AccessLeaseAction.Revoked));
+
+        Assert.Null(exception);
+    }
+
+    private static SutProvider<LeaseRevokedMailNotifier> Setup(bool flagOn = true)
+    {
+        var sutProvider = new SutProvider<LeaseRevokedMailNotifier>().Create();
+
+        sutProvider.GetDependency<IFeatureService>()
+            .IsEnabled(FeatureFlagKeys.PamEmailNotifications)
+            .Returns(flagOn);
+        sutProvider.GetDependency<IGlobalSettings>().BaseServiceUri.VaultWithHash.Returns(_vaultUrl);
+
+        return sutProvider;
+    }
+
+    private static void SetupOrganization(SutProvider<LeaseRevokedMailNotifier> sutProvider, AccessLease lease) =>
+        sutProvider.GetDependency<IOrganizationRepository>().GetByIdAsync(lease.OrganizationId)
+            .Returns(new Organization { Id = lease.OrganizationId, Name = _organizationName });
+
+    private static List<(Guid RecipientId, AccessLeaseRevokedMail Mail)> RecordMail(
+        SutProvider<LeaseRevokedMailNotifier> sutProvider)
+    {
+        List<(Guid RecipientId, AccessLeaseRevokedMail Mail)> sent = [];
+
+        sutProvider.GetDependency<IAccessMailNotifier>()
+            .When(x => x.SendToUserAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<Func<string, BaseMail<AccessLeaseRevokedView>>>()))
+            .Do(call => sent.Add((
+                call.Arg<Guid>(),
+                (AccessLeaseRevokedMail)call.Arg<Func<string, BaseMail<AccessLeaseRevokedView>>>()(
+                    "holder@example.com"))));
+
+        return sent;
+    }
+}

--- a/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
@@ -35,7 +35,7 @@ public class LeaseRevokedMailNotifierTests
 
         var (recipientId, mail) = Assert.Single(sent);
         Assert.Equal(lease.RequesterId, recipientId);
-        Assert.Equal("Your access was ended", mail.Subject);
+        Assert.Equal("Your access was revoked", mail.Subject);
         Assert.Equal(_organizationName, mail.View.OrganizationName);
         Assert.Equal("1 Sep 2026 at 17:00 UTC", mail.View.ScheduledEnd);
         Assert.Equal($"{_vaultUrl}/pam/requests/{lease.AccessRequestId}", mail.View.Url);

--- a/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
@@ -136,7 +136,7 @@ public class LeaseRevokedMailNotifierTests
         var sutProvider = new SutProvider<LeaseRevokedMailNotifier>().Create();
 
         sutProvider.GetDependency<IFeatureService>()
-            .IsEnabled(FeatureFlagKeys.PamEmailNotifications)
+            .IsEnabled(FeatureFlagKeys.Pam)
             .Returns(flagOn);
         sutProvider.GetDependency<IGlobalSettings>().BaseServiceUri.VaultWithHash.Returns(_vaultUrl);
 

--- a/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/Services/LeaseRevokedMailNotifierTests.cs
@@ -41,10 +41,6 @@ public class LeaseRevokedMailNotifierTests
         Assert.Equal($"{_vaultUrl}/pam/requests/{lease.AccessRequestId}", mail.View.Url);
     }
 
-    /// <summary>
-    /// The point of the whole feature. A holder who ends their own access already knows, and a mail thirty seconds
-    /// behind their own click is what teaches people to filter the channel.
-    /// </summary>
     [Theory]
     [BitAutoData(AccessLeaseAction.Cancelled)]
     [BitAutoData(AccessLeaseAction.None)]

--- a/src/Core/MailTemplates/Mjml/emails/Pam/AccessLeaseRevokedView.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/Pam/AccessLeaseRevokedView.mjml
@@ -13,15 +13,11 @@
       <mj-section background-color="#fff" padding="24px 0px">
         <mj-column padding="0px 25px">
           <mj-text padding="0px 0px 16px 0px" font-weight="600" font-size="18px" line-height="28px">
-            Your access was ended
-          </mj-text>
-          <mj-text padding="0px 0px 16px 0px" font-weight="400" line-height="24px">
-            Someone who manages this collection ended your active access in <b>{{OrganizationName}}</b> before it was
-            due to finish. The item is locked again, and this access cannot be resumed.
+            Your access was revoked
           </mj-text>
           <mj-text padding="0px 0px 24px 0px" font-weight="400" line-height="24px">
-            <b>It was scheduled to end</b><br />
-            {{ScheduledEnd}}
+            Someone who manages this collection revoked your access in <b>{{OrganizationName}}</b>, which was due to
+            run until {{ScheduledEnd}}. The item is locked again, and this access cannot be resumed.
           </mj-text>
           <mj-button
             padding="0px 0px 24px 0px"
@@ -33,8 +29,8 @@
             >View the request</mj-button
           >
           <mj-text padding="0px" font-size="12px" font-weight="400" line-height="24px">
-            If you still need access, ask for it again with a new request. Any reason given for ending this one is on
-            the request, along with the item it covered; neither is included in this email.
+            If you still need access, ask for it again with a new request. Any reason given for revoking this one is
+            on the request, along with the item it covered; neither is included in this email.
           </mj-text>
         </mj-column>
       </mj-section>

--- a/src/Core/MailTemplates/Mjml/emails/Pam/AccessLeaseRevokedView.mjml
+++ b/src/Core/MailTemplates/Mjml/emails/Pam/AccessLeaseRevokedView.mjml
@@ -1,0 +1,48 @@
+<mjml>
+  <mj-head>
+    <mj-include path="../../components/head.mjml" />
+  </mj-head>
+  <mj-body>
+    <!-- Blue Header Section -->
+    <mj-wrapper css-class="border-fix" padding="20px 24px 0px 24px">
+      <mj-bw-simple-hero />
+    </mj-wrapper>
+
+    <!-- Main Content -->
+    <mj-wrapper padding="0px 25px">
+      <mj-section background-color="#fff" padding="24px 0px">
+        <mj-column padding="0px 25px">
+          <mj-text padding="0px 0px 16px 0px" font-weight="600" font-size="18px" line-height="28px">
+            Your access was ended
+          </mj-text>
+          <mj-text padding="0px 0px 16px 0px" font-weight="400" line-height="24px">
+            Someone who manages this collection ended your active access in <b>{{OrganizationName}}</b> before it was
+            due to finish. The item is locked again, and this access cannot be resumed.
+          </mj-text>
+          <mj-text padding="0px 0px 24px 0px" font-weight="400" line-height="24px">
+            <b>It was scheduled to end</b><br />
+            {{ScheduledEnd}}
+          </mj-text>
+          <mj-button
+            padding="0px 0px 24px 0px"
+            inner-padding="12px 24px"
+            border-radius="20px"
+            font-weight="600"
+            align="left"
+            href="{{{Url}}}"
+            >View the request</mj-button
+          >
+          <mj-text padding="0px" font-size="12px" font-weight="400" line-height="24px">
+            If you still need access, ask for it again with a new request. Any reason given for ending this one is on
+            the request, along with the item it covered; neither is included in this email.
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+
+    <!-- Footer -->
+    <mj-wrapper padding-top="15px">
+      <mj-include path="../../components/footer.mjml" />
+    </mj-wrapper>
+  </mj-body>
+</mjml>

--- a/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.cs
+++ b/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.cs
@@ -4,7 +4,7 @@ using Bit.Core.Platform.Mail.Mailer;
 namespace Bit.Core.Pam.Models.Mail.AccessLeaseRevoked;
 
 /// <summary>
-/// The lease holder's notice that someone else ended their active access before its window ran out.
+/// The lease holder's notice that someone else revoked their active access before its window ran out.
 /// </summary>
 /// <remarks>
 /// This is a courtesy, not a control: the lease is already dead and the client has already re-locked by the time
@@ -55,5 +55,5 @@ public class AccessLeaseRevokedView : BaseMailView
 
 public class AccessLeaseRevokedMail : BaseMail<AccessLeaseRevokedView>
 {
-    public override string Subject { get; set; } = "Your access was ended";
+    public override string Subject { get; set; } = "Your access was revoked";
 }

--- a/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.cs
+++ b/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.cs
@@ -7,22 +7,19 @@ namespace Bit.Core.Pam.Models.Mail.AccessLeaseRevoked;
 /// The lease holder's notice that someone else revoked their active access before its window ran out.
 /// </summary>
 /// <remarks>
-/// This is a courtesy, not a control: the lease is already dead and the client has already re-locked by the time
-/// this is composed. It exists so someone mid-task learns why their item locked itself.
-///
-/// Sent only when an operator revoked the lease. A holder who ends their own access is not mailed about it, so
-/// there is no field here for who ended it — this view only ever describes the one case.
+/// A courtesy, not a control: the lease is already dead and the client has already re-locked by the time this is
+/// composed. It is sent only when an operator revoked the lease, so there is no field for who ended it.
 ///
 /// Bounded by zero knowledge in the same way its siblings are: the collection and cipher are named only by
-/// ciphertext the server cannot read. The revocation reason is left out for the reason <c>AccessRequest.Reason</c>
-/// is — free text that would name the very system being accessed, rendered into an HTML mail body.
+/// ciphertext the server cannot read, and the revocation reason is withheld for the reason
+/// <c>AccessRequest.Reason</c> is, being free text that would name the very system being accessed.
 /// <see cref="Url" /> carries the holder to it.
 /// </remarks>
 public class AccessLeaseRevokedView : BaseMailView
 {
     /// <summary>
-    /// UTC is spelled out in the rendered string. There is no per-recipient timezone on this path, so an
-    /// unqualified instant would be read as local time and would misstate how much of the window was cut short.
+    /// UTC is spelled out in the rendered string: there is no per-recipient timezone on this path, so an unqualified
+    /// instant would be read as local time and misstate how much of the window was cut short.
     /// </summary>
     private const string _windowFormat = "d MMM yyyy 'at' HH:mm 'UTC'";
 
@@ -31,24 +28,22 @@ public class AccessLeaseRevokedView : BaseMailView
     /// <summary>The request the ended lease was minted from, which is what <see cref="Url" /> addresses.</summary>
     public required Guid AccessRequestId { get; init; }
 
-    /// <summary>Plaintext, unlike the collection and cipher names this mail deliberately omits.</summary>
     public required string OrganizationName { get; init; }
 
     /// <summary>
     /// When the lease would have ended on its own, in UTC. Always in the future at send time:
-    /// <c>RevokeAccessLeaseCommand</c> refuses a lease whose window has already closed, so a revoke is always an
-    /// early end and this is what it cut short.
+    /// <c>RevokeAccessLeaseCommand</c> refuses a lease whose window has already closed.
     /// </summary>
     public required DateTime NotAfter { get; init; }
 
     public string ScheduledEnd => NotAfter.ToString(_windowFormat, CultureInfo.InvariantCulture);
 
     /// <summary>
-    /// The holder's own view of the request this lease came from, where the revocation is recorded as a decision
-    /// with whatever reason the operator gave. The user-scoped PAM pages mount at <c>pam</c>
-    /// (<c>apps/web/src/app/oss-routing.module.ts:687</c>) and the request page is <c>requests/:id</c> beneath it
-    /// (<c>access-requests-routing.module.ts:47</c>). The organization-scoped admin surface under
-    /// <c>/organizations/:organizationId/pam</c> is a different route tree and does not serve this page.
+    /// The request this lease came from, where the revocation is recorded with whatever reason the operator gave.
+    /// The user-scoped PAM pages mount at <c>pam</c> (<c>apps/web/src/app/oss-routing.module.ts:687</c>) with the
+    /// request page at <c>requests/:id</c> beneath it (<c>access-requests-routing.module.ts:47</c>). The
+    /// organization-scoped tree under <c>/organizations/:organizationId/pam</c> is a different route tree and does
+    /// not serve this page.
     /// </summary>
     public string Url => $"{WebVaultUrl}/pam/requests/{AccessRequestId}";
 }

--- a/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.cs
+++ b/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.cs
@@ -1,0 +1,59 @@
+﻿using System.Globalization;
+using Bit.Core.Platform.Mail.Mailer;
+
+namespace Bit.Core.Pam.Models.Mail.AccessLeaseRevoked;
+
+/// <summary>
+/// The lease holder's notice that someone else ended their active access before its window ran out.
+/// </summary>
+/// <remarks>
+/// This is a courtesy, not a control: the lease is already dead and the client has already re-locked by the time
+/// this is composed. It exists so someone mid-task learns why their item locked itself.
+///
+/// Sent only when an operator revoked the lease. A holder who ends their own access is not mailed about it, so
+/// there is no field here for who ended it — this view only ever describes the one case.
+///
+/// Bounded by zero knowledge in the same way its siblings are: the collection and cipher are named only by
+/// ciphertext the server cannot read. The revocation reason is left out for the reason <c>AccessRequest.Reason</c>
+/// is — free text that would name the very system being accessed, rendered into an HTML mail body.
+/// <see cref="Url" /> carries the holder to it.
+/// </remarks>
+public class AccessLeaseRevokedView : BaseMailView
+{
+    /// <summary>
+    /// UTC is spelled out in the rendered string. There is no per-recipient timezone on this path, so an
+    /// unqualified instant would be read as local time and would misstate how much of the window was cut short.
+    /// </summary>
+    private const string _windowFormat = "d MMM yyyy 'at' HH:mm 'UTC'";
+
+    public required string WebVaultUrl { get; init; }
+
+    /// <summary>The request the ended lease was minted from, which is what <see cref="Url" /> addresses.</summary>
+    public required Guid AccessRequestId { get; init; }
+
+    /// <summary>Plaintext, unlike the collection and cipher names this mail deliberately omits.</summary>
+    public required string OrganizationName { get; init; }
+
+    /// <summary>
+    /// When the lease would have ended on its own, in UTC. Always in the future at send time:
+    /// <c>RevokeAccessLeaseCommand</c> refuses a lease whose window has already closed, so a revoke is always an
+    /// early end and this is what it cut short.
+    /// </summary>
+    public required DateTime NotAfter { get; init; }
+
+    public string ScheduledEnd => NotAfter.ToString(_windowFormat, CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// The holder's own view of the request this lease came from, where the revocation is recorded as a decision
+    /// with whatever reason the operator gave. The user-scoped PAM pages mount at <c>privileged-controls</c>
+    /// (<c>apps/web/src/app/oss-routing.module.ts:687</c>) and the request page is <c>requests/:id</c> beneath it
+    /// (<c>access-requests-routing.module.ts:47</c>). The organization-scoped admin surface under
+    /// <c>/organizations/:organizationId/pam</c> is a different route tree and does not serve this page.
+    /// </summary>
+    public string Url => $"{WebVaultUrl}/privileged-controls/requests/{AccessRequestId}";
+}
+
+public class AccessLeaseRevokedMail : BaseMail<AccessLeaseRevokedView>
+{
+    public override string Subject { get; set; } = "Your access was ended";
+}

--- a/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.cs
+++ b/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.cs
@@ -45,12 +45,12 @@ public class AccessLeaseRevokedView : BaseMailView
 
     /// <summary>
     /// The holder's own view of the request this lease came from, where the revocation is recorded as a decision
-    /// with whatever reason the operator gave. The user-scoped PAM pages mount at <c>privileged-controls</c>
+    /// with whatever reason the operator gave. The user-scoped PAM pages mount at <c>pam</c>
     /// (<c>apps/web/src/app/oss-routing.module.ts:687</c>) and the request page is <c>requests/:id</c> beneath it
     /// (<c>access-requests-routing.module.ts:47</c>). The organization-scoped admin surface under
     /// <c>/organizations/:organizationId/pam</c> is a different route tree and does not serve this page.
     /// </summary>
-    public string Url => $"{WebVaultUrl}/privileged-controls/requests/{AccessRequestId}";
+    public string Url => $"{WebVaultUrl}/pam/requests/{AccessRequestId}";
 }
 
 public class AccessLeaseRevokedMail : BaseMail<AccessLeaseRevokedView>

--- a/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.html.hbs
+++ b/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.html.hbs
@@ -187,16 +187,7 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0px 0px 16px 0px;word-break:break-word;">
                   
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:18px;font-weight:600;line-height:28px;text-align:left;color:#1B2029;">Your access was ended</div>
-    
-                </td>
-              </tr>
-            
-              <tr>
-                <td align="left" style="font-size:0px;padding:0px 0px 16px 0px;word-break:break-word;">
-                  
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">Someone who manages this collection ended your active access in <b>{{OrganizationName}}</b> before it was
-            due to finish. The item is locked again, and this access cannot be resumed.</div>
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:18px;font-weight:600;line-height:28px;text-align:left;color:#1B2029;">Your access was revoked</div>
     
                 </td>
               </tr>
@@ -204,8 +195,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0px 0px 24px 0px;word-break:break-word;">
                   
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><b>It was scheduled to end</b><br>
-            {{ScheduledEnd}}</div>
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">Someone who manages this collection revoked your access in <b>{{OrganizationName}}</b>, which was due to
+            run until {{ScheduledEnd}}. The item is locked again, and this access cannot be resumed.</div>
     
                 </td>
               </tr>
@@ -231,8 +222,8 @@
               <tr>
                 <td align="left" style="font-size:0px;padding:0px;word-break:break-word;">
                   
-      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">If you still need access, ask for it again with a new request. Any reason given for ending this one is on
-            the request, along with the item it covered; neither is included in this email.</div>
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">If you still need access, ask for it again with a new request. Any reason given for revoking this one is
+            on the request, along with the item it covered; neither is included in this email.</div>
     
                 </td>
               </tr>

--- a/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.html.hbs
+++ b/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.html.hbs
@@ -1,0 +1,516 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+    </style>
+     
+    <style type="text/css">
+.border-fix > table {
+    border-collapse: separate !important;
+  }
+  .border-fix > table > tbody > tr > td {
+    border-radius: 3px;
+  }
+    </style>
+    
+  </head>
+  <body style="word-spacing:normal;background-color:#e6e9ef;">
+    
+    
+      <div style="background-color:#e6e9ef;" lang="und" dir="auto">
+        <!-- Blue Header Section -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="border-fix-outlook" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="border-fix" style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 24px 0px 24px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><![endif]-->
+            
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#175ddc;background-color:#175ddc;width:100%;border-radius:4px 4px 0px 0px;">
+        <tbody>
+          <tr>
+            <td>
+              
+        
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:612px;" width="612" bgcolor="#175ddc" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+        
+      <div style="margin:0px auto;border-radius:4px 4px 0px 0px;max-width:612px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;border-radius:4px 4px 0px 0px;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:572px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:10px 5px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:150px;">
+              
+      <img alt src="https://bitwarden.com/images/logo-horizontal-white.png" style="border:0;display:block;outline:none;text-decoration:none;height:30px;width:100%;font-size:16px;" width="150" height="30">
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+        
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+      
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Main Content -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:0px 25px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:610px;" width="610" bgcolor="#ffffff" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:610px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:24px 0px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:610px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+        <tbody>
+          <tr>
+            <td style="vertical-align:top;padding:0px 25px;">
+              
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 0px 16px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:18px;font-weight:600;line-height:28px;text-align:left;color:#1B2029;">Your access was ended</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 0px 16px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">Someone who manages this collection ended your active access in <b>{{OrganizationName}}</b> before it was
+            due to finish. The item is locked again, and this access cannot be resumed.</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 0px 24px 0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;"><b>It was scheduled to end</b><br>
+            {{ScheduledEnd}}</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px 0px 24px 0px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#175ddc" role="presentation" style="border:none;border-radius:20px;cursor:auto;mso-padding-alt:12px 24px;background:#175ddc;" valign="middle">
+              <a href="{{{Url}}}" style="display:inline-block;background:#175ddc;color:#ffffff;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:600;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:20px;" target="_blank">
+                View the request
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" style="font-size:0px;padding:0px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;font-weight:400;line-height:24px;text-align:left;color:#1B2029;">If you still need access, ask for it again with a new request. Any reason given for ending this one is on
+            the request, along with the item it covered; neither is included in this email.</div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    <!-- Footer -->
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;padding-top:15px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="660px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:660px;" width="660" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:660px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:5px 20px 10px 20px;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:620px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" style="font-size:0px;padding:0;word-break:break-word;">
+                  
+      
+     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://x.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-x-twitter.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.reddit.com/r/Bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-reddit.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://community.bitwarden.com/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-discourse.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://github.com/bitwarden" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-github.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.youtube.com/channel/UCId9a_jQqvJre0_dE2lE_Rw" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-youtube.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.linkedin.com/company/bitwarden1/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-linkedin.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td><td><![endif]-->
+              <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="float:none;display:inline-table;">
+                <tbody>
+                  
+      <tr>
+        <td style="padding:8px;vertical-align:middle;">
+          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-radius:3px;width:24px;">
+            <tbody>
+              <tr>
+                <td style="font-size:0;height:24px;vertical-align:middle;width:24px;">
+                  <a href="https://www.facebook.com/bitwarden/" target="_blank">
+                    <img alt height="24" src="https://assets.bitwarden.com/email/v1/social-icons-facebook.png" style="border-radius:3px;display:block;" width="24">
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </td>
+        
+      </tr>
+    
+                </tbody>
+              </table>
+            <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:12px;line-height:16px;text-align:center;color:#5A6D91;"><p style="margin-bottom: 5px; margin-top: 5px">
+        © {{ CurrentYear }} Bitwarden Inc. 1 N. Calle Cesar Chavez, Suite 102,
+        Santa Barbara, CA, USA
+      </p>
+      <p style="margin-top: 5px">
+        Always confirm you are on a trusted Bitwarden domain before logging
+        in:<br>
+        <a href="https://bitwarden.com/" style="text-decoration: none; color: #175ddc; font-weight: 400">bitwarden.com</a>
+        |
+        <a href="https://bitwarden.com/help/emails-from-bitwarden/" style="text-decoration: none; color: #175ddc; font-weight: 400">Learn why we include this</a>
+      </p></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  </body>
+</html>
+  

--- a/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.text.hbs
+++ b/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.text.hbs
@@ -1,0 +1,9 @@
+Your access was ended
+
+Someone who manages this collection ended your active access in {{OrganizationName}} before it was due to finish. The item is locked again, and this access cannot be resumed.
+
+It was scheduled to end: {{ScheduledEnd}}
+
+View the request: {{Url}}
+
+If you still need access, ask for it again with a new request. Any reason given for ending this one is on the request, along with the item it covered; neither is included in this email.

--- a/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.text.hbs
+++ b/src/Core/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedView.text.hbs
@@ -1,9 +1,7 @@
-Your access was ended
+Your access was revoked
 
-Someone who manages this collection ended your active access in {{OrganizationName}} before it was due to finish. The item is locked again, and this access cannot be resumed.
-
-It was scheduled to end: {{ScheduledEnd}}
+Someone who manages this collection revoked your access in {{OrganizationName}}, which was due to run until {{ScheduledEnd}}. The item is locked again, and this access cannot be resumed.
 
 View the request: {{Url}}
 
-If you still need access, ask for it again with a new request. Any reason given for ending this one is on the request, along with the item it covered; neither is included in this email.
+If you still need access, ask for it again with a new request. Any reason given for revoking this one is on the request, along with the item it covered; neither is included in this email.

--- a/test/Core.Test/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedViewTests.cs
+++ b/test/Core.Test/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedViewTests.cs
@@ -12,11 +12,7 @@ public class AccessLeaseRevokedViewTests
 {
     private static readonly Guid _requestId = Guid.Parse("6f1b2d84-0c37-4a91-8e55-1d7c93a4b208");
 
-    /// <summary>
-    /// <see cref="HandlebarMailRenderer" /> resolves both templates from the view's full class name and only fails
-    /// when a mail is actually sent, which no other spec in this feature reaches. This is the spec that catches a
-    /// misnamed or misplaced <c>.hbs</c>.
-    /// </summary>
+    /// <summary>The only spec that renders, so the only one that catches a misnamed or misplaced <c>.hbs</c>.</summary>
     [Fact]
     public async Task RenderAsync_SaysAccessWasRevokedAndPointsAtTheRequest()
     {
@@ -32,10 +28,7 @@ public class AccessLeaseRevokedViewTests
         }
     }
 
-    /// <summary>
-    /// A revoked lease is over. Copy that implies otherwise sends someone back to a "Start access" button that
-    /// will not help them, so the body has to say both that it cannot be resumed and what to do instead.
-    /// </summary>
+    /// <summary>A revoked lease is over; copy implying otherwise sends the holder to a button that cannot help.</summary>
     [Fact]
     public async Task RenderAsync_SaysTheAccessCannotBeResumedAndThatANewRequestIsNeeded()
     {
@@ -50,11 +43,7 @@ public class AccessLeaseRevokedViewTests
         }
     }
 
-    /// <summary>
-    /// The reason an operator gave is free text that may name the very system being accessed, so it is linked to
-    /// rather than rendered — the same call the request's reason and the approver's comment get. Nothing on the
-    /// view can carry it.
-    /// </summary>
+    /// <summary>The reason is free text that may name the system being accessed, so it is linked to, not rendered.</summary>
     [Fact]
     public void View_HasNoPlaceToCarryTheRevocationReason() =>
         Assert.DoesNotContain(
@@ -63,9 +52,6 @@ public class AccessLeaseRevokedViewTests
                 || property.Name.Contains("Comment", StringComparison.OrdinalIgnoreCase)
                 || property.Name.Contains("Detail", StringComparison.OrdinalIgnoreCase));
 
-    /// <summary>
-    /// An organization name is member-supplied text, so the HTML body must escape it rather than interpolate it raw.
-    /// </summary>
     [Fact]
     public async Task RenderAsync_EscapesTheOrganizationNameInTheHtmlBody()
     {
@@ -93,10 +79,7 @@ public class AccessLeaseRevokedViewTests
         NotAfter = new DateTime(2026, 9, 1, 17, 0, 0, DateTimeKind.Utc),
     };
 
-    /// <summary>
-    /// Both templates wrap their copy across source lines, so a sentence these specs assert on is not contiguous in
-    /// the rendered output. Collapsing runs of whitespace keeps them about the wording rather than the line breaks.
-    /// </summary>
+    /// <summary>Both templates wrap copy across source lines; collapsing whitespace keeps the specs about wording.</summary>
     private static string Reflow(string body) => Regex.Replace(body, @"\s+", " ");
 
     private static Task<(string html, string txt)> RenderAsync(BaseMailView view) =>

--- a/test/Core.Test/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedViewTests.cs
+++ b/test/Core.Test/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedViewTests.cs
@@ -1,0 +1,105 @@
+﻿using System.Text.RegularExpressions;
+using Bit.Core.Pam.Models.Mail.AccessLeaseRevoked;
+using Bit.Core.Platform.Mail.Mailer;
+using Bit.Core.Settings;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Pam.Models.Mail.AccessLeaseRevoked;
+
+public class AccessLeaseRevokedViewTests
+{
+    private static readonly Guid _requestId = Guid.Parse("6f1b2d84-0c37-4a91-8e55-1d7c93a4b208");
+
+    /// <summary>
+    /// <see cref="HandlebarMailRenderer" /> resolves both templates from the view's full class name and only fails
+    /// when a mail is actually sent, which no other spec in this feature reaches. This is the spec that catches a
+    /// misnamed or misplaced <c>.hbs</c>.
+    /// </summary>
+    [Fact]
+    public async Task RenderAsync_SaysAccessEndedAndPointsAtTheRequest()
+    {
+        var (html, text) = await RenderAsync(View());
+
+        foreach (var body in new[] { Reflow(html), Reflow(text) })
+        {
+            Assert.Contains("Your access was ended", body);
+            Assert.Contains("before it was due to finish", body);
+            Assert.Contains("Contoso", body);
+            Assert.Contains("1 Sep 2026 at 17:00 UTC", body);
+            Assert.Contains($"https://vault.example.com/#/privileged-controls/requests/{_requestId}", body);
+        }
+    }
+
+    /// <summary>
+    /// A revoked lease is over. Copy that implies otherwise sends someone back to a "Start access" button that
+    /// will not help them, so the body has to say both that it cannot be resumed and what to do instead.
+    /// </summary>
+    [Fact]
+    public async Task RenderAsync_SaysTheAccessCannotBeResumedAndThatANewRequestIsNeeded()
+    {
+        var (html, text) = await RenderAsync(View());
+
+        foreach (var body in new[] { Reflow(html), Reflow(text) })
+        {
+            Assert.Contains("cannot be resumed", body);
+            Assert.Contains("ask for it again with a new request", body);
+            Assert.DoesNotContain("Start access", body);
+            Assert.DoesNotContain("Resume", body);
+        }
+    }
+
+    /// <summary>
+    /// The reason an operator gave is free text that may name the very system being accessed, so it is linked to
+    /// rather than rendered — the same call the request's reason and the approver's comment get. Nothing on the
+    /// view can carry it.
+    /// </summary>
+    [Fact]
+    public void View_HasNoPlaceToCarryTheRevocationReason() =>
+        Assert.DoesNotContain(
+            typeof(AccessLeaseRevokedView).GetProperties(),
+            property => property.Name.Contains("Reason", StringComparison.OrdinalIgnoreCase)
+                || property.Name.Contains("Comment", StringComparison.OrdinalIgnoreCase)
+                || property.Name.Contains("Detail", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// An organization name is member-supplied text, so the HTML body must escape it rather than interpolate it raw.
+    /// </summary>
+    [Fact]
+    public async Task RenderAsync_EscapesTheOrganizationNameInTheHtmlBody()
+    {
+        var (html, _) = await RenderAsync(View(organizationName: "<script>alert(1)</script>"));
+
+        Assert.DoesNotContain("<script>alert(1)</script>", html);
+        Assert.Contains("&lt;script&gt;", html);
+    }
+
+    [Fact]
+    public void Url_TargetsTheHoldersOwnRequestPage() =>
+        Assert.Equal($"https://vault.example.com/#/privileged-controls/requests/{_requestId}", View().Url);
+
+    [Fact]
+    public void Subject_SaysTheAccessEndedWithoutNamingTheItemOrTheReason() =>
+        Assert.Equal(
+            "Your access was ended",
+            new AccessLeaseRevokedMail { ToEmails = ["holder@acme.com"], View = View() }.Subject);
+
+    private static AccessLeaseRevokedView View(string organizationName = "Contoso") => new()
+    {
+        WebVaultUrl = "https://vault.example.com/#",
+        AccessRequestId = _requestId,
+        OrganizationName = organizationName,
+        NotAfter = new DateTime(2026, 9, 1, 17, 0, 0, DateTimeKind.Utc),
+    };
+
+    /// <summary>
+    /// Both templates wrap their copy across source lines, so a sentence these specs assert on is not contiguous in
+    /// the rendered output. Collapsing runs of whitespace keeps them about the wording rather than the line breaks.
+    /// </summary>
+    private static string Reflow(string body) => Regex.Replace(body, @"\s+", " ");
+
+    private static Task<(string html, string txt)> RenderAsync(BaseMailView view) =>
+        new HandlebarMailRenderer(Substitute.For<ILogger<HandlebarMailRenderer>>(), new GlobalSettings())
+            .RenderAsync(view);
+}

--- a/test/Core.Test/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedViewTests.cs
+++ b/test/Core.Test/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedViewTests.cs
@@ -18,14 +18,14 @@ public class AccessLeaseRevokedViewTests
     /// misnamed or misplaced <c>.hbs</c>.
     /// </summary>
     [Fact]
-    public async Task RenderAsync_SaysAccessEndedAndPointsAtTheRequest()
+    public async Task RenderAsync_SaysAccessWasRevokedAndPointsAtTheRequest()
     {
         var (html, text) = await RenderAsync(View());
 
         foreach (var body in new[] { Reflow(html), Reflow(text) })
         {
-            Assert.Contains("Your access was ended", body);
-            Assert.Contains("before it was due to finish", body);
+            Assert.Contains("Your access was revoked", body);
+            Assert.Contains("which was due to run until", body);
             Assert.Contains("Contoso", body);
             Assert.Contains("1 Sep 2026 at 17:00 UTC", body);
             Assert.Contains($"https://vault.example.com/#/pam/requests/{_requestId}", body);
@@ -80,9 +80,9 @@ public class AccessLeaseRevokedViewTests
         Assert.Equal($"https://vault.example.com/#/pam/requests/{_requestId}", View().Url);
 
     [Fact]
-    public void Subject_SaysTheAccessEndedWithoutNamingTheItemOrTheReason() =>
+    public void Subject_SaysTheAccessWasRevokedWithoutNamingTheItemOrTheReason() =>
         Assert.Equal(
-            "Your access was ended",
+            "Your access was revoked",
             new AccessLeaseRevokedMail { ToEmails = ["holder@acme.com"], View = View() }.Subject);
 
     private static AccessLeaseRevokedView View(string organizationName = "Contoso") => new()

--- a/test/Core.Test/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedViewTests.cs
+++ b/test/Core.Test/Pam/Models/Mail/AccessLeaseRevoked/AccessLeaseRevokedViewTests.cs
@@ -28,7 +28,7 @@ public class AccessLeaseRevokedViewTests
             Assert.Contains("before it was due to finish", body);
             Assert.Contains("Contoso", body);
             Assert.Contains("1 Sep 2026 at 17:00 UTC", body);
-            Assert.Contains($"https://vault.example.com/#/privileged-controls/requests/{_requestId}", body);
+            Assert.Contains($"https://vault.example.com/#/pam/requests/{_requestId}", body);
         }
     }
 
@@ -77,7 +77,7 @@ public class AccessLeaseRevokedViewTests
 
     [Fact]
     public void Url_TargetsTheHoldersOwnRequestPage() =>
-        Assert.Equal($"https://vault.example.com/#/privileged-controls/requests/{_requestId}", View().Url);
+        Assert.Equal($"https://vault.example.com/#/pam/requests/{_requestId}", View().Url);
 
     [Fact]
     public void Subject_SaysTheAccessEndedWithoutNamingTheItemOrTheReason() =>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42817

## 📔 Objective

Emails a lease holder when an operator revokes their active access. The push already re-locks their client; this tells them why.

- Sent only when `AccessLeaseAction.Revoked`. A holder ending their own lease (`Cancelled`) receives nothing: mailing someone about their own action is what trains people to ignore the channel.
- Says "revoked", matching `pamStatusRevoked` and `pamAuditKindLeaseRevoked` in the web vault. The product reserves "ended" for the holder's own action.
- States that the access cannot be resumed and that regaining it needs a new request.
- The revocation reason is not included and stays on the request.

This is a courtesy, not a control: the lease is already dead server side before the mail is composed.

Top of a four PR stack on `pam/uat`. Sits on the decision notification PR.

## 📸 Screenshots
