### PR TITLE
Scaffold the target-system delete endpoint

### DIFF
--- a/bitwarden_license/src/Services/Pam/AccessConnector/Rotation/Api/Endpoints/Handlers/TargetSystemEndpointsHandler.cs
+++ b/bitwarden_license/src/Services/Pam/AccessConnector/Rotation/Api/Endpoints/Handlers/TargetSystemEndpointsHandler.cs
@@ -29,4 +29,7 @@ public class TargetSystemEndpointsHandler
 
     public Task Put(Guid orgId, Guid id, UpdateTargetSystemRequestModel model)
         => throw new NotImplementedException();
+
+    public Task Delete(Guid orgId, Guid id)
+        => throw new NotImplementedException();
 }

--- a/bitwarden_license/src/Services/Pam/AccessConnector/Rotation/Api/Endpoints/TargetSystemEndpoints.cs
+++ b/bitwarden_license/src/Services/Pam/AccessConnector/Rotation/Api/Endpoints/TargetSystemEndpoints.cs
@@ -43,6 +43,14 @@ internal static class TargetSystemEndpoints
             })
             .WithName("Pam_AccessConnectors_Rotation_TargetSystems_Put");
 
+        group.MapDelete("{id:guid}",
+            async (Guid orgId, Guid id, TargetSystemEndpointsHandler handler) =>
+            {
+                await handler.Delete(orgId, id);
+                return TypedResults.NoContent();
+            })
+            .WithName("Pam_AccessConnectors_Rotation_TargetSystems_Delete");
+
         return group;
     }
 }

--- a/bitwarden_license/src/Services/Pam/rotation-server.allium
+++ b/bitwarden_license/src/Services/Pam/rotation-server.allium
@@ -752,6 +752,32 @@ rule UpdateManualTargetSystem {
         -- registration request.
 }
 
+rule DeleteTargetSystem {
+    when: DeleteTargetSystem(target_system)
+    -- A configuration naming this target holds it: deleting the target would leave the
+    -- configuration -- and the credential it manages -- pointing at nothing. The
+    -- configurations go first (DeleteRotationConfig), which is also what releases each
+    -- cipher for a configuration elsewhere.
+    requires: not RotationConfigs.any(c => c.target_system = target_system)
+    ensures: AdministrationAudited(operation: target_deleted, target_system: target_system)
+    ensures:
+        for assignment in ConnectorTargetAssignments where target_system = target_system:
+            not exists assignment
+    ensures: not exists target_system
+    @guidance
+        -- Permanent, and deliberately narrower than DisableTargetSystem: disabling stops new
+        -- rotations being offered while the target and its configurations stay intact, so it
+        -- remains the reversible control for a target that is merely unavailable. Deleting is
+        -- for a target that has left the estate.
+        -- Its access connector assignments go with it: an assignment is only the
+        -- connector-to-target edge and means nothing once the target is gone, so it cascades
+        -- rather than blocking (mirroring an access connector's own assignments). No rotation
+        -- can be in flight to be torn up -- a job belongs to a configuration on this target,
+        -- and a surviving configuration blocks the delete outright.
+        -- The audit log, not the row, is the durable record of the target (Goal 4): the event
+        -- carries its name, which is why the audit emission is ordered before the removal.
+}
+
 -- Rotation configuration
 
 rule CreateRotationConfig {
@@ -1616,8 +1642,8 @@ rule RecordManualRotation {
 -- targets — an access connector registered (connector_registered), revoked (connector_revoked), its
 -- credential reissued in place (connector_credential_reissued), assigned to / unassigned from
 -- a target (connector_assigned, connector_unassigned), and a target system registered / disabled /
--- enabled / updated (target_registered, target_disabled, target_enabled,
--- target_system_updated). Connector connectivity edges
+-- enabled / updated / deleted (target_registered, target_disabled, target_enabled,
+-- target_system_updated, target_deleted). Connector connectivity edges
 -- (ConnectorConnected/ConnectorDisconnected) are liveness observations, not operations, and are
 -- not audited directly; a drop's impact on in-flight work is audited via the released outcome.
 --
@@ -1741,6 +1767,10 @@ surface TargetSystemView {
             when target_system.method = automatic
         UpdateManualTargetSystem(target_system, name)
             when target_system.method = manual
+        -- Permanently remove the target. Offered only once nothing is configured against it;
+        -- disable is the reversible control.
+        DeleteTargetSystem(target_system)
+            when not RotationConfigs.any(c => c.target_system = target_system)
 }
 
 surface RotationConfigView {

--- a/bitwarden_license/test/Services/Pam.Test/AccessConnector/Api/Endpoints/AccessConnectorAdminEndpointsTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/AccessConnector/Api/Endpoints/AccessConnectorAdminEndpointsTests.cs
@@ -79,7 +79,7 @@ public class AccessConnectorAdminEndpointsTests
     {
         var endpoints = AdminEndpoints();
 
-        Assert.Equal(22, endpoints.Count);
+        Assert.Equal(23, endpoints.Count);
         Assert.All(endpoints, endpoint =>
             Assert.Equal("internal", endpoint.Metadata.GetMetadata<IEndpointGroupNameMetadata>()?.EndpointGroupName));
     }
@@ -98,6 +98,7 @@ public class AccessConnectorAdminEndpointsTests
     [InlineData("Pam_AccessConnectors_Rotation_TargetSystems_Enable", "POST", "rotation/target-systems/{id:guid}/enable")]
     [InlineData("Pam_AccessConnectors_Rotation_TargetSystems_Disable", "POST", "rotation/target-systems/{id:guid}/disable")]
     [InlineData("Pam_AccessConnectors_Rotation_TargetSystems_Put", "PUT", "rotation/target-systems/{id:guid}")]
+    [InlineData("Pam_AccessConnectors_Rotation_TargetSystems_Delete", "DELETE", "rotation/target-systems/{id:guid}")]
     [InlineData("Pam_AccessConnectors_Rotation_Configs_GetAll", "GET", "rotation/configs")]
     [InlineData("Pam_AccessConnectors_Rotation_Configs_Get", "GET", "rotation/configs/{id:guid}")]
     [InlineData("Pam_AccessConnectors_Rotation_Configs_Post", "POST", "rotation/configs")]


### PR DESCRIPTION
## 🎟️ Tracking

_Needs a ticket before this leaves draft._

## 📔 Objective

Adds the one admin route the rotation scaffold (#8279) left out. A target system could be registered, enabled, disabled and updated, but never deleted — while both of its siblings on this surface already have a delete: `DELETE access-connectors/{id}` retires a connector, `DELETE rotation/configs/{id}` un-manages a credential. A target that had left the estate had no way off the list, with disable the only way to quiet it.

`DELETE organizations/{orgId}/access-connectors/rotation/target-systems/{id}`, with the matching handler stub, following #8279's pattern: the signature defines the wire contract the OpenAPI spec and the client bindings are generated from, and the body throws `NotImplementedException` like every other method on this handler.

The route carries a `WithDescription` because its semantics do not follow from the verb:

- **Refused while any rotation config still names the target.** A config is the configuration for a credential, so cascading it would silently stop a cipher rotating on the strength of one click elsewhere in the UI. The admin deletes those first — which is also what frees each cipher for a configuration elsewhere.
- **The access connector assignments pointing at it go with it.** An assignment is only the connector-to-target edge and means nothing once the target is gone.
- **Disable remains the reversible control** and is still the one to reach for: it stops new rotations being offered while the target and its configuration stay intact.

That split is what `PamRotationConfig`'s and `PamDaemonTargetAssignment`'s own FK comments already prescribed, and it means no rotation can be in flight to be torn up — a job belongs to a config on this target, and a surviving config refuses the delete outright.

## 🔒 Authorization

Nothing new. The route joins the existing connector admin group, so it inherits `ManageAccessConnectorRequirement` on top of `Policies.Application`, and the group's feature flag. The contract test asserting that no admin route carries `MemberOrProviderRequirement` matches by route prefix, so it picked the new route up unchanged.

## 🧪 Other changes

- `rotation-server.allium` gains `rule DeleteTargetSystem`, `target_deleted` in the `AdministrationAudited` vocabulary, and the trigger on the `TargetSystemView` surface — so the spec and the wire contract keep describing the same thing, as in #8279. The spec already carries `DeleteRotationConfig` for the sibling operation, and the target-system section modelled every other operation on a target, so the delete was the one hole in it. `allium check` reports no errors and no findings; its diagnostics are the same two unused-field infos and one unresolved-use warning as before.
- Contract test updated to 23 routes, with the new route's name, method and path locked like the rest. 239 tests pass.

**Deliberately omitted** (they land with the rest of the rotation feature, and are implemented on the UAT branch): the command and its interface, DI registration, the Dapper and EF repository methods, the `PamTargetSystem_DeleteWithAssignments` and `PamRotationConfig_AnyByTargetSystem` stored procedures, the migrator script, the `TargetSystemDeleted` audit kind, and the command and integration tests.
