### PR TITLE
PM-39423: read the PAM license claim back into the request context

### DIFF
--- a/src/Core/Context/CurrentContext.cs
+++ b/src/Core/Context/CurrentContext.cs
@@ -183,6 +183,10 @@ public class CurrentContext(
             ? secretsManagerAccessClaim.ToDictionary(s => s.Value, _ => true)
             : new Dictionary<string, bool>();
 
+        var accessPam = claimsDict.TryGetValue(Claims.PamAccess, out var pamAccessClaim)
+            ? pamAccessClaim.ToDictionary(s => s.Value, _ => true)
+            : new Dictionary<string, bool>();
+
         var organizations = new List<CurrentContextOrganization>();
         if (claimsDict.TryGetValue(Claims.OrganizationOwner, out var organizationOwnerClaim))
         {
@@ -192,6 +196,7 @@ public class CurrentContext(
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.Owner,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    AccessPam = accessPam.ContainsKey(c.Value),
                 }));
         }
         else if (orgApi && OrganizationId.HasValue)
@@ -211,6 +216,7 @@ public class CurrentContext(
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.Admin,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    AccessPam = accessPam.ContainsKey(c.Value),
                 }));
         }
 
@@ -222,6 +228,7 @@ public class CurrentContext(
                     Id = new Guid(c.Value),
                     Type = OrganizationUserType.User,
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    AccessPam = accessPam.ContainsKey(c.Value),
                 }));
         }
 
@@ -234,6 +241,7 @@ public class CurrentContext(
                     Type = OrganizationUserType.Custom,
                     Permissions = SetOrganizationPermissionsFromClaims(c.Value, claimsDict),
                     AccessSecretsManager = accessSecretsManager.ContainsKey(c.Value),
+                    AccessPam = accessPam.ContainsKey(c.Value),
                 }));
         }
 

--- a/test/Core.Test/Context/CurrentContextTests.cs
+++ b/test/Core.Test/Context/CurrentContextTests.cs
@@ -358,6 +358,56 @@ public class CurrentContextTests
         Assert.True(sutProvider.Sut.Organizations.First().AccessSecretsManager);
     }
 
+    [Theory]
+    [BitAutoData(Claims.OrganizationOwner)]
+    [BitAutoData(Claims.OrganizationAdmin)]
+    [BitAutoData(Claims.OrganizationUser)]
+    [BitAutoData(Claims.OrganizationCustom)]
+    public async Task SetContextAsync_PamAccess_SetsAccessPam(
+        string userOrgAssociation,
+        SutProvider<CurrentContext> sutProvider,
+        Guid orgId)
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new(userOrgAssociation, orgId.ToString()),
+            new(Claims.PamAccess, orgId.ToString())
+        };
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        // Act
+        await sutProvider.Sut.SetContextAsync(user);
+
+        // Assert
+        Assert.Single(sutProvider.Sut.Organizations);
+        Assert.True(sutProvider.Sut.Organizations.First().AccessPam);
+        Assert.True(sutProvider.Sut.AccessPam(orgId));
+    }
+
+    [Theory, BitAutoData]
+    public async Task SetContextAsync_PamAccessForAnotherOrganization_DoesNotSetAccessPam(
+        SutProvider<CurrentContext> sutProvider,
+        Guid orgId,
+        Guid otherOrgId)
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new(Claims.OrganizationUser, orgId.ToString()),
+            new(Claims.PamAccess, otherOrgId.ToString())
+        };
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        // Act
+        await sutProvider.Sut.SetContextAsync(user);
+
+        // Assert
+        Assert.Single(sutProvider.Sut.Organizations);
+        Assert.False(sutProvider.Sut.Organizations.First().AccessPam);
+        Assert.False(sutProvider.Sut.AccessPam(orgId));
+    }
+
     #endregion
 
     #region Provider Claims Tests


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39423

## 📔 Objective

`Claims.PamAccess` reaches the access token but nothing reads it back, so `ICurrentContext.AccessPam` is `false` on every token authenticated request and `PamLicenseGuard` refuses correctly licensed members.

- `CurrentContext.GetOrganizations` sets `AccessSecretsManager` in all four role branches (Owner, Admin, User, Custom) and `AccessPam` in none. This adds it.
- Effect on `pam/uat` today: submit, activate and extend fail with "A Privileged Controls license is required to access this item" for every member, licensed or not. Read paths are unaffected, so the item still renders as gated.
- The emission side was already correct (`CoreHelpers.BuildIdentityClaims`, `ApiResources`). Only the read side was missing.
- The `AccessPam` tests added in PM-39423 assign `Organizations` directly and never exercise claim parsing, which is why this passed CI. Adds 5 cases through `SetContextAsync(ClaimsPrincipal)`, one per role branch plus a wrong org case.

Verified against a local stack: a requester holding `OrganizationUser.AccessPam = 1` mints a lease, and the same call is refused once the seat is removed.

Sits on `pam/uat`.

## 📸 Screenshots

No user visible surface changes. The client side banner and copy from PM-39423 are unchanged.
