### PR TITLE
[PM-33527] Allow multiple tasks per budget

### DIFF
--- a/src/Admin/Jobs/OrganizationDeleteTasksJob.cs
+++ b/src/Admin/Jobs/OrganizationDeleteTasksJob.cs
@@ -13,20 +13,18 @@ using Quartz;
 namespace Bit.Admin.Jobs;
 
 /// <summary>
-/// Drains the <c>OrganizationDeleteTask</c> queue: claims the next pending task and dispatches it to
-/// the <see cref="IOrganizationDeleteTaskHandler"/> registered for its type, deleting in bounded
-/// batches within a run budget so a large cleanup resumes across runs. All lease, progress, and
+/// Drains the <c>OrganizationDeleteTask</c> queue, dispatching each claimed task to the
+/// <see cref="IOrganizationDeleteTaskHandler"/> registered for its type. All lease, progress, and
 /// error bookkeeping lives here; handlers only implement the per-type batch delete.
 /// </summary>
 public class OrganizationDeleteTasksJob : BaseJob
 {
+    // Budget for the whole run, shared across every task claimed in it. Under the trigger's
+    // five-minute interval so the final batch lands before the next firing.
     private static readonly TimeSpan _runBudget = TimeSpan.FromMinutes(4);
 
-    // A missing handler is expected transiently while a rolling deploy is in flight, but a
-    // genuinely orphaned type (enqueued with no handler that will ever be deployed) stays
-    // unhandled long after any deploy completes. Below this age we log the miss at Warning;
-    // beyond it we escalate to Error so a stuck type can be alerted on rather than lost in
-    // steady Warning volume.
+    // Below this age a missing handler is plausibly rolling-deploy skew and logs at Warning; beyond
+    // it the type is genuinely orphaned, so escalate to Error for alerting.
     private static readonly TimeSpan _orphanedTaskEscalationThreshold = TimeSpan.FromHours(1);
 
     private readonly IOrganizationDeleteTaskRepository _cleanupRepository;
@@ -53,41 +51,61 @@ public class OrganizationDeleteTasksJob : BaseJob
             return;
         }
 
-        var pending = await _cleanupRepository.ClaimNextPendingAsync();
-        if (pending is null)
+        var deadline = DateTime.UtcNow.Add(_runBudget);
+        var tasksClaimed = 0;
+
+        // Claiming one task per firing capped throughput at one organization per trigger interval
+        // regardless of how little work each needed. Claiming a row stamps RevisionDate, which puts
+        // it outside the claim predicate for the rest of this run, so the loop always progresses.
+        while (DateTime.UtcNow < deadline && !context.CancellationToken.IsCancellationRequested)
         {
-            return;
+            var pending = await _cleanupRepository.ClaimNextPendingAsync();
+            if (pending is null)
+            {
+                break;
+            }
+
+            tasksClaimed++;
+
+            if (!_handlers.TryGetValue(pending.TaskType, out var handler))
+            {
+                LogMissingHandler(pending);
+                continue;
+            }
+
+            await DrainTaskAsync(pending, handler, deadline, context.CancellationToken);
         }
 
-        if (!_handlers.TryGetValue(pending.TaskType, out var handler))
+        if (tasksClaimed > 0)
         {
-            // No handler is registered for this type. This is expected transiently when the server
-            // enqueuing tasks is ahead of this worker during a rolling deploy. We deliberately do NOT
-            // record a failure: doing so would burn the retry budget and could permanently abandon a
-            // task that only needs a newer worker. The claim lease expires and the task is reclaimed
-            // on a later run. Escalate to Error once it has been unhandled long enough that deploy
-            // skew is no longer a plausible explanation.
-            var unhandledFor = DateTime.UtcNow - pending.CreationDate;
-            var logLevel = unhandledFor >= _orphanedTaskEscalationThreshold ? LogLevel.Error : LogLevel.Warning;
-            _logger.Log(logLevel, Constants.BypassFiltersEventId,
-                "No handler registered for organization delete task type {TaskType} (task {TaskId}); leaving for retry. Unhandled for {UnhandledMinutes:N0} minutes.",
-                pending.TaskType, pending.Id, unhandledFor.TotalMinutes);
-            return;
+            _logger.LogInformation(Constants.BypassFiltersEventId,
+                "Organization delete tasks run claimed {TaskCount} task(s)", tasksClaimed);
         }
+    }
 
+    /// <summary>
+    /// Purges one claimed task in bounded batches until it drains or <paramref name="deadline"/>
+    /// passes. Failures are recorded rather than rethrown: the queue is strictly ordered, so
+    /// aborting the run on one organization would stall every task behind it.
+    /// </summary>
+    private async Task DrainTaskAsync(
+        OrganizationDeleteTask pending,
+        IOrganizationDeleteTaskHandler handler,
+        DateTime deadline,
+        CancellationToken cancellationToken)
+    {
         _logger.LogInformation(Constants.BypassFiltersEventId,
             "Starting {TaskType} cleanup for organization {OrganizationId} (task {TaskId})",
             pending.TaskType, pending.OrganizationId, pending.Id);
 
-        var deadline = DateTime.UtcNow.Add(_runBudget);
         var drained = false;
         var totalDeleted = 0L;
 
         try
         {
-            while (DateTime.UtcNow < deadline && !context.CancellationToken.IsCancellationRequested)
+            while (DateTime.UtcNow < deadline && !cancellationToken.IsCancellationRequested)
             {
-                var deleted = await handler.DeleteBatchAsync(pending, context.CancellationToken);
+                var deleted = await handler.DeleteBatchAsync(pending, cancellationToken);
                 if (deleted == 0)
                 {
                     // An empty batch is the only proof there is nothing left to purge.
@@ -99,9 +117,8 @@ public class OrganizationDeleteTasksJob : BaseJob
                 totalDeleted += deleted;
             }
 
-            // Completion has to be driven by an empty batch, not by the absence of deletions: if
-            // cancellation was already signalled or the budget already spent, the loop never runs
-            // and marking the task complete would strand the organization's events forever.
+            // Completing on anything but an empty batch would strand the organization's events: if
+            // the budget was already spent or cancellation signalled, the loop above never ran.
             if (drained)
             {
                 await _cleanupRepository.UpdateCompletedAsync(pending.Id);
@@ -118,23 +135,37 @@ public class OrganizationDeleteTasksJob : BaseJob
         }
         catch (Exception ex)
         {
-            // Store a sanitized error, never ex.Message: Azure SDK messages can embed
-            // row-key identifiers (e.g. UserId=..., CipherId=...) that must not be persisted.
-            var failureCount = await _cleanupRepository.UpdateErrorAsync(pending.Id, BuildSanitizedError(ex));
+            var sanitizedError = BuildSanitizedError(ex);
+            var failureCount = await _cleanupRepository.UpdateErrorAsync(pending.Id, sanitizedError);
 
-            // Individual failures surface through the rethrow below, but the transition to
-            // "abandoned" would not: once the cap is reached the task stops being claimed and goes
-            // quiet. Deleting these logs is a GDPR obligation, so a cleanup that has stopped
-            // retrying for good needs to be alertable rather than inferred from counting retries.
+            _logger.LogError(Constants.BypassFiltersEventId,
+                "Failed {TaskType} cleanup for organization {OrganizationId} (task {TaskId}) with {Error}; failure {FailureCount} of {MaxFailureCount}.",
+                pending.TaskType, pending.OrganizationId, pending.Id, sanitizedError, failureCount,
+                OrganizationDeleteTask.MaxFailureCount);
+
+            // Past the cap the task is never claimed again and goes quiet. Deleting these logs is a
+            // GDPR obligation, so giving up gets its own signal for alerting.
             if (failureCount >= OrganizationDeleteTask.MaxFailureCount)
             {
                 _logger.LogError(Constants.BypassFiltersEventId,
                     "Abandoning {TaskType} cleanup for organization {OrganizationId} (task {TaskId}) after {FailureCount} failures; it will not be retried.",
                     pending.TaskType, pending.OrganizationId, pending.Id, failureCount);
             }
-
-            throw;
         }
+    }
+
+    /// <summary>
+    /// Logs a task whose type has no registered handler. Deliberately records no failure: that
+    /// would burn the retry budget on a task that may only need a newer worker. The claim lease
+    /// expires and the task is reclaimed on a later run.
+    /// </summary>
+    private void LogMissingHandler(OrganizationDeleteTask pending)
+    {
+        var unhandledFor = DateTime.UtcNow - pending.CreationDate;
+        var logLevel = unhandledFor >= _orphanedTaskEscalationThreshold ? LogLevel.Error : LogLevel.Warning;
+        _logger.Log(logLevel, Constants.BypassFiltersEventId,
+            "No handler registered for organization delete task type {TaskType} (task {TaskId}); leaving for retry. Unhandled for {UnhandledMinutes:N0} minutes.",
+            pending.TaskType, pending.Id, unhandledFor.TotalMinutes);
     }
 
     private static string BuildSanitizedError(Exception ex) => ex switch

--- a/test/Admin.Test/Jobs/OrganizationDeleteTasksJobTests.cs
+++ b/test/Admin.Test/Jobs/OrganizationDeleteTasksJobTests.cs
@@ -51,7 +51,7 @@ public class OrganizationDeleteTasksJobTests
     [Fact]
     public async Task Execute_NoPendingCleanup_ReturnsEarly()
     {
-        _cleanupRepository.ClaimNextPendingAsync().Returns((OrganizationDeleteTask?)null);
+        QueuePending();
         var context = CreateContext();
 
         await _sut.Execute(context);
@@ -69,7 +69,7 @@ public class OrganizationDeleteTasksJobTests
             _featureService,
             _logger);
         var pending = CreatePending();
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         var context = CreateContext();
 
         await sut.Execute(context);
@@ -91,7 +91,7 @@ public class OrganizationDeleteTasksJobTests
         // Freshly enqueued: a missing handler is plausibly just rolling-deploy skew.
         var pending = CreatePending();
         pending.CreationDate = DateTime.UtcNow;
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         var context = CreateContext();
 
         await sut.Execute(context);
@@ -111,7 +111,7 @@ public class OrganizationDeleteTasksJobTests
         // Unhandled for hours: deploy skew is no longer a plausible explanation, so escalate.
         var pending = CreatePending();
         pending.CreationDate = DateTime.UtcNow.AddHours(-2);
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         var context = CreateContext();
 
         await sut.Execute(context);
@@ -124,7 +124,7 @@ public class OrganizationDeleteTasksJobTests
     public async Task Execute_DeletesRepeatedlyThenCompletes_WhenBatchReturnsZero()
     {
         var pending = CreatePending();
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         _handler
             .DeleteBatchAsync(pending, Arg.Any<CancellationToken>())
             .Returns(2000, 2000, 500, 0);
@@ -141,10 +141,97 @@ public class OrganizationDeleteTasksJobTests
     }
 
     [Fact]
+    public async Task Execute_MultiplePendingTasks_DrainsAllInOneRun()
+    {
+        // Regression: the job used to claim exactly one task per firing.
+        var first = CreatePending();
+        var second = CreatePending();
+        var third = CreatePending();
+        QueuePending(first, second, third);
+        _handler.DeleteBatchAsync(Arg.Any<OrganizationDeleteTask>(), Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        await _sut.Execute(CreateContext());
+
+        await _cleanupRepository.Received(1).UpdateCompletedAsync(first.Id);
+        await _cleanupRepository.Received(1).UpdateCompletedAsync(second.Id);
+        await _cleanupRepository.Received(1).UpdateCompletedAsync(third.Id);
+        // Three claims plus the one that returns null and ends the run.
+        await _cleanupRepository.Received(4).ClaimNextPendingAsync();
+    }
+
+    [Fact]
+    public async Task Execute_QueueEmpty_ClaimsOnceAndStops()
+    {
+        QueuePending();
+
+        await _sut.Execute(CreateContext());
+
+        await _cleanupRepository.Received(1).ClaimNextPendingAsync();
+    }
+
+    [Fact]
+    public async Task Execute_TaskFails_StillDrainsTasksBehindIt()
+    {
+        // The queue is strictly ordered, so aborting on one failure would stall everything behind it.
+        var failing = CreatePending();
+        var following = CreatePending();
+        QueuePending(failing, following);
+        _handler.DeleteBatchAsync(failing, Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException("boom"));
+        _handler.DeleteBatchAsync(following, Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        await _sut.Execute(CreateContext());
+
+        await _cleanupRepository.Received(1).UpdateErrorAsync(failing.Id, Arg.Any<string>());
+        await _cleanupRepository.DidNotReceive().UpdateCompletedAsync(failing.Id);
+        await _cleanupRepository.Received(1).UpdateCompletedAsync(following.Id);
+    }
+
+    [Fact]
+    public async Task Execute_TaskTypeHasNoHandler_StillDrainsTasksBehindIt()
+    {
+        var unhandled = CreatePending();
+        unhandled.TaskType = (OrganizationDeleteTaskType)99;
+        var following = CreatePending();
+        QueuePending(unhandled, following);
+        _handler.DeleteBatchAsync(following, Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        await _sut.Execute(CreateContext());
+
+        await _cleanupRepository.DidNotReceiveWithAnyArgs().UpdateErrorAsync(default, default!);
+        await _cleanupRepository.Received(1).UpdateCompletedAsync(following.Id);
+    }
+
+    [Fact]
+    public async Task Execute_CancellationRequested_StopsClaimingFurtherTasks()
+    {
+        var first = CreatePending();
+        var second = CreatePending();
+        QueuePending(first, second);
+
+        using var cts = new CancellationTokenSource();
+        _handler.DeleteBatchAsync(first, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                cts.Cancel();
+                return Task.FromResult(0);
+            });
+
+        await _sut.Execute(CreateContext(cts.Token));
+
+        // Only the first claim happens; the loop checks cancellation before claiming again.
+        await _cleanupRepository.Received(1).ClaimNextPendingAsync();
+        await _handler.DidNotReceive().DeleteBatchAsync(second, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Execute_CancellationRequested_LeavesPending()
     {
         var pending = CreatePending();
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
 
         using var cts = new CancellationTokenSource();
         _handler
@@ -166,14 +253,13 @@ public class OrganizationDeleteTasksJobTests
     public async Task Execute_CancellationAlreadySignalled_DoesNotCompleteWithoutDeleting()
     {
         var pending = CreatePending();
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
         await _sut.Execute(CreateContext(cts.Token));
 
-        // The loop never runs, so nothing was purged. Completing here would strand the
-        // organization's events permanently with the task marked done.
+        // Nothing was purged, so completing here would strand the organization's events.
         await _handler.DidNotReceiveWithAnyArgs().DeleteBatchAsync(default!, default);
         await _cleanupRepository.DidNotReceive().UpdateCompletedAsync(pending.Id);
     }
@@ -182,13 +268,12 @@ public class OrganizationDeleteTasksJobTests
     public async Task Execute_DeleteThrows_RecordsErrorAndDoesNotComplete()
     {
         var pending = CreatePending();
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         _handler
             .DeleteBatchAsync(pending, Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException("boom"));
         var context = CreateContext();
 
-        // BaseJob.Execute swallows exceptions after logging; we verify via substitute calls.
         await _sut.Execute(context);
 
         // The exception type is recorded, never the message.
@@ -200,7 +285,7 @@ public class OrganizationDeleteTasksJobTests
     public async Task Execute_DeleteThrows_BelowFailureCap_DoesNotLogAbandonment()
     {
         var pending = CreatePending();
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         _cleanupRepository.UpdateErrorAsync(pending.Id, Arg.Any<string>())
             .Returns(OrganizationDeleteTask.MaxFailureCount - 1);
         _handler
@@ -217,7 +302,7 @@ public class OrganizationDeleteTasksJobTests
     public async Task Execute_DeleteThrows_AtFailureCap_LogsAbandonment()
     {
         var pending = CreatePending();
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         _cleanupRepository.UpdateErrorAsync(pending.Id, Arg.Any<string>())
             .Returns(OrganizationDeleteTask.MaxFailureCount);
         _handler
@@ -234,7 +319,7 @@ public class OrganizationDeleteTasksJobTests
     public async Task Execute_DeleteThrows_DoesNotLeakRowKeyIdentifiersInError()
     {
         var pending = CreatePending();
-        _cleanupRepository.ClaimNextPendingAsync().Returns(pending);
+        QueuePending(pending);
         // Azure SDK messages can embed row-key identifiers; these must never be persisted.
         var leakyMessage = "The specified entity already exists. UserId=abc123, CipherId=def456";
         _handler
@@ -249,9 +334,27 @@ public class OrganizationDeleteTasksJobTests
             Arg.Is<string>(error => !error.Contains("UserId") && !error.Contains("CipherId")));
     }
 
+    [Fact]
+    public async Task Execute_DeleteThrows_DoesNotLeakRowKeyIdentifiersInLogs()
+    {
+        var pending = CreatePending();
+        QueuePending(pending);
+        // Failures are not rethrown, so this log is the only thing keeping the Azure SDK
+        // message out of the logging pipeline.
+        var leakyMessage = "The specified entity already exists. UserId=abc123, CipherId=def456";
+        _handler
+            .DeleteBatchAsync(pending, Arg.Any<CancellationToken>())
+            .Throws(new InvalidOperationException(leakyMessage));
+
+        await _sut.Execute(CreateContext());
+
+        AssertNotLoggedContaining(LogLevel.Error, "UserId");
+        AssertNotLoggedContaining(LogLevel.Error, "CipherId");
+        AssertLoggedContaining(LogLevel.Error, typeof(InvalidOperationException).FullName!);
+    }
+
     /// <summary>
-    /// Matches a specific log entry by content. Needed where <c>BaseJob.Execute</c> also logs at the
-    /// same level after the rethrow, so asserting on level alone would match both.
+    /// Matches a log entry by content, for levels where more than one entry can be emitted.
     /// </summary>
     private void AssertLoggedContaining(LogLevel level, string fragment) =>
         _logger.Received(1).Log(
@@ -284,6 +387,17 @@ public class OrganizationDeleteTasksJobTests
             Arg.Any<object>(),
             Arg.Any<Exception>(),
             Arg.Any<Func<object, Exception?, string>>());
+
+    /// <summary>
+    /// Stubs the queue with the given tasks in order, then empty. The job claims in a loop until
+    /// it gets null, so a stub returning the same task forever would spin for the whole run budget.
+    /// </summary>
+    private void QueuePending(params OrganizationDeleteTask[] tasks)
+    {
+        var queue = new Queue<OrganizationDeleteTask>(tasks);
+        _cleanupRepository.ClaimNextPendingAsync()
+            .Returns(_ => queue.Count > 0 ? queue.Dequeue() : null);
+    }
 
     private static OrganizationDeleteTask CreatePending() => new()
     {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33527](https://bitwarden.atlassian.net/browse/PM-33527)

## 📔 Objective

This pull request changes the `OrganizationDeleteTasksJob` from running one delete task for an organization regardless of how quick it ran to running multiple tasks in one time boundary to reduce waiting time after a task is complete



[PM-33527]: https://bitwarden.atlassian.net/browse/PM-33527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ