### PR TITLE
[PM-42891] - Add route param enforcement.

### DIFF
--- a/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/GroupsController.cs
@@ -48,7 +48,7 @@ public class GroupsController : Controller
     }
 
     [HttpGet("{id}")]
-    public async Task<IActionResult> Get(Guid organizationId, Guid id)
+    public async Task<IActionResult> Get([FromRoute] Guid organizationId, Guid id)
     {
         var group = await _groupRepository.GetByIdAsync(id);
         if (group == null || group.OrganizationId != organizationId)
@@ -60,7 +60,7 @@ public class GroupsController : Controller
 
     [HttpGet("")]
     public async Task<IActionResult> Get(
-        Guid organizationId,
+        [FromRoute] Guid organizationId,
         [FromQuery] GetGroupsQueryParamModel model)
     {
         var groupsListQueryResult = await _getGroupsListQuery.GetGroupsListAsync(organizationId, model);
@@ -75,7 +75,7 @@ public class GroupsController : Controller
     }
 
     [HttpPost("")]
-    public async Task<IActionResult> Post(Guid organizationId, [FromBody] ScimGroupRequestModel model)
+    public async Task<IActionResult> Post([FromRoute] Guid organizationId, [FromBody] ScimGroupRequestModel model)
     {
         var organization = await _organizationRepository.GetByIdAsync(organizationId);
         var group = await _postGroupCommand.PostGroupAsync(organization, model);
@@ -84,7 +84,7 @@ public class GroupsController : Controller
     }
 
     [HttpPut("{id}")]
-    public async Task<IActionResult> Put(Guid organizationId, Guid id, [FromBody] ScimGroupRequestModel model)
+    public async Task<IActionResult> Put([FromRoute] Guid organizationId, Guid id, [FromBody] ScimGroupRequestModel model)
     {
         var organization = await _organizationRepository.GetByIdAsync(organizationId);
         var group = await _putGroupCommand.PutGroupAsync(organization, id, model);
@@ -94,7 +94,7 @@ public class GroupsController : Controller
     }
 
     [HttpPatch("{id}")]
-    public async Task<IActionResult> Patch(Guid organizationId, Guid id, [FromBody] ScimPatchModel model)
+    public async Task<IActionResult> Patch([FromRoute] Guid organizationId, Guid id, [FromBody] ScimPatchModel model)
     {
         var group = await _groupRepository.GetByIdAsync(id);
         if (group == null || group.OrganizationId != organizationId)
@@ -107,7 +107,7 @@ public class GroupsController : Controller
     }
 
     [HttpDelete("{id}")]
-    public async Task<IActionResult> Delete(Guid organizationId, Guid id)
+    public async Task<IActionResult> Delete([FromRoute] Guid organizationId, Guid id)
     {
         await _deleteGroupCommand.DeleteGroupAsync(organizationId, id, EventSystemUser.SCIM);
         return new NoContentResult();

--- a/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
+++ b/bitwarden_license/src/Scim/Controllers/v2/UsersController.cs
@@ -49,7 +49,7 @@ public class UsersController : Controller
     }
 
     [HttpGet("{id}")]
-    public async Task<IActionResult> Get(Guid organizationId, Guid id)
+    public async Task<IActionResult> Get([FromRoute] Guid organizationId, Guid id)
     {
         var orgUser = await _organizationUserRepository.GetDetailsByIdAsync(id);
         if (orgUser == null || orgUser.OrganizationId != organizationId)
@@ -61,7 +61,7 @@ public class UsersController : Controller
 
     [HttpGet("")]
     public async Task<IActionResult> Get(
-        Guid organizationId,
+        [FromRoute] Guid organizationId,
         [FromQuery] GetUsersQueryParamModel model)
     {
         var usersListQueryResult = await _getUsersListQuery.GetUsersListAsync(organizationId, model);
@@ -76,7 +76,7 @@ public class UsersController : Controller
     }
 
     [HttpPost("")]
-    public async Task<IActionResult> Post(Guid organizationId, [FromBody] ScimUserRequestModel model)
+    public async Task<IActionResult> Post([FromRoute] Guid organizationId, [FromBody] ScimUserRequestModel model)
     {
         var orgUser = await _postUserCommand.PostUserAsync(organizationId, model);
         var scimUserResponseModel = new ScimUserResponseModel(orgUser);
@@ -84,7 +84,7 @@ public class UsersController : Controller
     }
 
     [HttpPut("{id}")]
-    public async Task<IActionResult> Put(Guid organizationId, Guid id, [FromBody] ScimUserRequestModel model)
+    public async Task<IActionResult> Put([FromRoute] Guid organizationId, Guid id, [FromBody] ScimUserRequestModel model)
     {
         var orgUser = await _organizationUserRepository.GetByIdAsync(id);
         if (orgUser == null || orgUser.OrganizationId != organizationId)
@@ -131,14 +131,14 @@ public class UsersController : Controller
     }
 
     [HttpPatch("{id}")]
-    public async Task<IActionResult> Patch(Guid organizationId, Guid id, [FromBody] ScimPatchModel model)
+    public async Task<IActionResult> Patch([FromRoute] Guid organizationId, Guid id, [FromBody] ScimPatchModel model)
     {
         await _patchUserCommand.PatchUserAsync(organizationId, id, model);
         return new NoContentResult();
     }
 
     [HttpDelete("{id}")]
-    public async Task<IActionResult> Delete(Guid organizationId, Guid id)
+    public async Task<IActionResult> Delete([FromRoute] Guid organizationId, Guid id)
     {
         await _removeOrganizationUserCommand.RemoveUserAsync(organizationId, id, EventSystemUser.SCIM);
         return new NoContentResult();

--- a/bitwarden_license/src/Services/Pam/AccessConnector/Api/Endpoints/AccessConnectorEndpoints.cs
+++ b/bitwarden_license/src/Services/Pam/AccessConnector/Api/Endpoints/AccessConnectorEndpoints.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Services.Pam.AccessConnector.Api.Endpoints.Handlers;
 using Bit.Services.Pam.AccessConnector.Api.Models.Request;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Services.Pam.AccessConnector.Api.Endpoints;
 
@@ -13,23 +14,23 @@ internal static class AccessConnectorEndpoints
     {
         group.WithTags("PamAccessConnectors");
 
-        group.MapGet("", (Guid orgId, AccessConnectorEndpointsHandler handler) => handler.GetAll(orgId))
+        group.MapGet("", ([FromRoute] Guid orgId, AccessConnectorEndpointsHandler handler) => handler.GetAll(orgId))
             .WithName("Pam_AccessConnectors_GetAll");
 
-        group.MapGet("{id:guid}", (Guid orgId, Guid id, AccessConnectorEndpointsHandler handler) => handler.Get(orgId, id))
+        group.MapGet("{id:guid}", ([FromRoute] Guid orgId, Guid id, AccessConnectorEndpointsHandler handler) => handler.Get(orgId, id))
             .WithName("Pam_AccessConnectors_Get")
             .WithDescription(
                 "Returns one access connector with its recent rotation activity -- the jobs it has worked and " +
                 "the attempts it recorded against them, newest first.");
 
-        group.MapPost("", (Guid orgId, RegisterAccessConnectorRequestModel model, AccessConnectorEndpointsHandler handler) => handler.Post(orgId, model))
+        group.MapPost("", ([FromRoute] Guid orgId, RegisterAccessConnectorRequestModel model, AccessConnectorEndpointsHandler handler) => handler.Post(orgId, model))
             .WithName("Pam_AccessConnectors_Post")
             .WithDescription(
                 "Registers an access connector and returns its client secret. The secret is shown exactly once here " +
                 "-- the server hashes it for storage and cannot return it again.");
 
         group.MapPost("{id:guid}/enable",
-            async (Guid orgId, Guid id, AccessConnectorEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, AccessConnectorEndpointsHandler handler) =>
             {
                 await handler.Enable(orgId, id);
                 return TypedResults.NoContent();
@@ -38,7 +39,7 @@ internal static class AccessConnectorEndpoints
             .WithDescription("Re-enables a disabled access connector so it can authenticate and claim jobs again.");
 
         group.MapPost("{id:guid}/disable",
-            async (Guid orgId, Guid id, AccessConnectorEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, AccessConnectorEndpointsHandler handler) =>
             {
                 await handler.Disable(orgId, id);
                 return TypedResults.NoContent();
@@ -49,7 +50,7 @@ internal static class AccessConnectorEndpoints
                 "are released, but its credential is retained so it can be re-enabled later.");
 
         group.MapDelete("{id:guid}",
-            async (Guid orgId, Guid id, AccessConnectorEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, AccessConnectorEndpointsHandler handler) =>
             {
                 await handler.Delete(orgId, id);
                 return TypedResults.NoContent();
@@ -61,7 +62,7 @@ internal static class AccessConnectorEndpoints
                 "remediation for a suspected compromise.");
 
         group.MapPost("{id:guid}/assignments",
-            async (Guid orgId, Guid id, AssignAccessConnectorTargetRequestModel model, AccessConnectorEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, AssignAccessConnectorTargetRequestModel model, AccessConnectorEndpointsHandler handler) =>
             {
                 await handler.AssignTarget(orgId, id, model);
                 return TypedResults.NoContent();
@@ -69,7 +70,7 @@ internal static class AccessConnectorEndpoints
             .WithName("Pam_AccessConnectors_AssignTarget");
 
         group.MapDelete("{id:guid}/assignments/{targetSystemId:guid}",
-            async (Guid orgId, Guid id, Guid targetSystemId, AccessConnectorEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, Guid targetSystemId, AccessConnectorEndpointsHandler handler) =>
             {
                 await handler.UnassignTarget(orgId, id, targetSystemId);
                 return TypedResults.NoContent();

--- a/bitwarden_license/src/Services/Pam/AccessConnector/Rotation/Api/Endpoints/RotationConfigEndpoints.cs
+++ b/bitwarden_license/src/Services/Pam/AccessConnector/Rotation/Api/Endpoints/RotationConfigEndpoints.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Services.Pam.AccessConnector.Rotation.Api.Endpoints.Handlers;
 using Bit.Services.Pam.AccessConnector.Rotation.Api.Models.Request;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Services.Pam.AccessConnector.Rotation.Api.Endpoints;
 
@@ -13,22 +14,22 @@ internal static class RotationConfigEndpoints
     {
         group.WithTags("PamAccessConnectorRotationConfigs");
 
-        group.MapGet("", (Guid orgId, RotationConfigEndpointsHandler handler) => handler.GetAll(orgId))
+        group.MapGet("", ([FromRoute] Guid orgId, RotationConfigEndpointsHandler handler) => handler.GetAll(orgId))
             .WithName("Pam_AccessConnectors_Rotation_Configs_GetAll");
 
-        group.MapGet("{id:guid}", (Guid orgId, Guid id, RotationConfigEndpointsHandler handler) => handler.Get(orgId, id))
+        group.MapGet("{id:guid}", ([FromRoute] Guid orgId, Guid id, RotationConfigEndpointsHandler handler) => handler.Get(orgId, id))
             .WithName("Pam_AccessConnectors_Rotation_Configs_Get");
 
-        group.MapPost("", (Guid orgId, CreateRotationConfigRequestModel model, RotationConfigEndpointsHandler handler) => handler.Post(orgId, model))
+        group.MapPost("", ([FromRoute] Guid orgId, CreateRotationConfigRequestModel model, RotationConfigEndpointsHandler handler) => handler.Post(orgId, model))
             .WithName("Pam_AccessConnectors_Rotation_Configs_Post");
 
         group.MapPut("{id:guid}",
-            (Guid orgId, Guid id, UpdateRotationConfigRequestModel model, RotationConfigEndpointsHandler handler) =>
+            ([FromRoute] Guid orgId, Guid id, UpdateRotationConfigRequestModel model, RotationConfigEndpointsHandler handler) =>
                 handler.Put(orgId, id, model))
             .WithName("Pam_AccessConnectors_Rotation_Configs_Put");
 
         group.MapPost("{id:guid}/pause",
-            async (Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
             {
                 await handler.Pause(orgId, id);
                 return TypedResults.NoContent();
@@ -36,7 +37,7 @@ internal static class RotationConfigEndpoints
             .WithName("Pam_AccessConnectors_Rotation_Configs_Pause");
 
         group.MapPost("{id:guid}/resume",
-            async (Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
             {
                 await handler.Resume(orgId, id);
                 return TypedResults.NoContent();
@@ -44,7 +45,7 @@ internal static class RotationConfigEndpoints
             .WithName("Pam_AccessConnectors_Rotation_Configs_Resume");
 
         group.MapPost("{id:guid}/rotate",
-            async (Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
             {
                 await handler.Rotate(orgId, id);
                 return TypedResults.NoContent();
@@ -53,7 +54,7 @@ internal static class RotationConfigEndpoints
             .WithDescription("Triggers an on-demand rotation now (spec TriggerRotationNow), subject to the per-config on-demand cooldown.");
 
         group.MapPost("{id:guid}/record-manual",
-            async (Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
             {
                 await handler.RecordManual(orgId, id);
                 return TypedResults.NoContent();
@@ -62,7 +63,7 @@ internal static class RotationConfigEndpoints
             .WithDescription("Records that an operator rotated a manual-target config's credential out of band, clearing its due obligation.");
 
         group.MapDelete("{id:guid}",
-            async (Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, RotationConfigEndpointsHandler handler) =>
             {
                 await handler.Delete(orgId, id);
                 return TypedResults.NoContent();

--- a/bitwarden_license/src/Services/Pam/AccessConnector/Rotation/Api/Endpoints/TargetSystemEndpoints.cs
+++ b/bitwarden_license/src/Services/Pam/AccessConnector/Rotation/Api/Endpoints/TargetSystemEndpoints.cs
@@ -1,5 +1,6 @@
 ﻿using Bit.Services.Pam.AccessConnector.Rotation.Api.Endpoints.Handlers;
 using Bit.Services.Pam.AccessConnector.Rotation.Api.Models.Request;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Services.Pam.AccessConnector.Rotation.Api.Endpoints;
 
@@ -13,14 +14,14 @@ internal static class TargetSystemEndpoints
     {
         group.WithTags("PamAccessConnectorRotationTargetSystems");
 
-        group.MapGet("", (Guid orgId, TargetSystemEndpointsHandler handler) => handler.GetAll(orgId))
+        group.MapGet("", ([FromRoute] Guid orgId, TargetSystemEndpointsHandler handler) => handler.GetAll(orgId))
             .WithName("Pam_AccessConnectors_Rotation_TargetSystems_GetAll");
 
-        group.MapPost("", (Guid orgId, RegisterTargetSystemRequestModel model, TargetSystemEndpointsHandler handler) => handler.Post(orgId, model))
+        group.MapPost("", ([FromRoute] Guid orgId, RegisterTargetSystemRequestModel model, TargetSystemEndpointsHandler handler) => handler.Post(orgId, model))
             .WithName("Pam_AccessConnectors_Rotation_TargetSystems_Post");
 
         group.MapPost("{id:guid}/enable",
-            async (Guid orgId, Guid id, TargetSystemEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, TargetSystemEndpointsHandler handler) =>
             {
                 await handler.Enable(orgId, id);
                 return TypedResults.NoContent();
@@ -28,7 +29,7 @@ internal static class TargetSystemEndpoints
             .WithName("Pam_AccessConnectors_Rotation_TargetSystems_Enable");
 
         group.MapPost("{id:guid}/disable",
-            async (Guid orgId, Guid id, TargetSystemEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, TargetSystemEndpointsHandler handler) =>
             {
                 await handler.Disable(orgId, id);
                 return TypedResults.NoContent();
@@ -36,7 +37,7 @@ internal static class TargetSystemEndpoints
             .WithName("Pam_AccessConnectors_Rotation_TargetSystems_Disable");
 
         group.MapPut("{id:guid}",
-            async (Guid orgId, Guid id, UpdateTargetSystemRequestModel model, TargetSystemEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, UpdateTargetSystemRequestModel model, TargetSystemEndpointsHandler handler) =>
             {
                 await handler.Put(orgId, id, model);
                 return TypedResults.NoContent();
@@ -44,7 +45,7 @@ internal static class TargetSystemEndpoints
             .WithName("Pam_AccessConnectors_Rotation_TargetSystems_Put");
 
         group.MapDelete("{id:guid}",
-            async (Guid orgId, Guid id, TargetSystemEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, TargetSystemEndpointsHandler handler) =>
             {
                 await handler.Delete(orgId, id);
                 return TypedResults.NoContent();

--- a/bitwarden_license/src/Services/Pam/Api/Endpoints/AccessRuleEndpoints.cs
+++ b/bitwarden_license/src/Services/Pam/Api/Endpoints/AccessRuleEndpoints.cs
@@ -3,6 +3,7 @@ using Bit.OrganizationAuthorization;
 using Bit.Services.Pam.Api.Authorization;
 using Bit.Services.Pam.Api.Endpoints.Handlers;
 using Bit.Services.Pam.Api.Models.Request;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Bit.Services.Pam.Api.Endpoints;
 
@@ -30,22 +31,22 @@ internal static class AccessRuleEndpoints
         group.WithTags("AccessRules");
         group.RequireAuthorization(new AuthorizeAttribute<MemberRequirement>());
 
-        group.MapGet("", (Guid orgId, AccessRuleEndpointsHandler handler) => handler.GetAll(orgId))
+        group.MapGet("", ([FromRoute] Guid orgId, AccessRuleEndpointsHandler handler) => handler.GetAll(orgId))
             .WithName("Pam_AccessRules_GetAll");
 
-        group.MapGet("{id:guid}", (Guid orgId, Guid id, AccessRuleEndpointsHandler handler) => handler.Get(orgId, id))
+        group.MapGet("{id:guid}", ([FromRoute] Guid orgId, Guid id, AccessRuleEndpointsHandler handler) => handler.Get(orgId, id))
             .WithName("Pam_AccessRules_Get");
 
-        group.MapPost("", (Guid orgId, AccessRuleRequestModel model, AccessRuleEndpointsHandler handler) => handler.Post(orgId, model))
+        group.MapPost("", ([FromRoute] Guid orgId, AccessRuleRequestModel model, AccessRuleEndpointsHandler handler) => handler.Post(orgId, model))
             .WithName("Pam_AccessRules_Post")
             .RequireAuthorization(new AuthorizeAttribute<ManageAccessRulesRequirement>());
 
-        group.MapPut("{id:guid}", (Guid orgId, Guid id, AccessRuleRequestModel model, AccessRuleEndpointsHandler handler) => handler.Put(orgId, id, model))
+        group.MapPut("{id:guid}", ([FromRoute] Guid orgId, Guid id, AccessRuleRequestModel model, AccessRuleEndpointsHandler handler) => handler.Put(orgId, id, model))
             .WithName("Pam_AccessRules_Put")
             .RequireAuthorization(new AuthorizeAttribute<ManageAccessRulesRequirement>());
 
         group.MapDelete("{id:guid}",
-            async (Guid orgId, Guid id, AccessRuleEndpointsHandler handler) =>
+            async ([FromRoute] Guid orgId, Guid id, AccessRuleEndpointsHandler handler) =>
             {
                 await handler.Delete(orgId, id);
                 return TypedResults.NoContent();

--- a/bitwarden_license/test/Scim.IntegrationTest/OrganizationIdFromRouteTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/OrganizationIdFromRouteTests.cs
@@ -1,13 +1,13 @@
 ﻿using System.Reflection;
+using Bit.IntegrationTestCommon;
 using Bit.Scim.IntegrationTest.Factories;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Xunit;
 
 namespace Bit.Scim.IntegrationTest;
 
-public class OrganizationIdFromRouteTests(ScimApplicationFactory factory) : IClassFixture<ScimApplicationFactory>
+public class OrganizationIdFromRouteTests(ScimApplicationFactory factory)
+    : RouteIdFromRouteTestsBase(factory.Services), IClassFixture<ScimApplicationFactory>
 {
     private const string _scimPolicy = "Scim";
     private static readonly string[] _organizationIdRouteNames = ["orgId", "organizationId"];
@@ -20,59 +20,19 @@ public class OrganizationIdFromRouteTests(ScimApplicationFactory factory) : ICla
     /// SCIM authorization reads the id from route values only. [FromRoute] forces the binding to that.
     /// </summary>
     [Fact]
-    public void AllScimEndpoints_BindOrganizationIdFromRoute()
-    {
-        var endpointDataSources = factory.Services.GetRequiredService<IEnumerable<EndpointDataSource>>();
+    public void AllScimEndpoints_BindOrganizationIdFromRoute() =>
+        AssertAllGuardedEndpointsBindIdFromRoute();
 
-        var violations = endpointDataSources
-            .SelectMany(source => source.Endpoints)
-            .Where(HasScimPolicy)
-            .Where(HasOrganizationIdParameterNotBoundFromRoute)
-            .Select(Describe)
-            .Distinct()
-            .OrderBy(description => description)
-            .ToList();
-
-        Assert.True(violations.Count == 0, BuildFailureMessage(violations));
-    }
-
-    private static bool HasScimPolicy(Endpoint endpoint) =>
+    protected override bool IsGuardedEndpoint(Endpoint endpoint) =>
         endpoint.Metadata
             .OfType<IAuthorizeData>()
             .Any(data => data.Policy == _scimPolicy);
 
-    private static bool HasOrganizationIdParameterNotBoundFromRoute(Endpoint endpoint)
-    {
-        var methodInfo = GetMethodInfo(endpoint);
-        if (methodInfo == null)
-        {
-            return false;
-        }
-
-        return methodInfo.GetParameters()
-            .Where(IsOrganizationIdParameter)
-            .Any(parameter => parameter.GetCustomAttribute<FromRouteAttribute>() == null);
-    }
-
-    private static bool IsOrganizationIdParameter(ParameterInfo parameter) =>
+    protected override bool IsRouteIdParameter(ParameterInfo parameter) =>
         _organizationIdRouteNames.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase);
 
-    private static MethodInfo? GetMethodInfo(Endpoint endpoint) =>
-        endpoint.Metadata.GetMetadata<ControllerActionDescriptor>()?.MethodInfo
-        ?? endpoint.Metadata.GetMetadata<MethodInfo>();
-
-    private static string Describe(Endpoint endpoint)
-    {
-        var route = (endpoint as RouteEndpoint)?.RoutePattern.RawText ?? endpoint.DisplayName ?? "(unknown route)";
-        var httpMethods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods;
-        var verbs = httpMethods is { Count: > 0 } ? string.Join(",", httpMethods) : "ANY";
-
-        return $"{verbs} {route}";
-    }
-
-    private static string BuildFailureMessage(List<string> violations) =>
-        $"{violations.Count} SCIM endpoint(s) declare an 'orgId' or 'organizationId' parameter without [FromRoute]. " +
+    protected override string FailureSummary(int violationCount) =>
+        $"{violationCount} SCIM endpoint(s) declare an 'orgId' or 'organizationId' parameter without [FromRoute]. " +
         "SCIM authorization reads the organization id from route values only, so a same-named parameter must be " +
-        "bound with [FromRoute] or a form body value can shadow it and diverge from the authorized organization:" +
-        $"\n  - {string.Join("\n  - ", violations)}";
+        "bound with [FromRoute] or a form body value can shadow it and diverge from the authorized organization";
 }

--- a/bitwarden_license/test/Scim.IntegrationTest/OrganizationIdFromRouteTests.cs
+++ b/bitwarden_license/test/Scim.IntegrationTest/OrganizationIdFromRouteTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Reflection;
+using Bit.Scim.IntegrationTest.Factories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Xunit;
+
+namespace Bit.Scim.IntegrationTest;
+
+public class OrganizationIdFromRouteTests(ScimApplicationFactory factory) : IClassFixture<ScimApplicationFactory>
+{
+    private const string _scimPolicy = "Scim";
+    private static readonly string[] _organizationIdRouteNames = ["orgId", "organizationId"];
+
+    /// <summary>
+    /// IF the endpoint is guarded by the "Scim" authorization policy
+    /// AND has an orgId or organizationId parameter
+    /// THEN that parameter must have [FromRoute].
+    ///
+    /// SCIM authorization reads the id from route values only. [FromRoute] forces the binding to that.
+    /// </summary>
+    [Fact]
+    public void AllScimEndpoints_BindOrganizationIdFromRoute()
+    {
+        var endpointDataSources = factory.Services.GetRequiredService<IEnumerable<EndpointDataSource>>();
+
+        var violations = endpointDataSources
+            .SelectMany(source => source.Endpoints)
+            .Where(HasScimPolicy)
+            .Where(HasOrganizationIdParameterNotBoundFromRoute)
+            .Select(Describe)
+            .Distinct()
+            .OrderBy(description => description)
+            .ToList();
+
+        Assert.True(violations.Count == 0, BuildFailureMessage(violations));
+    }
+
+    private static bool HasScimPolicy(Endpoint endpoint) =>
+        endpoint.Metadata
+            .OfType<IAuthorizeData>()
+            .Any(data => data.Policy == _scimPolicy);
+
+    private static bool HasOrganizationIdParameterNotBoundFromRoute(Endpoint endpoint)
+    {
+        var methodInfo = GetMethodInfo(endpoint);
+        if (methodInfo == null)
+        {
+            return false;
+        }
+
+        return methodInfo.GetParameters()
+            .Where(IsOrganizationIdParameter)
+            .Any(parameter => parameter.GetCustomAttribute<FromRouteAttribute>() == null);
+    }
+
+    private static bool IsOrganizationIdParameter(ParameterInfo parameter) =>
+        _organizationIdRouteNames.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase);
+
+    private static MethodInfo? GetMethodInfo(Endpoint endpoint) =>
+        endpoint.Metadata.GetMetadata<ControllerActionDescriptor>()?.MethodInfo
+        ?? endpoint.Metadata.GetMetadata<MethodInfo>();
+
+    private static string Describe(Endpoint endpoint)
+    {
+        var route = (endpoint as RouteEndpoint)?.RoutePattern.RawText ?? endpoint.DisplayName ?? "(unknown route)";
+        var httpMethods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods;
+        var verbs = httpMethods is { Count: > 0 } ? string.Join(",", httpMethods) : "ANY";
+
+        return $"{verbs} {route}";
+    }
+
+    private static string BuildFailureMessage(List<string> violations) =>
+        $"{violations.Count} SCIM endpoint(s) declare an 'orgId' or 'organizationId' parameter without [FromRoute]. " +
+        "SCIM authorization reads the organization id from route values only, so a same-named parameter must be " +
+        "bound with [FromRoute] or a form body value can shadow it and diverge from the authorized organization:" +
+        $"\n  - {string.Join("\n  - ", violations)}";
+}

--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -64,7 +64,7 @@ public class GroupsController : Controller
 
     [HttpGet("{id}")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task<GroupResponseModel> Get(Guid orgId, Guid id)
+    public async Task<GroupResponseModel> Get([FromRoute] Guid orgId, Guid id)
     {
         var group = await _groupRepository.GetByIdAsync(id);
         if (group == null || group.OrganizationId != orgId)
@@ -77,7 +77,7 @@ public class GroupsController : Controller
 
     [HttpGet("{id}/details")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task<GroupDetailsResponseModel> GetDetails(Guid orgId, Guid id)
+    public async Task<GroupDetailsResponseModel> GetDetails([FromRoute] Guid orgId, Guid id)
     {
         var groupDetails = await _groupRepository.GetByIdWithCollectionsAsync(id);
         if (groupDetails?.Item1 == null || groupDetails.Item1.OrganizationId != orgId)
@@ -90,7 +90,7 @@ public class GroupsController : Controller
 
     [HttpGet("")]
     [Authorize<OrganizationCollectionManagementAccessRequirement>]
-    public async Task<ListResponseModel<GroupResponseModel>> GetOrganizationGroups(Guid orgId)
+    public async Task<ListResponseModel<GroupResponseModel>> GetOrganizationGroups([FromRoute] Guid orgId)
     {
         var groups = await _groupRepository.GetManyByOrganizationIdAsync(orgId);
         var responses = groups.Select(g => new GroupResponseModel(g));
@@ -99,7 +99,7 @@ public class GroupsController : Controller
 
     [HttpGet("details")]
     [Authorize<ManageUsersOrGroupsRequirement>]
-    public async Task<ListResponseModel<GroupDetailsResponseModel>> GetOrganizationGroupDetails(Guid orgId)
+    public async Task<ListResponseModel<GroupDetailsResponseModel>> GetOrganizationGroupDetails([FromRoute] Guid orgId)
     {
         var groups = await _groupRepository.GetManyWithCollectionsByOrganizationIdAsync(orgId);
         var responses = groups.Select(g => new GroupDetailsResponseModel(g.Item1, g.Item2));
@@ -108,7 +108,7 @@ public class GroupsController : Controller
 
     [HttpGet("{id}/users")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task<IEnumerable<Guid>> GetUsers(Guid orgId, Guid id)
+    public async Task<IEnumerable<Guid>> GetUsers([FromRoute] Guid orgId, Guid id)
     {
         var group = await _groupRepository.GetByIdAsync(id);
         if (group == null || group.OrganizationId != orgId)
@@ -122,7 +122,7 @@ public class GroupsController : Controller
 
     [HttpPost("")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task<GroupResponseModel> Post(Guid orgId, [FromBody] GroupRequestModel model)
+    public async Task<GroupResponseModel> Post([FromRoute] Guid orgId, [FromBody] GroupRequestModel model)
     {
         // Check the user has permission to grant access to the collections for the new group
         if (model.Collections?.Any() == true)
@@ -146,7 +146,7 @@ public class GroupsController : Controller
 
     [HttpPut("{id}")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task<GroupResponseModel> Put(Guid orgId, Guid id, [FromBody] GroupRequestModel model)
+    public async Task<GroupResponseModel> Put([FromRoute] Guid orgId, Guid id, [FromBody] GroupRequestModel model)
     {
         var (group, currentAccess) = await _groupRepository.GetByIdWithCollectionsAsync(id);
         if (group == null || group.OrganizationId != orgId)
@@ -217,14 +217,14 @@ public class GroupsController : Controller
     [HttpPost("{id}")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task<GroupResponseModel> PostPut(Guid orgId, Guid id, [FromBody] GroupRequestModel model)
+    public async Task<GroupResponseModel> PostPut([FromRoute] Guid orgId, Guid id, [FromBody] GroupRequestModel model)
     {
         return await Put(orgId, id, model);
     }
 
     [HttpDelete("{id}")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task Delete(Guid orgId, Guid id)
+    public async Task Delete([FromRoute] Guid orgId, Guid id)
     {
         var group = await _groupRepository.GetByIdAsync(id);
         if (group == null || group.OrganizationId != orgId)
@@ -238,14 +238,14 @@ public class GroupsController : Controller
     [HttpPost("{id}/delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task PostDelete(Guid orgId, Guid id)
+    public async Task PostDelete([FromRoute] Guid orgId, Guid id)
     {
         await Delete(orgId, id);
     }
 
     [HttpDelete("")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task BulkDelete(Guid orgId, [FromBody] GroupBulkRequestModel model)
+    public async Task BulkDelete([FromRoute] Guid orgId, [FromBody] GroupBulkRequestModel model)
     {
         var groups = await _groupRepository.GetManyByManyIds(model.Ids);
 
@@ -263,14 +263,14 @@ public class GroupsController : Controller
     [HttpPost("delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task PostBulkDelete(Guid orgId, [FromBody] GroupBulkRequestModel model)
+    public async Task PostBulkDelete([FromRoute] Guid orgId, [FromBody] GroupBulkRequestModel model)
     {
         await BulkDelete(orgId, model);
     }
 
     [HttpDelete("{id}/user/{orgUserId}")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task DeleteUser(Guid orgId, Guid id, Guid orgUserId)
+    public async Task DeleteUser([FromRoute] Guid orgId, Guid id, Guid orgUserId)
     {
         var group = await _groupRepository.GetByIdAsync(id);
         if (group == null || group.OrganizationId != orgId)
@@ -284,7 +284,7 @@ public class GroupsController : Controller
     [HttpPost("{id}/delete-user/{orgUserId}")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageGroupsRequirement>]
-    public async Task PostDeleteUser(Guid orgId, Guid id, Guid orgUserId)
+    public async Task PostDeleteUser([FromRoute] Guid orgId, Guid id, Guid orgUserId)
     {
         await DeleteUser(orgId, id, orgUserId);
     }

--- a/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationInviteLinksController.cs
@@ -79,7 +79,7 @@ public class OrganizationInviteLinksController(
     [HttpGet("")]
     [Authorize<ManageUsersRequirement>]
     [ProducesResponseType(typeof(OrganizationInviteLinkResponseModel), (int)HttpStatusCode.OK)]
-    public async Task<IResult> Get(Guid orgId)
+    public async Task<IResult> Get([FromRoute] Guid orgId)
     {
         var result = await getOrganizationInviteLinkQuery.GetAsync(orgId);
 
@@ -90,7 +90,7 @@ public class OrganizationInviteLinksController(
     [HttpPost("")]
     [Authorize<ManageUsersRequirement>]
     [ProducesResponseType(typeof(OrganizationInviteLinkResponseModel), (int)HttpStatusCode.Created)]
-    public async Task<IResult> Create(Guid orgId, [FromBody] CreateOrganizationInviteLinkRequestModel model)
+    public async Task<IResult> Create([FromRoute] Guid orgId, [FromBody] CreateOrganizationInviteLinkRequestModel model)
     {
         var result = await createOrganizationInviteLinkCommand.CreateAsync(
             model.ToCommandRequest(orgId));
@@ -104,7 +104,7 @@ public class OrganizationInviteLinksController(
     [HttpPut("")]
     [Authorize<ManageUsersRequirement>]
     [ProducesResponseType(typeof(OrganizationInviteLinkResponseModel), (int)HttpStatusCode.OK)]
-    public async Task<IResult> Update(Guid orgId, [FromBody] UpdateOrganizationInviteLinkRequestModel model)
+    public async Task<IResult> Update([FromRoute] Guid orgId, [FromBody] UpdateOrganizationInviteLinkRequestModel model)
     {
         var result = await updateOrganizationInviteLinkCommand.UpdateAsync(
             model.ToCommandRequest(orgId));
@@ -116,7 +116,7 @@ public class OrganizationInviteLinksController(
     [HttpPut("support-confirm")]
     [Authorize<ManageUsersRequirement>]
     [ProducesResponseType(typeof(OrganizationInviteLinkResponseModel), (int)HttpStatusCode.OK)]
-    public async Task<IResult> UpdateInviteSupportConfirm(Guid orgId, [FromBody] UpdateInviteSupportConfirmRequestModel model)
+    public async Task<IResult> UpdateInviteSupportConfirm([FromRoute] Guid orgId, [FromBody] UpdateInviteSupportConfirmRequestModel model)
     {
         var result = await updateInviteSupportConfirmCommand.UpdateAsync(
             model.ToCommandRequest(orgId));
@@ -128,7 +128,7 @@ public class OrganizationInviteLinksController(
     [HttpDelete("")]
     [Authorize<ManageUsersRequirement>]
     [ProducesResponseType((int)HttpStatusCode.NoContent)]
-    public async Task<IResult> Delete(Guid orgId)
+    public async Task<IResult> Delete([FromRoute] Guid orgId)
     {
         var result = await deleteOrganizationInviteLinkCommand.DeleteAsync(orgId);
         return Handle(result);
@@ -137,7 +137,7 @@ public class OrganizationInviteLinksController(
     [HttpPost("refresh")]
     [Authorize<ManageUsersRequirement>]
     [ProducesResponseType(typeof(OrganizationInviteLinkResponseModel), (int)HttpStatusCode.OK)]
-    public async Task<IResult> Refresh(Guid orgId, [FromBody] RefreshOrganizationInviteLinkRequestModel model)
+    public async Task<IResult> Refresh([FromRoute] Guid orgId, [FromBody] RefreshOrganizationInviteLinkRequestModel model)
     {
         var result = await refreshOrganizationInviteLinkCommand.RefreshAsync(
             model.ToCommandRequest(orgId));

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -247,7 +247,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpGet("{id}/reset-password-details")]
     [Authorize<ManageAccountRecoveryRequirement>]
-    public async Task<OrganizationUserResetPasswordDetailsResponseModel> GetResetPasswordDetails([FromRoute] Guid orgId, Guid id,
+    public async Task<OrganizationUserResetPasswordDetailsResponseModel> GetResetPasswordDetails(Guid id,
         [BindOrganization] Organization organization)
     {
         var organizationUser = await _organizationUserRepository.GetByIdAsync(id);
@@ -429,7 +429,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPut("{id}")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<IResult> Put([FromRoute] Guid orgId, [BindOrganization] Organization organization, Guid id, [FromBody] OrganizationUserUpdateRequestModel model)
+    public async Task<IResult> Put([BindOrganization] Organization organization, Guid id, [FromBody] OrganizationUserUpdateRequestModel model)
     {
         var (organizationUser, currentAccess) = await _organizationUserRepository.GetByIdWithCollectionsAsync(id);
 
@@ -875,7 +875,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPost("bulk-auto-confirm")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkAutomaticallyConfirmOrganizationUsersAsync(
-        [FromRoute] Guid orgId,
         [BindOrganization] Organization organization,
         [FromBody] OrganizationUserBulkConfirmRequestModel model)
     {

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -174,7 +174,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpGet("{id}")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<OrganizationUserDetailsResponseModel> Get(Guid orgId, Guid id, bool includeGroups = false)
+    public async Task<OrganizationUserDetailsResponseModel> Get([FromRoute] Guid orgId, Guid id, bool includeGroups = false)
     {
         var (organizationUser, collections) = await _organizationUserRepository.GetDetailsByIdWithSharedCollectionsAsync(id);
         if (organizationUser == null || organizationUser.OrganizationId != orgId)
@@ -207,7 +207,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     /// <returns>List of users for the organization.</returns>
     [HttpGet("mini-details")]
     [Authorize<MemberOrProviderRequirement>]
-    public async Task<ListResponseModel<OrganizationUserUserMiniDetailsResponseModel>> GetMiniDetails(Guid orgId)
+    public async Task<ListResponseModel<OrganizationUserUserMiniDetailsResponseModel>> GetMiniDetails([FromRoute] Guid orgId)
     {
         var organizationUserUserDetails = await _organizationUserRepository.GetManyDetailsByOrganizationAsync(orgId);
         return new ListResponseModel<OrganizationUserUserMiniDetailsResponseModel>(
@@ -215,7 +215,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     }
 
     [HttpGet("")]
-    public async Task<ListResponseModel<OrganizationUserUserDetailsResponseModel>> GetAll(Guid orgId, bool includeGroups = false, bool includeCollections = false)
+    public async Task<ListResponseModel<OrganizationUserUserDetailsResponseModel>> GetAll([FromRoute] Guid orgId, bool includeGroups = false, bool includeCollections = false)
     {
         var request = new OrganizationUserUserDetailsQueryRequest
         {
@@ -247,7 +247,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpGet("{id}/reset-password-details")]
     [Authorize<ManageAccountRecoveryRequirement>]
-    public async Task<OrganizationUserResetPasswordDetailsResponseModel> GetResetPasswordDetails(Guid id,
+    public async Task<OrganizationUserResetPasswordDetailsResponseModel> GetResetPasswordDetails([FromRoute] Guid orgId, Guid id,
         [BindOrganization] Organization organization)
     {
         var organizationUser = await _organizationUserRepository.GetByIdAsync(id);
@@ -274,7 +274,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPost("account-recovery-details")]
     [Authorize<ManageAccountRecoveryRequirement>]
-    public async Task<ListResponseModel<OrganizationUserResetPasswordDetailsResponseModel>> GetAccountRecoveryDetails(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserResetPasswordDetailsResponseModel>> GetAccountRecoveryDetails([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         var organizationUsers = await _organizationUserRepository.GetManyAsync(model.Ids);
         var authorizedIds = new List<Guid>();
@@ -301,7 +301,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPost("invite")]
     [Authorize<ManageUsersRequirement>]
-    public async Task Invite(Guid orgId, [FromBody] OrganizationUserInviteRequestModel model)
+    public async Task Invite([FromRoute] Guid orgId, [FromBody] OrganizationUserInviteRequestModel model)
     {
         // Check the user has permission to grant access to the collections for the new user
         if (model.Collections?.Any() == true)
@@ -323,7 +323,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPost("reinvite")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkReinvite(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkReinvite([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         var userId = _userService.GetProperUserId(User);
 
@@ -336,14 +336,14 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPost("{id}/reinvite")]
     [Authorize<ManageUsersRequirement>]
-    public async Task Reinvite(Guid orgId, Guid id)
+    public async Task Reinvite([FromRoute] Guid orgId, Guid id)
     {
         var userId = _userService.GetProperUserId(User);
         await _resendOrganizationInviteCommand.ResendInviteAsync(orgId, userId.Value, id);
     }
 
     [HttpPost("{organizationUserId}/accept-init")]
-    public async Task<IResult> AcceptInit(Guid orgId, Guid organizationUserId, [FromBody] OrganizationUserAcceptInitRequestModel model)
+    public async Task<IResult> AcceptInit([FromRoute] Guid orgId, Guid organizationUserId, [FromBody] OrganizationUserAcceptInitRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         if (user == null)
@@ -368,7 +368,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     }
 
     [HttpPost("{organizationUserId}/accept")]
-    public async Task Accept(Guid orgId, Guid organizationUserId, [FromBody] OrganizationUserAcceptRequestModel model)
+    public async Task Accept([FromRoute] Guid orgId, Guid organizationUserId, [FromBody] OrganizationUserAcceptRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         if (user == null)
@@ -400,7 +400,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPost("{id}/confirm")]
     [Authorize<ManageUsersRequirement>]
-    public async Task Confirm(Guid orgId, Guid id, [FromBody] OrganizationUserConfirmRequestModel model)
+    public async Task Confirm([FromRoute] Guid orgId, Guid id, [FromBody] OrganizationUserConfirmRequestModel model)
     {
         var userId = _userService.GetProperUserId(User);
         _ = await _confirmOrganizationUserCommand.ConfirmUserAsync(orgId, id, model.Key, userId.Value, model.DefaultUserCollectionName);
@@ -408,7 +408,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPost("confirm")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkConfirm(Guid orgId,
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkConfirm([FromRoute] Guid orgId,
         [FromBody] OrganizationUserBulkConfirmRequestModel model)
     {
         var userId = _userService.GetProperUserId(User);
@@ -420,7 +420,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPost("public-keys")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserPublicKeyResponseModel>> UserPublicKeys(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserPublicKeyResponseModel>> UserPublicKeys([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         var result = await _organizationUserRepository.GetManyPublicKeysByOrganizationUserAsync(orgId, model.Ids);
         var responses = result.Select(r => new OrganizationUserPublicKeyResponseModel(r.Id, r.UserId, r.PublicKey)).ToList();
@@ -429,7 +429,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPut("{id}")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<IResult> Put([BindOrganization] Organization organization, Guid id, [FromBody] OrganizationUserUpdateRequestModel model)
+    public async Task<IResult> Put([FromRoute] Guid orgId, [BindOrganization] Organization organization, Guid id, [FromBody] OrganizationUserUpdateRequestModel model)
     {
         var (organizationUser, currentAccess) = await _organizationUserRepository.GetByIdWithCollectionsAsync(id);
 
@@ -531,7 +531,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     }
 
     [HttpPut("{userId}/reset-password-enrollment")]
-    public async Task PutResetPasswordEnrollment(Guid orgId, Guid userId, [FromBody] OrganizationUserResetPasswordEnrollmentRequestModel model)
+    public async Task PutResetPasswordEnrollment([FromRoute] Guid orgId, Guid userId, [FromBody] OrganizationUserResetPasswordEnrollmentRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         if (user == null)
@@ -560,7 +560,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 #nullable enable
     [HttpPut("{id}/recover-account")]
     [Authorize<ManageAccountRecoveryRequirement>]
-    public async Task<IResult> RecoverAccount(Guid orgId, Guid id, [FromBody] OrganizationUserResetPasswordRequestModel model,
+    public async Task<IResult> RecoverAccount([FromRoute] Guid orgId, Guid id, [FromBody] OrganizationUserResetPasswordRequestModel model,
         [InjectOrganizationUser] OrganizationUser targetOrganizationUser)
     {
 
@@ -581,7 +581,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpDelete("{id}")]
     [Authorize<ManageUsersRequirement>]
-    public async Task Remove(Guid orgId, Guid id)
+    public async Task Remove([FromRoute] Guid orgId, Guid id)
     {
         var userId = _userService.GetProperUserId(User);
         await _removeOrganizationUserCommand.RemoveUserAsync(orgId, id, userId.Value);
@@ -590,14 +590,14 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPost("{id}/remove")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageUsersRequirement>]
-    public async Task PostRemove(Guid orgId, Guid id)
+    public async Task PostRemove([FromRoute] Guid orgId, Guid id)
     {
         await Remove(orgId, id);
     }
 
     [HttpDelete("")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRemove(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRemove([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         var userId = _userService.GetProperUserId(User);
         var result = await _removeOrganizationUserCommand.RemoveUsersAsync(orgId, model.Ids, userId.Value);
@@ -608,14 +608,14 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPost("remove")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PostBulkRemove(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PostBulkRemove([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         return await BulkRemove(orgId, model);
     }
 
     [HttpDelete("{id}/delete-account")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<IResult> DeleteAccount(Guid orgId, Guid id)
+    public async Task<IResult> DeleteAccount([FromRoute] Guid orgId, Guid id)
     {
         var currentUserId = _userService.GetProperUserId(User);
         if (currentUserId == null)
@@ -636,14 +636,14 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPost("{id}/delete-account")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageUsersRequirement>]
-    public async Task PostDeleteAccount(Guid orgId, Guid id)
+    public async Task PostDeleteAccount([FromRoute] Guid orgId, Guid id)
     {
         await DeleteAccount(orgId, id);
     }
 
     [HttpDelete("delete-account")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkDeleteAccount(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkDeleteAccount([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         var currentUserId = _userService.GetProperUserId(User);
         if (currentUserId == null)
@@ -664,21 +664,21 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPost("delete-account")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PostBulkDeleteAccount(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PostBulkDeleteAccount([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         return await BulkDeleteAccount(orgId, model);
     }
 
     [HttpPut("{id}/revoke")]
     [Authorize<ManageUsersRequirement>]
-    public async Task RevokeAsync(Guid orgId, Guid id)
+    public async Task RevokeAsync([FromRoute] Guid orgId, Guid id)
     {
         await RestoreOrRevokeUserAsync(orgId, id, (orgUser, userId) => _revokeOrganizationUserCommand.RevokeUserAsync(orgUser, userId, RevocationReason.Manual));
     }
 
     [HttpPut("revoke-self")]
     [Authorize<MemberRequirement>]
-    public async Task<IResult> RevokeSelfAsync(Guid orgId)
+    public async Task<IResult> RevokeSelfAsync([FromRoute] Guid orgId)
     {
         var userId = _userService.GetProperUserId(User);
         if (!userId.HasValue)
@@ -693,14 +693,14 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPatch("{id}/revoke")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead")]
     [Authorize<ManageUsersRequirement>]
-    public async Task PatchRevokeAsync(Guid orgId, Guid id)
+    public async Task PatchRevokeAsync([FromRoute] Guid orgId, Guid id)
     {
         await RevokeAsync(orgId, id);
     }
 
     [HttpPut("revoke")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRevokeAsync(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRevokeAsync([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         var currentUserId = _userService.GetProperUserId(User);
         if (currentUserId == null)
@@ -726,7 +726,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPatch("revoke")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PatchBulkRevokeAsync(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PatchBulkRevokeAsync([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         return await BulkRevokeAsync(orgId, model);
     }
@@ -734,7 +734,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPut("{id}/restore")]
     [Authorize<ManageUsersRequirement>]
     [Obsolete("This endpoint is deprecated. Use _vNext endpoint instead. This will be removed in a future release.")]
-    public async Task RestoreAsync(Guid orgId, Guid id)
+    public async Task RestoreAsync([FromRoute] Guid orgId, Guid id)
     {
         await RestoreOrRevokeUserAsync(orgId, id, (orgUser, userId) => _restoreOrganizationUserCommand.RestoreUserAsync(orgUser, userId, null));
     }
@@ -742,7 +742,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpPut("{id}/restore/vnext")]
     [Authorize<ManageUsersRequirement>]
-    public async Task RestoreAsync_vNext(Guid orgId, Guid id, [FromBody] OrganizationUserRestoreRequest request)
+    public async Task RestoreAsync_vNext([FromRoute] Guid orgId, Guid id, [FromBody] OrganizationUserRestoreRequest request)
     {
         await RestoreOrRevokeUserAsync(orgId, id, (orgUser, userId) => _restoreOrganizationUserCommand.RestoreUserAsync(orgUser, userId, request.DefaultUserCollectionName));
     }
@@ -750,14 +750,14 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPatch("{id}/restore")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead")]
     [Authorize<ManageUsersRequirement>]
-    public async Task PatchRestoreAsync(Guid orgId, Guid id)
+    public async Task PatchRestoreAsync([FromRoute] Guid orgId, Guid id)
     {
         await RestoreAsync(orgId, id);
     }
 
     [HttpPut("restore")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRestoreAsync(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRestoreAsync([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         return await RestoreOrRevokeUsersAsync(orgId, model,
             (orgId, orgUserIds, restoringUserId) => _restoreOrganizationUserCommand.RestoreUsersAsync(orgId, orgUserIds,
@@ -767,14 +767,14 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPatch("restore")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PatchBulkRestoreAsync(Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
+    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PatchBulkRestoreAsync([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
     {
         return await BulkRestoreAsync(orgId, model);
     }
 
     [HttpPut("enable-secrets-manager")]
     [Authorize<ManageUsersRequirement>]
-    public async Task BulkEnableSecretsManagerAsync(Guid orgId,
+    public async Task BulkEnableSecretsManagerAsync([FromRoute] Guid orgId,
         [FromBody] OrganizationUserBulkRequestModel model)
     {
         var orgUsers = (await _organizationUserRepository.GetManyAsync(model.Ids))
@@ -814,7 +814,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     /// </summary>
     [HttpPut("enable-pam")]
     [Authorize<ManageUsersRequirement>]
-    public async Task BulkEnablePamAsync(Guid orgId,
+    public async Task BulkEnablePamAsync([FromRoute] Guid orgId,
         [FromBody] OrganizationUserBulkRequestModel model)
     {
         var orgUsers = (await _organizationUserRepository.GetManyAsync(model.Ids))
@@ -865,7 +865,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
     [HttpGet("pending-auto-confirm")]
     [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserPendingAutoConfirmResponseModel>> GetPendingAutoConfirmUsersAsync(Guid orgId)
+    public async Task<ListResponseModel<OrganizationUserPendingAutoConfirmResponseModel>> GetPendingAutoConfirmUsersAsync([FromRoute] Guid orgId)
     {
         var pendingUsers = await _getPendingAutoConfirmUsersQuery.GetPendingAutoConfirmUsersAsync(orgId);
         return new ListResponseModel<OrganizationUserPendingAutoConfirmResponseModel>(
@@ -875,6 +875,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
     [HttpPost("bulk-auto-confirm")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkAutomaticallyConfirmOrganizationUsersAsync(
+        [FromRoute] Guid orgId,
         [BindOrganization] Organization organization,
         [FromBody] OrganizationUserBulkConfirmRequestModel model)
     {
@@ -926,7 +927,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
             new OrganizationUserBulkResponseModel(r.Item1.Id, r.Item2)));
     }
 
-    private async Task<IDictionary<Guid, bool>> GetClaimedByOrganizationStatusAsync(Guid orgId, IEnumerable<Guid> userIds)
+    private async Task<IDictionary<Guid, bool>> GetClaimedByOrganizationStatusAsync([FromRoute] Guid orgId, IEnumerable<Guid> userIds)
     {
         var usersOrganizationClaimedStatus = await _getOrganizationUsersClaimedStatusQuery.GetUsersOrganizationClaimedStatusAsync(orgId, userIds);
         return usersOrganizationClaimedStatus;

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -926,7 +926,7 @@ public class OrganizationUsersController : BaseAdminConsoleController
             new OrganizationUserBulkResponseModel(r.Item1.Id, r.Item2)));
     }
 
-    private async Task<IDictionary<Guid, bool>> GetClaimedByOrganizationStatusAsync([FromRoute] Guid orgId, IEnumerable<Guid> userIds)
+    private async Task<IDictionary<Guid, bool>> GetClaimedByOrganizationStatusAsync(Guid orgId, IEnumerable<Guid> userIds)
     {
         var usersOrganizationClaimedStatus = await _getOrganizationUsersClaimedStatusQuery.GetUsersOrganizationClaimedStatusAsync(orgId, userIds);
         return usersOrganizationClaimedStatus;

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -488,7 +488,7 @@ public class OrganizationsController : Controller
     [HttpGet("{orgId}/private-key")]
     [RequireFeature(FeatureFlagKeys.GenerateInviteLink)]
     [Authorize<ManageUsersRequirement>]
-    public async Task<OrganizationPrivateKeyResponseModel> GetPrivateKey(Guid orgId)
+    public async Task<OrganizationPrivateKeyResponseModel> GetPrivateKey([FromRoute] Guid orgId)
     {
         var org = await _organizationRepository.GetByIdAsync(orgId);
         if (org == null)

--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -115,7 +115,7 @@ public class PoliciesController : Controller
 
     [HttpGet("master-password")]
     [Authorize<OrgUserLinkedToUserIdRequirement>]
-    public async Task<PolicyResponseModel> GetMasterPasswordPolicy(Guid orgId)
+    public async Task<PolicyResponseModel> GetMasterPasswordPolicy([FromRoute] Guid orgId)
     {
         var organizationAbility = await _organizationAbilityCacheService.GetOrganizationAbilityAsync(orgId);
 

--- a/src/Api/AdminConsole/Controllers/PoliciesController.cs
+++ b/src/Api/AdminConsole/Controllers/PoliciesController.cs
@@ -57,7 +57,7 @@ public class PoliciesController : Controller
 
     [HttpGet("{type}")]
     [Authorize<ManagePoliciesRequirement>]
-    public async Task<PolicyStatusResponseModel> Get(Guid orgId, PolicyType type)
+    public async Task<PolicyStatusResponseModel> Get([FromRoute] Guid orgId, PolicyType type)
     {
         var policy = await _policyQuery.RunAsync(orgId, type);
         if (policy.Type is PolicyType.SingleOrg)
@@ -70,7 +70,7 @@ public class PoliciesController : Controller
 
     [HttpGet("")]
     [Authorize<ManagePoliciesRequirement>]
-    public async Task<ListResponseModel<PolicyStatusResponseModel>> GetAll(string orgId)
+    public async Task<ListResponseModel<PolicyStatusResponseModel>> GetAll([FromRoute] string orgId)
     {
         var orgIdGuid = new Guid(orgId);
         if (!await _currentContext.ManagePolicies(orgIdGuid))
@@ -136,7 +136,7 @@ public class PoliciesController : Controller
 
     [HttpPut("{type}")]
     [Authorize<ManagePoliciesRequirement>]
-    public async Task<PolicyResponseModel> Put(Guid orgId, PolicyType type, [FromBody] SavePolicyRequest model)
+    public async Task<PolicyResponseModel> Put([FromRoute] Guid orgId, PolicyType type, [FromBody] SavePolicyRequest model)
     {
         var savePolicyRequest = await model.ToSavePolicyModelAsync(orgId, type, _currentContext);
 

--- a/src/Api/AdminConsole/Controllers/ProviderOrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/ProviderOrganizationsController.cs
@@ -51,7 +51,7 @@ public class ProviderOrganizationsController : Controller
 
     [HttpGet("")]
     [Authorize<ProviderUserRequirement>]
-    public async Task<ListResponseModel<ProviderOrganizationOrganizationDetailsResponseModel>> Get(Guid providerId)
+    public async Task<ListResponseModel<ProviderOrganizationOrganizationDetailsResponseModel>> Get([FromRoute] Guid providerId)
     {
         var providerOrganizations = await _providerOrganizationRepository.GetManyDetailsByProviderAsync(providerId);
         var responses = providerOrganizations.Select(o => new ProviderOrganizationOrganizationDetailsResponseModel(o));
@@ -60,7 +60,7 @@ public class ProviderOrganizationsController : Controller
 
     [HttpPost("add")]
     [Authorize<ProviderAdminRequirement>]
-    public async Task Add(Guid providerId, [FromBody] ProviderOrganizationAddRequestModel model)
+    public async Task Add([FromRoute] Guid providerId, [FromBody] ProviderOrganizationAddRequestModel model)
     {
         if (!await _currentContext.OrganizationOwner(model.OrganizationId))
         {
@@ -73,7 +73,7 @@ public class ProviderOrganizationsController : Controller
     [HttpPost("")]
     [SelfHosted(NotSelfHostedOnly = true)]
     [Authorize<ProviderAdminRequirement>]
-    public async Task<ProviderOrganizationResponseModel> Post(Guid providerId, [FromBody] ProviderOrganizationCreateRequestModel model)
+    public async Task<ProviderOrganizationResponseModel> Post([FromRoute] Guid providerId, [FromBody] ProviderOrganizationCreateRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         if (user == null)
@@ -89,7 +89,7 @@ public class ProviderOrganizationsController : Controller
 
     [HttpDelete("{id:guid}")]
     [Authorize<ProviderAdminRequirement>]
-    public async Task Delete(Guid providerId, Guid id)
+    public async Task Delete([FromRoute] Guid providerId, Guid id)
     {
         var provider = await _providerRepository.GetByIdAsync(providerId);
 
@@ -106,7 +106,7 @@ public class ProviderOrganizationsController : Controller
     [HttpPost("{id:guid}/delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ProviderAdminRequirement>]
-    public async Task PostDelete(Guid providerId, Guid id)
+    public async Task PostDelete([FromRoute] Guid providerId, Guid id)
     {
         await Delete(providerId, id);
     }

--- a/src/Api/AdminConsole/Controllers/ProviderUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/ProviderUsersController.cs
@@ -37,7 +37,7 @@ public class ProviderUsersController : Controller
 
     [HttpGet("{id:guid}")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task<ProviderUserResponseModel> Get(Guid providerId, Guid id)
+    public async Task<ProviderUserResponseModel> Get([FromRoute] Guid providerId, Guid id)
     {
         var providerUser = await _providerUserRepository.GetByIdAsync(id);
         if (providerUser == null || providerUser.ProviderId != providerId)
@@ -50,7 +50,7 @@ public class ProviderUsersController : Controller
 
     [HttpGet("")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task<ListResponseModel<ProviderUserUserDetailsResponseModel>> GetAll(Guid providerId)
+    public async Task<ListResponseModel<ProviderUserUserDetailsResponseModel>> GetAll([FromRoute] Guid providerId)
     {
         var providerUsers = await _providerUserRepository.GetManyDetailsByProviderAsync(providerId);
         var responses = providerUsers.Select(o => new ProviderUserUserDetailsResponseModel(o));
@@ -59,7 +59,7 @@ public class ProviderUsersController : Controller
 
     [HttpPost("invite")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task Invite(Guid providerId, [FromBody] ProviderUserInviteRequestModel model)
+    public async Task Invite([FromRoute] Guid providerId, [FromBody] ProviderUserInviteRequestModel model)
     {
         var invite = ProviderUserInviteFactory.CreateInitialInvite(model.Emails, model.Type.Value,
             _userService.GetProperUserId(User).Value, providerId);
@@ -68,7 +68,7 @@ public class ProviderUsersController : Controller
 
     [HttpPost("reinvite")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> BulkReinvite(Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
+    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> BulkReinvite([FromRoute] Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
     {
         var invite = ProviderUserInviteFactory.CreateReinvite(model.Ids, _userService.GetProperUserId(User).Value, providerId);
         var result = await _providerService.ResendInvitesAsync(invite);
@@ -78,7 +78,7 @@ public class ProviderUsersController : Controller
 
     [HttpPost("{id:guid}/reinvite")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task Reinvite(Guid providerId, Guid id)
+    public async Task Reinvite([FromRoute] Guid providerId, Guid id)
     {
         var invite = ProviderUserInviteFactory.CreateReinvite(new[] { id },
             _userService.GetProperUserId(User).Value, providerId);
@@ -87,7 +87,7 @@ public class ProviderUsersController : Controller
 
     [HttpPost("{id:guid}/accept")]
     [NoopAuthorize]
-    public async Task Accept(Guid providerId, Guid id, [FromBody] ProviderUserAcceptRequestModel model)
+    public async Task Accept([FromRoute] Guid providerId, Guid id, [FromBody] ProviderUserAcceptRequestModel model)
     {
         var user = await _userService.GetUserByPrincipalAsync(User);
         if (user == null)
@@ -100,7 +100,7 @@ public class ProviderUsersController : Controller
 
     [HttpPost("{id:guid}/confirm")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task Confirm(Guid providerId, Guid id, [FromBody] ProviderUserConfirmRequestModel model)
+    public async Task Confirm([FromRoute] Guid providerId, Guid id, [FromBody] ProviderUserConfirmRequestModel model)
     {
         var userId = _userService.GetProperUserId(User);
         await _providerService.ConfirmUsersAsync(providerId, new Dictionary<Guid, string> { [id] = model.Key }, userId.Value);
@@ -108,7 +108,7 @@ public class ProviderUsersController : Controller
 
     [HttpPost("confirm")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> BulkConfirm(Guid providerId,
+    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> BulkConfirm([FromRoute] Guid providerId,
         [FromBody] ProviderUserBulkConfirmRequestModel model)
     {
         var userId = _userService.GetProperUserId(User);
@@ -120,7 +120,7 @@ public class ProviderUsersController : Controller
 
     [HttpPost("public-keys")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task<ListResponseModel<ProviderUserPublicKeyResponseModel>> UserPublicKeys(Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
+    public async Task<ListResponseModel<ProviderUserPublicKeyResponseModel>> UserPublicKeys([FromRoute] Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
     {
         var result = await _providerUserRepository.GetManyPublicKeysByProviderUserAsync(providerId, model.Ids);
         var responses = result.Select(r => new ProviderUserPublicKeyResponseModel(r.Id, r.UserId, r.PublicKey)).ToList();
@@ -129,7 +129,7 @@ public class ProviderUsersController : Controller
 
     [HttpPut("{id:guid}")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task Put(Guid providerId, Guid id, [FromBody] ProviderUserUpdateRequestModel model)
+    public async Task Put([FromRoute] Guid providerId, Guid id, [FromBody] ProviderUserUpdateRequestModel model)
     {
         var providerUser = await _providerUserRepository.GetByIdAsync(id);
         if (providerUser == null || providerUser.ProviderId != providerId)
@@ -144,14 +144,14 @@ public class ProviderUsersController : Controller
     [HttpPost("{id:guid}")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task PostPut(Guid providerId, Guid id, [FromBody] ProviderUserUpdateRequestModel model)
+    public async Task PostPut([FromRoute] Guid providerId, Guid id, [FromBody] ProviderUserUpdateRequestModel model)
     {
         await Put(providerId, id, model);
     }
 
     [HttpDelete("{id:guid}")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task Delete(Guid providerId, Guid id)
+    public async Task Delete([FromRoute] Guid providerId, Guid id)
     {
         var userId = _userService.GetProperUserId(User);
         await _providerService.DeleteUsersAsync(providerId, new[] { id }, userId.Value);
@@ -160,14 +160,14 @@ public class ProviderUsersController : Controller
     [HttpPost("{id:guid}/delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task PostDelete(Guid providerId, Guid id)
+    public async Task PostDelete([FromRoute] Guid providerId, Guid id)
     {
         await Delete(providerId, id);
     }
 
     [HttpDelete("")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> BulkDelete(Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
+    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> BulkDelete([FromRoute] Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
     {
         var userId = _userService.GetProperUserId(User);
         var result = await _providerService.DeleteUsersAsync(providerId, model.Ids, userId.Value);
@@ -178,7 +178,7 @@ public class ProviderUsersController : Controller
     [HttpPost("delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ManageProviderUsersRequirement>]
-    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> PostBulkDelete(Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
+    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> PostBulkDelete([FromRoute] Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
     {
         return await BulkDelete(providerId, model);
     }

--- a/src/Api/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Api/AdminConsole/Controllers/ProvidersController.cs
@@ -41,7 +41,7 @@ public class ProvidersController : Controller
 
     [HttpGet("{providerId:guid}")]
     [Authorize<ProviderUserRequirement>]
-    public async Task<ProviderResponseModel> Get(Guid providerId)
+    public async Task<ProviderResponseModel> Get([FromRoute] Guid providerId)
     {
         var provider = await _providerRepository.GetByIdAsync(providerId);
         if (provider == null)
@@ -54,7 +54,7 @@ public class ProvidersController : Controller
 
     [HttpPut("{providerId:guid}")]
     [Authorize<ProviderAdminRequirement>]
-    public async Task<ProviderResponseModel> Put(Guid providerId, [FromBody] ProviderUpdateRequestModel model)
+    public async Task<ProviderResponseModel> Put([FromRoute] Guid providerId, [FromBody] ProviderUpdateRequestModel model)
     {
         var provider = await _providerRepository.GetByIdAsync(providerId);
         if (provider == null)
@@ -89,14 +89,14 @@ public class ProvidersController : Controller
     [HttpPost("{providerId:guid}")]
     [Obsolete("This endpoint is deprecated. Use PUT method instead")]
     [Authorize<ProviderAdminRequirement>]
-    public async Task<ProviderResponseModel> PostPut(Guid providerId, [FromBody] ProviderUpdateRequestModel model)
+    public async Task<ProviderResponseModel> PostPut([FromRoute] Guid providerId, [FromBody] ProviderUpdateRequestModel model)
     {
         return await Put(providerId, model);
     }
 
     [HttpPost("{providerId:guid}/setup")]
     [Authorize<ProviderAdminRequirement>]
-    public async Task<ProviderResponseModel> Setup(Guid providerId, [FromBody] ProviderSetupRequestModel model)
+    public async Task<ProviderResponseModel> Setup([FromRoute] Guid providerId, [FromBody] ProviderSetupRequestModel model)
     {
         var provider = await _providerRepository.GetByIdAsync(providerId);
         if (provider == null)
@@ -118,7 +118,7 @@ public class ProvidersController : Controller
 
     [HttpPost("{providerId}/delete-recover-token")]
     [AllowAnonymous]
-    public async Task PostDeleteRecoverToken(Guid providerId, [FromBody] ProviderVerifyDeleteRecoverRequestModel model)
+    public async Task PostDeleteRecoverToken([FromRoute] Guid providerId, [FromBody] ProviderVerifyDeleteRecoverRequestModel model)
     {
         var provider = await _providerRepository.GetByIdAsync(providerId);
         if (provider == null)
@@ -130,7 +130,7 @@ public class ProvidersController : Controller
 
     [HttpDelete("{providerId}")]
     [Authorize<ProviderAdminRequirement>]
-    public async Task Delete(Guid providerId)
+    public async Task Delete([FromRoute] Guid providerId)
     {
         var provider = await _providerRepository.GetByIdAsync(providerId);
         if (provider == null)
@@ -150,7 +150,7 @@ public class ProvidersController : Controller
     [HttpPost("{providerId}/delete")]
     [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
     [Authorize<ProviderAdminRequirement>]
-    public async Task PostDelete(Guid providerId)
+    public async Task PostDelete([FromRoute] Guid providerId)
     {
         await Delete(providerId);
     }

--- a/src/Api/Controllers/SelfHosted/SelfHostedOrganizationSponsorshipsController.cs
+++ b/src/Api/Controllers/SelfHosted/SelfHostedOrganizationSponsorshipsController.cs
@@ -104,7 +104,7 @@ public class SelfHostedOrganizationSponsorshipsController : Controller
 
     [Authorize("Application")]
     [HttpGet("{orgId}/sponsored")]
-    public async Task<ListResponseModel<OrganizationSponsorshipInvitesResponseModel>> GetSponsoredOrganizations(Guid orgId)
+    public async Task<ListResponseModel<OrganizationSponsorshipInvitesResponseModel>> GetSponsoredOrganizations([FromRoute] Guid orgId)
     {
         var sponsoringOrg = await _organizationRepository.GetByIdAsync(orgId);
         if (sponsoringOrg == null)

--- a/src/Libraries/Subscriptions.Organization/OrganizationSubscriptionEndpointsExtensions.cs
+++ b/src/Libraries/Subscriptions.Organization/OrganizationSubscriptionEndpointsExtensions.cs
@@ -30,7 +30,7 @@ public static class OrganizationSubscriptionEndpointsExtensions
         group.RequireFeature(InvoicingFeatureFlags.PM36631_PreviewDrivenCart);
 
         group.MapGet("preview",
-                async (Guid organizationId, [FromServices] OrganizationSubscriptionEndpointsHandler handler) => await handler.GetPreviewAsync(organizationId))
+                async ([FromRoute] Guid organizationId, [FromServices] OrganizationSubscriptionEndpointsHandler handler) => await handler.GetPreviewAsync(organizationId))
             .WithName("GetOrganizationSubscriptionPreview")
             .WithDescription("Previews the organization's upcoming subscription renewal.");
 

--- a/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
@@ -2,13 +2,12 @@
 using Bit.Api.AdminConsole.Authorization;
 using Bit.Api.IntegrationTest.Factories;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using Xunit;
 
 namespace Bit.Api.IntegrationTest.AdminConsole.Authorization;
 
-public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory) : IClassFixture<ApiApplicationFactory>
+public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory)
+    : RequirementFromRouteTestsBase(factory), IClassFixture<ApiApplicationFactory>
 {
     private static readonly string[] _organizationIdRouteNames = ["orgId", "organizationId"];
 
@@ -29,70 +28,18 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
     /// The handler reads the id from route values only. [FromRoute] forces the binding to that.
     /// </summary>
     [Fact]
-    public void AllOrganizationRequirementEndpoints_BindOrganizationIdFromRoute()
-    {
-        var endpointDataSources = factory.Services.GetRequiredService<IEnumerable<EndpointDataSource>>();
+    public void AllOrganizationRequirementEndpoints_BindOrganizationIdFromRoute() =>
+        AssertAllRequirementEndpointsBindIdFromRoute();
 
-        var violations = endpointDataSources
-            .SelectMany(source => source.Endpoints)
-            .Where(HasOrganizationRequirement)
-            .Where(HasOrganizationIdParameterNotBoundFromRoute)
-            .Select(Describe)
-            .Distinct()
-            .OrderBy(description => description)
-            .ToList();
-
-        Assert.True(violations.Count == 0, BuildFailureMessage(violations));
-    }
-
-    private static bool HasOrganizationRequirement(Endpoint endpoint) =>
-        endpoint.Metadata
-            .OfType<IAuthorizationRequirementData>()
-            .SelectMany(data => data.GetRequirements())
-            .Any(IsOrganizationRequirement);
-
-    private static bool IsOrganizationRequirement(IAuthorizationRequirement requirement) =>
+    protected override bool IsRequirement(IAuthorizationRequirement requirement) =>
         requirement is IOrganizationRequirement || _routeReadingRequirements.Contains(requirement.GetType());
 
-    private static bool HasOrganizationIdParameterNotBoundFromRoute(Endpoint endpoint)
-    {
-        var methodInfo = GetMethodInfo(endpoint);
-        if (methodInfo == null)
-        {
-            return false;
-        }
-
-        return methodInfo.GetParameters()
-            .Where(IsOrganizationIdParameter)
-            .Any(parameter => parameter.GetCustomAttribute<FromRouteAttribute>() == null);
-    }
-
-    private static bool IsOrganizationIdParameter(ParameterInfo parameter) =>
+    protected override bool IsRouteIdParameter(ParameterInfo parameter) =>
         _organizationIdRouteNames.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase);
 
-    private static MethodInfo? GetMethodInfo(Endpoint endpoint) =>
-        endpoint.Metadata.GetMetadata<ControllerActionDescriptor>()?.MethodInfo
-        ?? endpoint.Metadata.GetMetadata<MethodInfo>();
-
-    private static string Describe(Endpoint endpoint)
-    {
-        var route = (endpoint as RouteEndpoint)?.RoutePattern.RawText ?? endpoint.DisplayName ?? "(unknown route)";
-        var httpMethods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods;
-        var verbs = httpMethods is { Count: > 0 } ? string.Join(",", httpMethods) : "ANY";
-
-        var requirements = endpoint.Metadata
-            .OfType<IAuthorizationRequirementData>()
-            .SelectMany(data => data.GetRequirements())
-            .Where(IsOrganizationRequirement)
-            .Select(requirement => requirement.GetType().Name)
-            .Distinct();
-
-        return $"{verbs} {route} [{string.Join(", ", requirements)}]";
-    }
-
-    private static string BuildFailureMessage(List<string> violations) =>
-        $"{violations.Count} endpoint(s) guarded by an organization requirement declare an 'orgId' or " +
+    protected override string FailureSummary(int violationCount) =>
+        $"{violationCount} endpoint(s) guarded by an organization requirement declare an 'orgId' or " +
         "'organizationId' parameter without [FromRoute]. The requirement handler reads the organization id from " +
         "route values only, so a same-named parameter must be bound with [FromRoute] or a form body value can " +
-        $"shadow it and diverge from the authorized id:\n  - {string.Join("\n  - ", violations)}";
+        "shadow it and diverge from the authorized id";
 }

--- a/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Reflection;
+using Bit.Api.AdminConsole.Authorization;
+using Bit.Api.IntegrationTest.Factories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Authorization;
+
+public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory) : IClassFixture<ApiApplicationFactory>
+{
+    private static readonly string[] _organizationIdRouteNames = ["orgId", "organizationId"];
+
+    /// <summary>
+    /// Every endpoint guarded by an <see cref="IOrganizationRequirement"/> must bind the organization id from
+    /// the route with an explicit <c>[FromRoute]</c> parameter named <c>orgId</c> or <c>organizationId</c>.
+    /// <see cref="OrganizationRequirementHandler"/> resolves the id via
+    /// <see cref="HttpContextExtensions.GetOrganizationId"/>, which reads route values only and throws
+    /// <see cref="HttpContextExtensions.NoOrgIdError"/> otherwise. An endpoint that does not bind the id from
+    /// the route would therefore fail at runtime. This test enforces the binding at build time.
+    /// </summary>
+    [Fact]
+    public void AllOrganizationRequirementEndpoints_BindOrganizationIdFromRoute()
+    {
+        var endpointDataSources = factory.Services.GetRequiredService<IEnumerable<EndpointDataSource>>();
+
+        var violations = endpointDataSources
+            .SelectMany(source => source.Endpoints)
+            .Where(HasOrganizationRequirement)
+            .Where(endpoint => !BindsOrganizationIdFromRoute(endpoint))
+            .Select(Describe)
+            .Distinct()
+            .OrderBy(description => description)
+            .ToList();
+
+        Assert.True(violations.Count == 0, BuildFailureMessage(violations));
+    }
+
+    private static bool HasOrganizationRequirement(Endpoint endpoint) =>
+        endpoint.Metadata
+            .OfType<IAuthorizationRequirementData>()
+            .SelectMany(data => data.GetRequirements())
+            .OfType<IOrganizationRequirement>()
+            .Any();
+
+    private static bool BindsOrganizationIdFromRoute(Endpoint endpoint)
+    {
+        var methodInfo = GetMethodInfo(endpoint);
+        if (methodInfo == null)
+        {
+            return false;
+        }
+
+        return methodInfo.GetParameters().Any(IsOrganizationIdFromRoute);
+    }
+
+    private static bool IsOrganizationIdFromRoute(ParameterInfo parameter)
+    {
+        var fromRoute = parameter.GetCustomAttribute<FromRouteAttribute>();
+        if (fromRoute == null)
+        {
+            return false;
+        }
+
+        var boundName = fromRoute.Name ?? parameter.Name;
+        return _organizationIdRouteNames.Contains(boundName, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static MethodInfo? GetMethodInfo(Endpoint endpoint) =>
+        endpoint.Metadata.GetMetadata<ControllerActionDescriptor>()?.MethodInfo
+        ?? endpoint.Metadata.GetMetadata<MethodInfo>();
+
+    private static string Describe(Endpoint endpoint)
+    {
+        var route = (endpoint as RouteEndpoint)?.RoutePattern.RawText ?? endpoint.DisplayName ?? "(unknown route)";
+        var httpMethods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods;
+        var verbs = httpMethods is { Count: > 0 } ? string.Join(",", httpMethods) : "ANY";
+
+        var requirements = endpoint.Metadata
+            .OfType<IAuthorizationRequirementData>()
+            .SelectMany(data => data.GetRequirements())
+            .OfType<IOrganizationRequirement>()
+            .Select(requirement => requirement.GetType().Name)
+            .Distinct();
+
+        return $"{verbs} {route} [{string.Join(", ", requirements)}]";
+    }
+
+    private static string BuildFailureMessage(IReadOnlyCollection<string> violations) =>
+        $"{violations.Count} endpoint(s) guarded by an IOrganizationRequirement do not bind the organization id " +
+        "from the route. Each must declare a parameter with [FromRoute] named 'orgId' or 'organizationId' " +
+        "(the OrganizationRequirementHandler reads the id from route values only and will otherwise throw at " +
+        $"runtime):\n  - {string.Join("\n  - ", violations)}";
+}

--- a/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
@@ -1,5 +1,7 @@
 ﻿using System.Reflection;
+using Bit.Api.AdminConsole.Attributes;
 using Bit.Api.AdminConsole.Authorization;
+using Bit.Api.Billing.Attributes;
 using Bit.Api.IntegrationTest.Factories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -13,12 +15,8 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
     private static readonly string[] _organizationIdRouteNames = ["orgId", "organizationId"];
 
     /// <summary>
-    /// Every endpoint guarded by an <see cref="IOrganizationRequirement"/> must bind the organization id from
-    /// the route with an explicit <c>[FromRoute]</c> parameter named <c>orgId</c> or <c>organizationId</c>.
-    /// <see cref="OrganizationRequirementHandler"/> resolves the id via
-    /// <see cref="HttpContextExtensions.GetOrganizationId"/>, which reads route values only and throws
-    /// <see cref="HttpContextExtensions.NoOrgIdError"/> otherwise. An endpoint that does not bind the id from
-    /// the route would therefore fail at runtime. This test enforces the binding at build time.
+    /// <see cref="OrganizationRequirementHandler"/> reads the organization id from route values only, so every
+    /// <see cref="IOrganizationRequirement"/> endpoint must source it from the route or it fails at runtime.
     /// </summary>
     [Fact]
     public void AllOrganizationRequirementEndpoints_BindOrganizationIdFromRoute()
@@ -52,7 +50,9 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
             return false;
         }
 
-        return methodInfo.GetParameters().Any(IsOrganizationIdFromRoute);
+        return methodInfo.GetParameters().Any(IsOrganizationIdFromRoute)
+               || methodInfo.GetCustomAttribute<InjectOrganizationAttribute>() != null
+               || methodInfo.GetParameters().Any(parameter => parameter.GetCustomAttribute<BindOrganizationAttribute>() != null);
     }
 
     private static bool IsOrganizationIdFromRoute(ParameterInfo parameter)
@@ -88,8 +88,9 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
     }
 
     private static string BuildFailureMessage(IReadOnlyCollection<string> violations) =>
-        $"{violations.Count} endpoint(s) guarded by an IOrganizationRequirement do not bind the organization id " +
-        "from the route. Each must declare a parameter with [FromRoute] named 'orgId' or 'organizationId' " +
+        $"{violations.Count} endpoint(s) guarded by an IOrganizationRequirement do not source the organization id " +
+        "from the route. Each must declare a parameter with [FromRoute] named 'orgId' or 'organizationId', or use " +
+        "a route-reading binder ([InjectOrganization] on the action or [BindOrganization] on a parameter) " +
         "(the OrganizationRequirementHandler reads the id from route values only and will otherwise throw at " +
         $"runtime):\n  - {string.Join("\n  - ", violations)}";
 }

--- a/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
@@ -1,7 +1,5 @@
 ﻿using System.Reflection;
-using Bit.Api.AdminConsole.Attributes;
 using Bit.Api.AdminConsole.Authorization;
-using Bit.Api.Billing.Attributes;
 using Bit.Api.IntegrationTest.Factories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,9 +12,21 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
 {
     private static readonly string[] _organizationIdRouteNames = ["orgId", "organizationId"];
 
+    private static readonly Type[] _routeReadingRequirements =
+    [
+        typeof(OrgUserLinkedToUserIdRequirement),
+        typeof(OrganizationCollectionManagementAccessRequirement),
+    ];
+
     /// <summary>
-    /// <see cref="OrganizationRequirementHandler"/> reads the organization id from route values only, so every
-    /// <see cref="IOrganizationRequirement"/> endpoint must source it from the route or it fails at runtime.
+    /// IF the endpoint uses:
+    ///   <see cref="IOrganizationRequirement"/>
+    ///   OR <see cref="OrgUserLinkedToUserIdRequirement"/>
+    ///   OR <see cref="OrganizationCollectionManagementAccessRequirement"/>
+    /// AND has an orgId or organizationId parameter
+    /// THEN that parameter must have [FromRoute].
+    ///
+    /// The handler reads the id from route values only. [FromRoute] forces the binding to that.
     /// </summary>
     [Fact]
     public void AllOrganizationRequirementEndpoints_BindOrganizationIdFromRoute()
@@ -26,7 +36,7 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
         var violations = endpointDataSources
             .SelectMany(source => source.Endpoints)
             .Where(HasOrganizationRequirement)
-            .Where(endpoint => !BindsOrganizationIdFromRoute(endpoint))
+            .Where(HasOrganizationIdParameterNotBoundFromRoute)
             .Select(Describe)
             .Distinct()
             .OrderBy(description => description)
@@ -39,10 +49,12 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
         endpoint.Metadata
             .OfType<IAuthorizationRequirementData>()
             .SelectMany(data => data.GetRequirements())
-            .OfType<IOrganizationRequirement>()
-            .Any();
+            .Any(IsOrganizationRequirement);
 
-    private static bool BindsOrganizationIdFromRoute(Endpoint endpoint)
+    private static bool IsOrganizationRequirement(IAuthorizationRequirement requirement) =>
+        requirement is IOrganizationRequirement || _routeReadingRequirements.Contains(requirement.GetType());
+
+    private static bool HasOrganizationIdParameterNotBoundFromRoute(Endpoint endpoint)
     {
         var methodInfo = GetMethodInfo(endpoint);
         if (methodInfo == null)
@@ -50,22 +62,13 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
             return false;
         }
 
-        return methodInfo.GetParameters().Any(IsOrganizationIdFromRoute)
-               || methodInfo.GetCustomAttribute<InjectOrganizationAttribute>() != null
-               || methodInfo.GetParameters().Any(parameter => parameter.GetCustomAttribute<BindOrganizationAttribute>() != null);
+        return methodInfo.GetParameters()
+            .Where(IsOrganizationIdParameter)
+            .Any(parameter => parameter.GetCustomAttribute<FromRouteAttribute>() == null);
     }
 
-    private static bool IsOrganizationIdFromRoute(ParameterInfo parameter)
-    {
-        var fromRoute = parameter.GetCustomAttribute<FromRouteAttribute>();
-        if (fromRoute == null)
-        {
-            return false;
-        }
-
-        var boundName = fromRoute.Name ?? parameter.Name;
-        return _organizationIdRouteNames.Contains(boundName, StringComparer.OrdinalIgnoreCase);
-    }
+    private static bool IsOrganizationIdParameter(ParameterInfo parameter) =>
+        _organizationIdRouteNames.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase);
 
     private static MethodInfo? GetMethodInfo(Endpoint endpoint) =>
         endpoint.Metadata.GetMetadata<ControllerActionDescriptor>()?.MethodInfo
@@ -80,17 +83,16 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
         var requirements = endpoint.Metadata
             .OfType<IAuthorizationRequirementData>()
             .SelectMany(data => data.GetRequirements())
-            .OfType<IOrganizationRequirement>()
+            .Where(IsOrganizationRequirement)
             .Select(requirement => requirement.GetType().Name)
             .Distinct();
 
         return $"{verbs} {route} [{string.Join(", ", requirements)}]";
     }
 
-    private static string BuildFailureMessage(IReadOnlyCollection<string> violations) =>
-        $"{violations.Count} endpoint(s) guarded by an IOrganizationRequirement do not source the organization id " +
-        "from the route. Each must declare a parameter with [FromRoute] named 'orgId' or 'organizationId', or use " +
-        "a route-reading binder ([InjectOrganization] on the action or [BindOrganization] on a parameter) " +
-        "(the OrganizationRequirementHandler reads the id from route values only and will otherwise throw at " +
-        $"runtime):\n  - {string.Join("\n  - ", violations)}";
+    private static string BuildFailureMessage(List<string> violations) =>
+        $"{violations.Count} endpoint(s) guarded by an organization requirement declare an 'orgId' or " +
+        "'organizationId' parameter without [FromRoute]. The requirement handler reads the organization id from " +
+        "route values only, so a same-named parameter must be bound with [FromRoute] or a form body value can " +
+        $"shadow it and diverge from the authorized id:\n  - {string.Join("\n  - ", violations)}";
 }

--- a/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Authorization/OrganizationRequirementFromRouteTests.cs
@@ -1,13 +1,14 @@
 ﻿using System.Reflection;
 using Bit.Api.AdminConsole.Authorization;
 using Bit.Api.IntegrationTest.Factories;
+using Bit.IntegrationTestCommon;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
 
 namespace Bit.Api.IntegrationTest.AdminConsole.Authorization;
 
 public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory)
-    : RequirementFromRouteTestsBase(factory), IClassFixture<ApiApplicationFactory>
+    : RouteIdFromRouteTestsBase(factory.Services), IClassFixture<ApiApplicationFactory>
 {
     private static readonly string[] _organizationIdRouteNames = ["orgId", "organizationId"];
 
@@ -29,10 +30,25 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
     /// </summary>
     [Fact]
     public void AllOrganizationRequirementEndpoints_BindOrganizationIdFromRoute() =>
-        AssertAllRequirementEndpointsBindIdFromRoute();
+        AssertAllGuardedEndpointsBindIdFromRoute();
 
-    protected override bool IsRequirement(IAuthorizationRequirement requirement) =>
-        requirement is IOrganizationRequirement || _routeReadingRequirements.Contains(requirement.GetType());
+    protected override bool IsGuardedEndpoint(Endpoint endpoint) =>
+        endpoint.Metadata
+            .OfType<IAuthorizationRequirementData>()
+            .SelectMany(data => data.GetRequirements())
+            .Any(IsRequirement);
+
+    protected override string DescribeSuffix(Endpoint endpoint)
+    {
+        var requirements = endpoint.Metadata
+            .OfType<IAuthorizationRequirementData>()
+            .SelectMany(data => data.GetRequirements())
+            .Where(IsRequirement)
+            .Select(requirement => requirement.GetType().Name)
+            .Distinct();
+
+        return $" [{string.Join(", ", requirements)}]";
+    }
 
     protected override bool IsRouteIdParameter(ParameterInfo parameter) =>
         _organizationIdRouteNames.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase);
@@ -42,4 +58,7 @@ public class OrganizationRequirementFromRouteTests(ApiApplicationFactory factory
         "'organizationId' parameter without [FromRoute]. The requirement handler reads the organization id from " +
         "route values only, so a same-named parameter must be bound with [FromRoute] or a form body value can " +
         "shadow it and diverge from the authorized id";
+
+    private static bool IsRequirement(IAuthorizationRequirement requirement) =>
+        requirement is IOrganizationRequirement || _routeReadingRequirements.Contains(requirement.GetType());
 }

--- a/test/Api.IntegrationTest/AdminConsole/Authorization/ProviderRequirementFromRouteTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Authorization/ProviderRequirementFromRouteTests.cs
@@ -1,13 +1,14 @@
 ﻿using System.Reflection;
 using Bit.Api.AdminConsole.Authorization.Providers;
 using Bit.Api.IntegrationTest.Factories;
+using Bit.IntegrationTestCommon;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
 
 namespace Bit.Api.IntegrationTest.AdminConsole.Authorization;
 
 public class ProviderRequirementFromRouteTests(ApiApplicationFactory factory)
-    : RequirementFromRouteTestsBase(factory), IClassFixture<ApiApplicationFactory>
+    : RouteIdFromRouteTestsBase(factory.Services), IClassFixture<ApiApplicationFactory>
 {
     private const string _providerIdRouteName = "providerId";
 
@@ -21,10 +22,25 @@ public class ProviderRequirementFromRouteTests(ApiApplicationFactory factory)
     /// </summary>
     [Fact]
     public void AllProviderRequirementEndpoints_BindProviderIdFromRoute() =>
-        AssertAllRequirementEndpointsBindIdFromRoute();
+        AssertAllGuardedEndpointsBindIdFromRoute();
 
-    protected override bool IsRequirement(IAuthorizationRequirement requirement) =>
-        requirement is IProviderRequirement;
+    protected override bool IsGuardedEndpoint(Endpoint endpoint) =>
+        endpoint.Metadata
+            .OfType<IAuthorizationRequirementData>()
+            .SelectMany(data => data.GetRequirements())
+            .Any(IsRequirement);
+
+    protected override string DescribeSuffix(Endpoint endpoint)
+    {
+        var requirements = endpoint.Metadata
+            .OfType<IAuthorizationRequirementData>()
+            .SelectMany(data => data.GetRequirements())
+            .Where(IsRequirement)
+            .Select(requirement => requirement.GetType().Name)
+            .Distinct();
+
+        return $" [{string.Join(", ", requirements)}]";
+    }
 
     protected override bool IsRouteIdParameter(ParameterInfo parameter) =>
         string.Equals(parameter.Name, _providerIdRouteName, StringComparison.OrdinalIgnoreCase);
@@ -34,4 +50,7 @@ public class ProviderRequirementFromRouteTests(ApiApplicationFactory factory)
         "without [FromRoute]. The ProviderRequirementHandler reads the provider id from route values only, so a " +
         "same-named parameter must be bound with [FromRoute] or a form body value can shadow it and diverge from " +
         "the authorized id";
+
+    private static bool IsRequirement(IAuthorizationRequirement requirement) =>
+        requirement is IProviderRequirement;
 }

--- a/test/Api.IntegrationTest/AdminConsole/Authorization/ProviderRequirementFromRouteTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Authorization/ProviderRequirementFromRouteTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+using Bit.Api.AdminConsole.Authorization.Providers;
+using Bit.Api.IntegrationTest.Factories;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Authorization;
+
+public class ProviderRequirementFromRouteTests(ApiApplicationFactory factory)
+    : RequirementFromRouteTestsBase(factory), IClassFixture<ApiApplicationFactory>
+{
+    private const string _providerIdRouteName = "providerId";
+
+    /// <summary>
+    /// IF the endpoint uses:
+    ///   <see cref="IProviderRequirement"/>
+    /// AND has a providerId parameter
+    /// THEN that parameter must have [FromRoute].
+    ///
+    /// The handler reads the id from route values only. [FromRoute] forces the binding to that.
+    /// </summary>
+    [Fact]
+    public void AllProviderRequirementEndpoints_BindProviderIdFromRoute() =>
+        AssertAllRequirementEndpointsBindIdFromRoute();
+
+    protected override bool IsRequirement(IAuthorizationRequirement requirement) =>
+        requirement is IProviderRequirement;
+
+    protected override bool IsRouteIdParameter(ParameterInfo parameter) =>
+        string.Equals(parameter.Name, _providerIdRouteName, StringComparison.OrdinalIgnoreCase);
+
+    protected override string FailureSummary(int violationCount) =>
+        $"{violationCount} endpoint(s) guarded by an IProviderRequirement declare a 'providerId' parameter " +
+        "without [FromRoute]. The ProviderRequirementHandler reads the provider id from route values only, so a " +
+        "same-named parameter must be bound with [FromRoute] or a form body value can shadow it and diverge from " +
+        "the authorized id";
+}

--- a/test/Api.IntegrationTest/AdminConsole/Authorization/RequirementFromRouteTestsBase.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Authorization/RequirementFromRouteTestsBase.cs
@@ -1,0 +1,75 @@
+﻿using System.Reflection;
+using Bit.Api.IntegrationTest.Factories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Authorization;
+
+public abstract class RequirementFromRouteTestsBase(ApiApplicationFactory factory)
+{
+    protected abstract bool IsRequirement(IAuthorizationRequirement requirement);
+
+    protected abstract bool IsRouteIdParameter(ParameterInfo parameter);
+
+    protected abstract string FailureSummary(int violationCount);
+
+    protected void AssertAllRequirementEndpointsBindIdFromRoute()
+    {
+        var endpointDataSources = factory.Services.GetRequiredService<IEnumerable<EndpointDataSource>>();
+
+        var violations = endpointDataSources
+            .SelectMany(source => source.Endpoints)
+            .Where(HasRequirement)
+            .Where(HasIdParameterNotBoundFromRoute)
+            .Select(Describe)
+            .Distinct()
+            .OrderBy(description => description)
+            .ToList();
+
+        Assert.True(violations.Count == 0, BuildFailureMessage(violations));
+    }
+
+    private bool HasRequirement(Endpoint endpoint) =>
+        endpoint.Metadata
+            .OfType<IAuthorizationRequirementData>()
+            .SelectMany(data => data.GetRequirements())
+            .Any(IsRequirement);
+
+    private bool HasIdParameterNotBoundFromRoute(Endpoint endpoint)
+    {
+        var methodInfo = GetMethodInfo(endpoint);
+        if (methodInfo == null)
+        {
+            return false;
+        }
+
+        return methodInfo.GetParameters()
+            .Where(IsRouteIdParameter)
+            .Any(parameter => parameter.GetCustomAttribute<FromRouteAttribute>() == null);
+    }
+
+    private static MethodInfo? GetMethodInfo(Endpoint endpoint) =>
+        endpoint.Metadata.GetMetadata<ControllerActionDescriptor>()?.MethodInfo
+        ?? endpoint.Metadata.GetMetadata<MethodInfo>();
+
+    private string Describe(Endpoint endpoint)
+    {
+        var route = (endpoint as RouteEndpoint)?.RoutePattern.RawText ?? endpoint.DisplayName ?? "(unknown route)";
+        var httpMethods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods;
+        var verbs = httpMethods is { Count: > 0 } ? string.Join(",", httpMethods) : "ANY";
+
+        var requirements = endpoint.Metadata
+            .OfType<IAuthorizationRequirementData>()
+            .SelectMany(data => data.GetRequirements())
+            .Where(IsRequirement)
+            .Select(requirement => requirement.GetType().Name)
+            .Distinct();
+
+        return $"{verbs} {route} [{string.Join(", ", requirements)}]";
+    }
+
+    private string BuildFailureMessage(List<string> violations) =>
+        $"{FailureSummary(violations.Count)}:\n  - {string.Join("\n  - ", violations)}";
+}

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerGetTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerGetTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Net;
+using Bit.Api.IntegrationTest.Factories;
+using Bit.Api.IntegrationTest.Helpers;
+using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Xunit;
+
+namespace Bit.Api.IntegrationTest.AdminConsole.Controllers;
+
+public class OrganizationUsersControllerGetTests : IClassFixture<ApiApplicationFactory>, IAsyncLifetime
+{
+    private readonly HttpClient _client;
+    private readonly ApiApplicationFactory _factory;
+    private readonly LoginHelper _loginHelper;
+
+    private string _ownerEmailA = null!;
+    private Organization _organizationA = null!;
+
+    private string _ownerEmailB = null!;
+    private Organization _organizationB = null!;
+    private OrganizationUser _orgUserB = null!;
+
+    public OrganizationUsersControllerGetTests(ApiApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _loginHelper = new LoginHelper(_factory, _client);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ownerEmailA = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(_ownerEmailA);
+        (_organizationA, _) = await OrganizationTestHelpers.SignUpAsync(
+            _factory,
+            plan: PlanType.EnterpriseAnnually,
+            ownerEmail: _ownerEmailA,
+            passwordManagerSeats: 10,
+            paymentMethod: PaymentMethodType.Card);
+
+        _ownerEmailB = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(_ownerEmailB);
+        (_organizationB, _orgUserB) = await OrganizationTestHelpers.SignUpAsync(
+            _factory,
+            plan: PlanType.EnterpriseAnnually,
+            ownerEmail: _ownerEmailB,
+            passwordManagerSeats: 10,
+            paymentMethod: PaymentMethodType.Card);
+    }
+
+    public Task DisposeAsync()
+    {
+        _client.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Get_MemberOfDifferentOrganization_WithSpoofedOrgIdInBody_ReturnsForbidden()
+    {
+        await _loginHelper.LoginAsync(_ownerEmailA);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/organizations/{_organizationA.Id}/users/{_orgUserB.Id}")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["orgId"] = _organizationA.Id.ToString()
+            })
+        };
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+}

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerGetTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerGetTests.cs
@@ -57,7 +57,7 @@ public class OrganizationUsersControllerGetTests : IClassFixture<ApiApplicationF
     }
 
     [Fact]
-    public async Task Get_UserFromDifferentOrganization_WithSpoofedOrgIdInBody_ReturnsNotFound()
+    public async Task Get_UserFromDifferentOrganization_WitOrgBIdInBody_ReturnsNotFound()
     {
         await _loginHelper.LoginAsync(_ownerEmailA);
 

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerGetTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerGetTests.cs
@@ -57,7 +57,7 @@ public class OrganizationUsersControllerGetTests : IClassFixture<ApiApplicationF
     }
 
     [Fact]
-    public async Task Get_MemberOfDifferentOrganization_WithSpoofedOrgIdInBody_ReturnsForbidden()
+    public async Task Get_UserFromDifferentOrganization_WithSpoofedOrgIdInBody_ReturnsNotFound()
     {
         await _loginHelper.LoginAsync(_ownerEmailA);
 
@@ -73,6 +73,6 @@ public class OrganizationUsersControllerGetTests : IClassFixture<ApiApplicationF
 
         var response = await _client.SendAsync(request);
 
-        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerGetTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerGetTests.cs
@@ -67,7 +67,7 @@ public class OrganizationUsersControllerGetTests : IClassFixture<ApiApplicationF
         {
             Content = new FormUrlEncodedContent(new Dictionary<string, string>
             {
-                ["orgId"] = _organizationA.Id.ToString()
+                ["orgId"] = _organizationB.Id.ToString()
             })
         };
 

--- a/test/IntegrationTestCommon/RouteIdFromRouteTestsBase.cs
+++ b/test/IntegrationTestCommon/RouteIdFromRouteTestsBase.cs
@@ -1,27 +1,30 @@
-﻿using System.Reflection;
-using Bit.Api.IntegrationTest.Factories;
-using Microsoft.AspNetCore.Authorization;
+using System.Reflection;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Bit.Api.IntegrationTest.AdminConsole.Authorization;
+namespace Bit.IntegrationTestCommon;
 
-public abstract class RequirementFromRouteTestsBase(ApiApplicationFactory factory)
+public abstract class RouteIdFromRouteTestsBase(IServiceProvider services)
 {
-    protected abstract bool IsRequirement(IAuthorizationRequirement requirement);
+    protected abstract bool IsGuardedEndpoint(Endpoint endpoint);
 
     protected abstract bool IsRouteIdParameter(ParameterInfo parameter);
 
     protected abstract string FailureSummary(int violationCount);
 
-    protected void AssertAllRequirementEndpointsBindIdFromRoute()
+    protected virtual string DescribeSuffix(Endpoint endpoint) => string.Empty;
+
+    protected void AssertAllGuardedEndpointsBindIdFromRoute()
     {
-        var endpointDataSources = factory.Services.GetRequiredService<IEnumerable<EndpointDataSource>>();
+        var endpointDataSources = services.GetRequiredService<IEnumerable<EndpointDataSource>>();
 
         var violations = endpointDataSources
             .SelectMany(source => source.Endpoints)
-            .Where(HasRequirement)
+            .Where(IsGuardedEndpoint)
             .Where(HasIdParameterNotBoundFromRoute)
             .Select(Describe)
             .Distinct()
@@ -30,12 +33,6 @@ public abstract class RequirementFromRouteTestsBase(ApiApplicationFactory factor
 
         Assert.True(violations.Count == 0, BuildFailureMessage(violations));
     }
-
-    private bool HasRequirement(Endpoint endpoint) =>
-        endpoint.Metadata
-            .OfType<IAuthorizationRequirementData>()
-            .SelectMany(data => data.GetRequirements())
-            .Any(IsRequirement);
 
     private bool HasIdParameterNotBoundFromRoute(Endpoint endpoint)
     {
@@ -60,14 +57,7 @@ public abstract class RequirementFromRouteTestsBase(ApiApplicationFactory factor
         var httpMethods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods;
         var verbs = httpMethods is { Count: > 0 } ? string.Join(",", httpMethods) : "ANY";
 
-        var requirements = endpoint.Metadata
-            .OfType<IAuthorizationRequirementData>()
-            .SelectMany(data => data.GetRequirements())
-            .Where(IsRequirement)
-            .Select(requirement => requirement.GetType().Name)
-            .Distinct();
-
-        return $"{verbs} {route} [{string.Join(", ", requirements)}]";
+        return $"{verbs} {route}{DescribeSuffix(endpoint)}";
     }
 
     private string BuildFailureMessage(List<string> violations) =>

--- a/test/IntegrationTestCommon/RouteIdFromRouteTestsBase.cs
+++ b/test/IntegrationTestCommon/RouteIdFromRouteTestsBase.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;

--- a/test/Libraries/Subscriptions.Organization.Test/OrganizationSubscriptionEndpointsTests.cs
+++ b/test/Libraries/Subscriptions.Organization.Test/OrganizationSubscriptionEndpointsTests.cs
@@ -18,7 +18,10 @@ public class OrganizationSubscriptionEndpointsTests
     {
         var app = WebApplication.CreateBuilder().Build();
 
-        var group = app.MapOrganizationSubscriptionEndpoints();
+        // The host mounts this group under a prefix carrying the {organizationId} route token
+        // (see Startup.MapSubscriptionEndpoints); mirror it so [FromRoute] parameters materialize.
+        var group = app.MapGroup("/organizations/{organizationId:guid}/billing/subscription")
+            .MapOrganizationSubscriptionEndpoints();
         group.MapGet("/__probe", () => Results.Ok());
 
         var endpoint = ((IEndpointRouteBuilder)app).DataSources

--- a/test/Libraries/Subscriptions.Organization.Test/OrganizationSubscriptionEndpointsTests.cs
+++ b/test/Libraries/Subscriptions.Organization.Test/OrganizationSubscriptionEndpointsTests.cs
@@ -18,9 +18,8 @@ public class OrganizationSubscriptionEndpointsTests
     {
         var app = WebApplication.CreateBuilder().Build();
 
-        // The host mounts this group under a prefix carrying the {organizationId} route token
-        // (see Startup.MapSubscriptionEndpoints); mirror it so [FromRoute] parameters materialize.
-        var group = app.MapGroup("/organizations/{organizationId:guid}/billing/subscription")
+        // only organizationId is important for the mapping.
+        var group = app.MapGroup("/{organizationId:guid}")
             .MapOrganizationSubscriptionEndpoints();
         group.MapGet("/__probe", () => Results.Ok());
 


### PR DESCRIPTION
## 🎟️ Tracking
[PM-42891](https://bitwarden.atlassian.net/browse/PM-42891)

## 📔 Objective
This goes through and makes user that everything using `IOrganizationRequirement` based Requirements uses the orgId passed through the route instead of whatever is defaulted to the binding.


[PM-42891]: https://bitwarden.atlassian.net/browse/PM-42891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ