### PR TITLE
[PM-34222] Stamp collected events with server time

### DIFF
--- a/src/Events/Controllers/CollectController.cs
+++ b/src/Events/Controllers/CollectController.cs
@@ -55,7 +55,7 @@ public class CollectController : Controller
             {
                 // User events
                 case EventType.User_ClientExportedVault:
-                    await _eventService.LogUserEventAsync(_currentContext.UserId.Value, eventModel.Type, eventModel.Date);
+                    await _eventService.LogUserEventAsync(_currentContext.UserId.Value, eventModel.Type);
                     break;
 
                 case EventType.Organization_ItemOrganization_Accepted:
@@ -73,7 +73,7 @@ public class CollectController : Controller
                         continue;
                     }
 
-                    await _eventService.LogOrganizationUserEventAsync(orgUser, eventModel.Type, eventModel.Date);
+                    await _eventService.LogOrganizationUserEventAsync(orgUser, eventModel.Type);
 
                     continue;
 
@@ -142,7 +142,7 @@ public class CollectController : Controller
                     }
 
                     ciphersCache.TryAdd(eventModel.CipherId.Value, cipher);
-                    cipherEvents.Add(new Tuple<Cipher, EventType, DateTime?>(cipher, eventModel.Type, eventModel.Date));
+                    cipherEvents.Add(new Tuple<Cipher, EventType, DateTime?>(cipher, eventModel.Type, null));
                     break;
 
                 case EventType.Organization_ClientExportedVault:
@@ -168,7 +168,7 @@ public class CollectController : Controller
                         continue;
                     }
 
-                    await _eventService.LogOrganizationEventAsync(organization, eventModel.Type, eventModel.Date);
+                    await _eventService.LogOrganizationEventAsync(organization, eventModel.Type);
                     break;
                 case EventType.PhishingBlocker_SiteAccessed:
                 case EventType.PhishingBlocker_SiteExited:
@@ -191,7 +191,7 @@ public class CollectController : Controller
                         continue;
                     }
 
-                    await _eventService.LogOrganizationUserEventAsync(orgUserContext, eventModel.Type, eventModel.Date);
+                    await _eventService.LogOrganizationUserEventAsync(orgUserContext, eventModel.Type);
                     break;
                 default:
                     continue;

--- a/src/Events/Models/EventModel.cs
+++ b/src/Events/Models/EventModel.cs
@@ -6,6 +6,10 @@ public class EventModel
 {
     public EventType Type { get; set; }
     public Guid? CipherId { get; set; }
+    /// <summary>
+    /// Accepted for backwards compatibility with existing clients and deliberately ignored.
+    /// Events are stamped with server time in <see cref="Bit.Core.Services.IEventService"/>.
+    /// </summary>
     public DateTime Date { get; set; }
     public Guid? OrganizationId { get; set; }
 }

--- a/test/Events.IntegrationTest/Controllers/CollectControllerTests.cs
+++ b/test/Events.IntegrationTest/Controllers/CollectControllerTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using Bit.Core.AdminConsole.Entities;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
+using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
 using Bit.Core.Vault.Entities;
 using Bit.Core.Vault.Enums;
@@ -444,38 +445,53 @@ public class CollectControllerTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task Post_CipherClientCopiedPassword_WithSkewedClientDate_Success()
+    public async Task Post_UserClientExportedVault_WithSkewedClientDate_StoresServerTime()
     {
-        var cipher = await CreateCipherForUserAsync(_ownerId);
+        var eventRepository = _factory.GetService<IEventRepository>();
+        var skewedClientDate = DateTime.UtcNow.AddMinutes(-4);
+        var sentAt = DateTime.UtcNow;
 
         var response = await _client.PostAsJsonAsync<IEnumerable<EventModel>>("collect",
         [
             new EventModel
             {
-                Type = EventType.Cipher_ClientCopiedPassword,
-                CipherId = cipher.Id,
-                Date = DateTime.UtcNow.AddMinutes(-4),
+                Type = EventType.User_ClientExportedVault,
+                Date = skewedClientDate,
             },
         ]);
 
         response.EnsureSuccessStatusCode();
+
+        var stored = await GetSingleExportedVaultEventAsync(eventRepository);
+        Assert.True(stored.Date >= sentAt.AddSeconds(-30),
+            $"stored the client's date instead of server time. stored={stored.Date:O} client={skewedClientDate:O}");
     }
 
     [Fact]
-    public async Task Post_CipherClientCopiedPassword_WithoutClientDate_Success()
+    public async Task Post_UserClientExportedVault_WithoutClientDate_StoresServerTime()
     {
-        var cipher = await CreateCipherForUserAsync(_ownerId);
+        var eventRepository = _factory.GetService<IEventRepository>();
+        var sentAt = DateTime.UtcNow;
 
         var response = await _client.PostAsJsonAsync<IEnumerable<EventModel>>("collect",
         [
-            new EventModel
-            {
-                Type = EventType.Cipher_ClientCopiedPassword,
-                CipherId = cipher.Id,
-            },
+            new EventModel { Type = EventType.User_ClientExportedVault },
         ]);
 
         response.EnsureSuccessStatusCode();
+
+        var stored = await GetSingleExportedVaultEventAsync(eventRepository);
+        Assert.True(stored.Date >= sentAt.AddSeconds(-30),
+            $"an absent date should not be stored verbatim. stored={stored.Date:O}");
+    }
+
+    private async Task<IEvent> GetSingleExportedVaultEventAsync(IEventRepository eventRepository)
+    {
+        var events = await eventRepository.GetManyByUserAsync(
+            _ownerId, DateTime.UtcNow.AddDays(-30), DateTime.UtcNow.AddDays(1),
+            new PageOptions { PageSize = 100 });
+
+        return Assert.Single(events.Data.Where(e => e.Type == EventType.User_ClientExportedVault));
     }
 
     private async Task<Cipher> CreateCipherForUserAsync(Guid userId)

--- a/test/Events.IntegrationTest/Controllers/CollectControllerTests.cs
+++ b/test/Events.IntegrationTest/Controllers/CollectControllerTests.cs
@@ -443,6 +443,41 @@ public class CollectControllerTests : IAsyncLifetime
         response.EnsureSuccessStatusCode();
     }
 
+    [Fact]
+    public async Task Post_CipherClientCopiedPassword_WithSkewedClientDate_Success()
+    {
+        var cipher = await CreateCipherForUserAsync(_ownerId);
+
+        var response = await _client.PostAsJsonAsync<IEnumerable<EventModel>>("collect",
+        [
+            new EventModel
+            {
+                Type = EventType.Cipher_ClientCopiedPassword,
+                CipherId = cipher.Id,
+                Date = DateTime.UtcNow.AddMinutes(-4),
+            },
+        ]);
+
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task Post_CipherClientCopiedPassword_WithoutClientDate_Success()
+    {
+        var cipher = await CreateCipherForUserAsync(_ownerId);
+
+        var response = await _client.PostAsJsonAsync<IEnumerable<EventModel>>("collect",
+        [
+            new EventModel
+            {
+                Type = EventType.Cipher_ClientCopiedPassword,
+                CipherId = cipher.Id,
+            },
+        ]);
+
+        response.EnsureSuccessStatusCode();
+    }
+
     private async Task<Cipher> CreateCipherForUserAsync(Guid userId)
     {
         var cipherRepository = _factory.GetService<ICipherRepository>();

--- a/test/Events.Test/Controllers/CollectControllerTests.cs
+++ b/test/Events.Test/Controllers/CollectControllerTests.cs
@@ -76,7 +76,7 @@ public class CollectControllerTests
         var result = await _sut.Post(events);
 
         Assert.IsType<OkResult>(result);
-        await _eventService.Received(1).LogUserEventAsync(userId, EventType.User_ClientExportedVault, eventDate);
+        await _eventService.Received(1).LogUserEventAsync(userId, EventType.User_ClientExportedVault, null);
     }
 
     [Theory]
@@ -103,7 +103,7 @@ public class CollectControllerTests
         var result = await _sut.Post(events);
 
         Assert.IsType<OkResult>(result);
-        await _eventService.Received(1).LogOrganizationUserEventAsync(orgUser, type, eventDate);
+        await _eventService.Received(1).LogOrganizationUserEventAsync(orgUser, type, null);
     }
 
     [Theory]
@@ -183,7 +183,7 @@ public class CollectControllerTests
                 tuples => tuples.Count() == 1 &&
                          tuples.First().Item1 == cipherDetails &&
                          tuples.First().Item2 == EventType.Cipher_ClientAutofilled &&
-                         tuples.First().Item3 == eventDate
+                         tuples.First().Item3 == null
             )
         );
     }
@@ -635,7 +635,7 @@ public class CollectControllerTests
         Assert.IsType<OkResult>(result);
         await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _organizationRepository.Received(1).GetByIdAsync(orgId);
-        await _eventService.Received(1).LogOrganizationEventAsync(organization, EventType.Organization_ClientExportedVault, eventDate);
+        await _eventService.Received(1).LogOrganizationEventAsync(organization, EventType.Organization_ClientExportedVault, null);
     }
 
     [Theory]
@@ -830,7 +830,7 @@ public class CollectControllerTests
         Assert.IsType<OkResult>(result);
         await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _organizationRepository.Received(1).GetByIdAsync(orgId);
-        await _eventService.Received(1).LogOrganizationEventAsync(organization, eventType, eventDate);
+        await _eventService.Received(1).LogOrganizationEventAsync(organization, eventType, null);
     }
 
     [Theory]
@@ -910,7 +910,7 @@ public class CollectControllerTests
         Assert.IsType<OkResult>(result);
         await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _organizationRepository.Received(1).GetByIdAsync(orgId);
-        await _eventService.Received(1).LogOrganizationEventAsync(organization, EventType.Organization_InviteLinkClientCopied, eventDate);
+        await _eventService.Received(1).LogOrganizationEventAsync(organization, EventType.Organization_InviteLinkClientCopied, null);
     }
 
     [Theory]
@@ -996,7 +996,7 @@ public class CollectControllerTests
         await _organizationRepository.Received(1).GetByIdAsync(orgId);
         await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _eventService.Received(1).LogOrganizationUserEventAsync(
-            Arg.Is<OrganizationUser>(o => o == orgUser), type, eventDate);
+            Arg.Is<OrganizationUser>(o => o == orgUser), type, null);
     }
 
     [Theory]
@@ -1080,5 +1080,85 @@ public class CollectControllerTests
         await _organizationUserRepository.Received(1).GetByOrganizationAsync(orgId, userId);
         await _organizationRepository.Received(1).GetByIdAsync(orgId);
         await _eventService.DidNotReceiveWithAnyArgs().LogOrganizationUserEventAsync(Arg.Any<OrganizationUser>(), Arg.Any<EventType>(), Arg.Any<DateTime?>());
+    }
+
+    [Theory]
+    [AutoData]
+    public async Task Post_CipherEventWithSkewedClientDate_DoesNotForwardClientDate(Guid userId, Guid cipherId, CipherDetails cipherDetails)
+    {
+        _currentContext.UserId.Returns(userId);
+        cipherDetails.Id = cipherId;
+        _cipherRepository.GetByIdAsync(cipherId, userId).Returns(cipherDetails);
+        var events = new List<EventModel>
+        {
+            new EventModel
+            {
+                Type = EventType.Cipher_ClientCopiedPassword,
+                CipherId = cipherId,
+                Date = DateTime.UtcNow.AddMinutes(-4)
+            }
+        };
+
+        var result = await _sut.Post(events);
+
+        Assert.IsType<OkResult>(result);
+        await _eventService.Received(1).LogCipherEventsAsync(
+            Arg.Is<IEnumerable<Tuple<Cipher, EventType, DateTime?>>>(
+                tuples => tuples.Single().Item3 == null
+            )
+        );
+    }
+
+    [Theory]
+    [AutoData]
+    public async Task Post_CipherEventWithFutureClientDate_DoesNotForwardClientDate(Guid userId, Guid cipherId, CipherDetails cipherDetails)
+    {
+        _currentContext.UserId.Returns(userId);
+        cipherDetails.Id = cipherId;
+        _cipherRepository.GetByIdAsync(cipherId, userId).Returns(cipherDetails);
+        var events = new List<EventModel>
+        {
+            new EventModel
+            {
+                Type = EventType.Cipher_ClientCopiedPassword,
+                CipherId = cipherId,
+                Date = DateTime.UtcNow.AddHours(2)
+            }
+        };
+
+        var result = await _sut.Post(events);
+
+        Assert.IsType<OkResult>(result);
+        await _eventService.Received(1).LogCipherEventsAsync(
+            Arg.Is<IEnumerable<Tuple<Cipher, EventType, DateTime?>>>(
+                tuples => tuples.Single().Item3 == null
+            )
+        );
+    }
+
+    [Theory]
+    [AutoData]
+    public async Task Post_CipherEventWithNoClientDate_DoesNotForwardDateTimeMinValue(Guid userId, Guid cipherId, CipherDetails cipherDetails)
+    {
+        _currentContext.UserId.Returns(userId);
+        cipherDetails.Id = cipherId;
+        _cipherRepository.GetByIdAsync(cipherId, userId).Returns(cipherDetails);
+        var events = new List<EventModel>
+        {
+            new EventModel
+            {
+                Type = EventType.Cipher_ClientCopiedPassword,
+                CipherId = cipherId
+            }
+        };
+
+        var result = await _sut.Post(events);
+
+        Assert.IsType<OkResult>(result);
+        await _eventService.Received(1).LogCipherEventsAsync(
+            Arg.Is<IEnumerable<Tuple<Cipher, EventType, DateTime?>>>(
+                tuples => tuples.Single().Item3 == null
+            )
+        );
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34222](https://bitwarden.atlassian.net/browse/PM-34222)

## 📔 Objective

Organization event logs mixed two clocks. Server-originated events (create item, invite user) used the server's UTC clock, while client-originated events (copy password, view item, autofill, export vault) carried a timestamp generated on the user's device and were stored verbatim. On a device whose clock was a few minutes slow, the log showed events out of causal order: the reported case shows an item's password copied roughly three and a half minutes before the item itself was created.

`CollectController` was the only place a client-controlled timestamp entered the event pipeline. Every other `IEventService` caller already lets the service stamp the event, so this drops the client-supplied date at those five call sites and `EventService`'s existing `DateTime.UtcNow` fallback applies per event, putting the whole log on one clock.

### This is also an audit-log integrity fix

Worth calling out separately, because it is the stronger reason to ship this. Before this change there was no validation of any kind on the incoming `date`, so any authenticated user could choose the timestamp on their own audit entries: `Cipher_ClientCopiedPassword`, `User_ClientExportedVault`, `Organization_ClientExportedVault`. A user could backdate an export to bury it among older activity, or push it far enough into the future that it never appears in the event log's date-range query at all. That is log forgery by the actor the log exists to record, and it is now closed.

This matches the design intent already documented for event logging, that server-side events are preferred because they cannot be circumvented by modifying the client.

### Other defects fixed

- A payload that omits `date` previously bound to `DateTime.MinValue` and was stored as a year-1 event.
- A future-dated event was stored but fell outside the event log's date-range query, so it could never be retrieved through the UI.

### Trade-offs

Events queued on a client that was offline are now recorded at the time the server received them rather than the time the device claims. The upload interval is 60 seconds, so in the normal case this shifts a timestamp by under a minute, well inside the error it removes.

Ordering within a batch of cipher events is preserved, because the fallback is evaluated per event rather than per batch. Note this does not extend to a mixed batch: cipher events are accumulated and flushed after the loop while user and organization events are awaited inline, so a cipher event followed by an organization event will stamp the organization event first. The distortion is milliseconds, against the minutes it replaces.

An alternative that preserves the exact gaps between all events in a batch was considered and rejected as roughly four times the code on an audit path, with a new failure mode (ordering can invert between consecutive batches, which this approach never does).

No feature flag: carrying two timestamp semantics simultaneously would produce a log that is neither. Rollback is a revert. Existing rows written with a skewed device timestamp keep their values, as the true time is not recoverable.

`EventModel.Date` is kept so existing clients continue to work unchanged, and is now documented as accepted-and-ignored.

Consumers of these events through SIEM or webhook integrations will see the `date` field change meaning for client-originated events.

## 🧪 Testing

- 62 unit test cases and 24 integration test cases pass.
- The two integration tests verify end to end that the stored `Date` is server receipt time, by reading the event back through `IEventRepository`. Reverting any call site fails exactly those two tests.
- Also covered: a backdated timestamp, a future-dated timestamp, and a payload with no `date` field at all.

## 📸 Screenshots

Not applicable, no UI changes.


[PM-34222]: https://bitwarden.atlassian.net/browse/PM-34222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ