### PR TITLE
Read member adoption details for an organization

### DIFF
--- a/src/Core/Dirt/Models/Data/MemberAdoptionReportAccessGraph.cs
+++ b/src/Core/Dirt/Models/Data/MemberAdoptionReportAccessGraph.cs
@@ -1,0 +1,11 @@
+namespace Bit.Core.Dirt.Reports.Models.Data;
+
+/// <summary>
+/// A member's access to one collection, whether granted directly or through a group.
+/// </summary>
+public readonly record struct MemberCollectionAccess(Guid OrganizationUserId, Guid CollectionId);
+
+/// <summary>
+/// An organization-owned, non-deleted cipher's membership of one collection.
+/// </summary>
+public readonly record struct CollectionCipherLink(Guid CollectionId, Guid CipherId);

--- a/src/Core/Dirt/Models/Data/MemberAdoptionReportDetail.cs
+++ b/src/Core/Dirt/Models/Data/MemberAdoptionReportDetail.cs
@@ -1,0 +1,14 @@
+﻿namespace Bit.Core.Dirt.Reports.Models.Data;
+
+public class MemberAdoptionReportDetail
+{
+    public Guid OrganizationUserId { get; set; }
+    public Guid? UserId { get; set; }
+    public string? Name { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public DateTime? LastActivityDate { get; set; }
+    public bool HasExtensionInstalled { get; set; }
+    public int VaultItemCount { get; set; }
+    public int SharedItemCount { get; set; }
+    public bool HasRedeemedSponsorship { get; set; }
+}

--- a/src/Core/Dirt/Reports/ReportFeatures/SharedItemCountCalculator.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/SharedItemCountCalculator.cs
@@ -1,0 +1,264 @@
+using System.Runtime.InteropServices;
+using Bit.Core.Dirt.Reports.Models.Data;
+
+namespace Bit.Core.Dirt.Reports.ReportFeatures;
+
+/// <summary>
+/// Counts, per member, the distinct organization-owned ciphers reachable through the collections that
+/// member can access. Both repository implementations share this so the two backends cannot diverge.
+/// </summary>
+public static class SharedItemCountCalculator
+{
+    /// <summary>
+    /// Returns the distinct reachable cipher count keyed by organization user id. Members with no
+    /// reachable ciphers are omitted; callers should treat a missing key as zero.
+    /// </summary>
+    public static Dictionary<Guid, int> Calculate(
+        IReadOnlyCollection<MemberCollectionAccess> access,
+        IReadOnlyCollection<CollectionCipherLink> content)
+    {
+        if (access.Count == 0 || content.Count == 0)
+        {
+            return new Dictionary<Guid, int>();
+        }
+
+        var links = AsSpan(content);
+
+        var collectionIndexes = new Dictionary<Guid, int>();
+        var cipherIndexes = new Dictionary<Guid, int>();
+        var linkCollections = new int[links.Length];
+        var linkCiphers = new int[links.Length];
+
+        for (var i = 0; i < links.Length; i++)
+        {
+            var link = links[i];
+
+            if (!collectionIndexes.TryGetValue(link.CollectionId, out var collection))
+            {
+                collection = collectionIndexes.Count;
+                collectionIndexes[link.CollectionId] = collection;
+            }
+
+            if (!cipherIndexes.TryGetValue(link.CipherId, out var cipher))
+            {
+                cipher = cipherIndexes.Count;
+                cipherIndexes[link.CipherId] = cipher;
+            }
+
+            linkCollections[i] = collection;
+            linkCiphers[i] = cipher;
+        }
+
+        var collectionCount = collectionIndexes.Count;
+
+        // A cipher reachable through only one collection can never be reached twice by the same member, so
+        // those ciphers are counted in bulk per collection instead of being deduplicated one at a time.
+        // cipherSlots holds the link count per cipher first, then the cipher's slot in the stamp array,
+        // or -1 when the cipher needs no stamping.
+        var cipherSlots = new int[cipherIndexes.Count];
+        for (var i = 0; i < linkCiphers.Length; i++)
+        {
+            cipherSlots[linkCiphers[i]]++;
+        }
+
+        var sharedCipherCount = 0;
+        for (var i = 0; i < cipherSlots.Length; i++)
+        {
+            cipherSlots[i] = cipherSlots[i] == 1 ? -1 : sharedCipherCount++;
+        }
+
+        var exclusiveCounts = new int[collectionCount];
+        var sharedStarts = new int[collectionCount + 1];
+        for (var i = 0; i < links.Length; i++)
+        {
+            if (cipherSlots[linkCiphers[i]] < 0)
+            {
+                exclusiveCounts[linkCollections[i]]++;
+            }
+            else
+            {
+                sharedStarts[linkCollections[i] + 1]++;
+            }
+        }
+
+        for (var i = 0; i < collectionCount; i++)
+        {
+            sharedStarts[i + 1] += sharedStarts[i];
+        }
+
+        var sharedCiphers = new int[sharedStarts[collectionCount]];
+        var sharedCursors = new int[collectionCount];
+        Array.Copy(sharedStarts, sharedCursors, collectionCount);
+        for (var i = 0; i < links.Length; i++)
+        {
+            var slot = cipherSlots[linkCiphers[i]];
+            if (slot >= 0)
+            {
+                sharedCiphers[sharedCursors[linkCollections[i]]++] = slot;
+            }
+        }
+
+        var edges = AsSpan(access);
+
+        var memberIndexes = new Dictionary<Guid, int>();
+        var memberIds = new List<Guid>();
+        var memberDegrees = new List<int>();
+        for (var i = 0; i < edges.Length; i++)
+        {
+            var edge = edges[i];
+            if (!collectionIndexes.ContainsKey(edge.CollectionId))
+            {
+                continue;
+            }
+
+            if (!memberIndexes.TryGetValue(edge.OrganizationUserId, out var member))
+            {
+                member = memberIds.Count;
+                memberIndexes[edge.OrganizationUserId] = member;
+                memberIds.Add(edge.OrganizationUserId);
+                memberDegrees.Add(0);
+            }
+
+            memberDegrees[member]++;
+        }
+
+        var memberCount = memberIds.Count;
+        if (memberCount == 0)
+        {
+            return new Dictionary<Guid, int>();
+        }
+
+        var memberStarts = new int[memberCount + 1];
+        for (var i = 0; i < memberCount; i++)
+        {
+            memberStarts[i + 1] = memberStarts[i] + memberDegrees[i];
+        }
+
+        var memberCollections = new int[memberStarts[memberCount]];
+        var memberCursors = new int[memberCount];
+        Array.Copy(memberStarts, memberCursors, memberCount);
+        for (var i = 0; i < edges.Length; i++)
+        {
+            var edge = edges[i];
+            if (collectionIndexes.TryGetValue(edge.CollectionId, out var collection))
+            {
+                memberCollections[memberCursors[memberIndexes[edge.OrganizationUserId]]++] = collection;
+            }
+        }
+
+        var stamps = new int[sharedCipherCount];
+        var stampToken = 0;
+        var countsByAccessSet = new Dictionary<AccessSet, int>(new AccessSetComparer(memberCollections));
+        var result = new Dictionary<Guid, int>(memberCount);
+
+        for (var member = 0; member < memberCount; member++)
+        {
+            var start = memberStarts[member];
+            var length = memberStarts[member + 1] - start;
+
+            // Sorting and deduplicating in place turns the access set into a canonical signature, so members
+            // granted the same collections through different groups share one computation.
+            if (length > 1)
+            {
+                Array.Sort(memberCollections, start, length);
+
+                var write = start + 1;
+                for (var read = start + 1; read < start + length; read++)
+                {
+                    if (memberCollections[read] != memberCollections[write - 1])
+                    {
+                        memberCollections[write++] = memberCollections[read];
+                    }
+                }
+
+                length = write - start;
+            }
+
+            var accessSet = new AccessSet(start, length);
+            if (!countsByAccessSet.TryGetValue(accessSet, out var count))
+            {
+                stampToken++;
+
+                for (var i = 0; i < length; i++)
+                {
+                    var collection = memberCollections[start + i];
+                    count += exclusiveCounts[collection];
+
+                    var sharedEnd = sharedStarts[collection + 1];
+                    for (var shared = sharedStarts[collection]; shared < sharedEnd; shared++)
+                    {
+                        ref var stamp = ref stamps[sharedCiphers[shared]];
+                        if (stamp != stampToken)
+                        {
+                            stamp = stampToken;
+                            count++;
+                        }
+                    }
+                }
+
+                countsByAccessSet[accessSet] = count;
+            }
+
+            if (count > 0)
+            {
+                result[memberIds[member]] = count;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Enumerating through the interface costs a dispatch per element, and these inputs run to millions of
+    /// edges, so the two shapes the repositories actually pass are read directly.
+    /// </summary>
+    private static ReadOnlySpan<T> AsSpan<T>(IReadOnlyCollection<T> source)
+    {
+        switch (source)
+        {
+            case T[] array:
+                return array;
+            case List<T> list:
+                return CollectionsMarshal.AsSpan(list);
+            default:
+                var copy = new T[source.Count];
+                var index = 0;
+                foreach (var item in source)
+                {
+                    copy[index++] = item;
+                }
+
+                return copy;
+        }
+    }
+
+    /// <summary>
+    /// A member's normalized access set, as a range within the shared collection-index buffer.
+    /// </summary>
+    private readonly record struct AccessSet(int Start, int Length);
+
+    private sealed class AccessSetComparer(int[] collections) : IEqualityComparer<AccessSet>
+    {
+        public bool Equals(AccessSet x, AccessSet y)
+        {
+            if (x.Length != y.Length)
+            {
+                return false;
+            }
+
+            if (x.Start == y.Start)
+            {
+                return true;
+            }
+
+            return collections.AsSpan(x.Start, x.Length).SequenceEqual(collections.AsSpan(y.Start, y.Length));
+        }
+
+        public int GetHashCode(AccessSet accessSet)
+        {
+            var hash = new HashCode();
+            hash.AddBytes(MemoryMarshal.AsBytes(collections.AsSpan(accessSet.Start, accessSet.Length)));
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/src/Core/Dirt/Repositories/IMemberAdoptionReportRepository.cs
+++ b/src/Core/Dirt/Repositories/IMemberAdoptionReportRepository.cs
@@ -1,0 +1,8 @@
+﻿using Bit.Core.Dirt.Reports.Models.Data;
+
+namespace Bit.Core.Dirt.Reports.Repositories;
+
+public interface IMemberAdoptionReportRepository
+{
+    Task<IReadOnlyList<MemberAdoptionReportDetail>> GetMemberAdoptionDetailsByOrganizationIdAsync(Guid organizationId);
+}

--- a/src/Infrastructure.Dapper/DapperServiceCollectionExtensions.cs
+++ b/src/Infrastructure.Dapper/DapperServiceCollectionExtensions.cs
@@ -88,6 +88,7 @@ public static class DapperServiceCollectionExtensions
         services.AddSingleton<IOrganizationApplicationRepository, OrganizationApplicationRepository>();
         services.AddSingleton<IOrganizationDeleteTaskRepository, OrganizationDeleteTaskRepository>();
         services.AddSingleton<IOrganizationMemberBaseDetailRepository, OrganizationMemberBaseDetailRepository>();
+        services.AddSingleton<IMemberAdoptionReportRepository, MemberAdoptionReportRepository>();
 
         if (selfHosted)
         {

--- a/src/Infrastructure.Dapper/Dirt/MemberAdoptionReportRepository.cs
+++ b/src/Infrastructure.Dapper/Dirt/MemberAdoptionReportRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.ReportFeatures;
 using Bit.Core.Dirt.Reports.Repositories;
 using Bit.Core.Settings;
 using Bit.Infrastructure.Dapper.Repositories;
@@ -10,6 +11,14 @@ namespace Bit.Infrastructure.Dapper.Dirt;
 
 public class MemberAdoptionReportRepository : BaseRepository, IMemberAdoptionReportRepository
 {
+    /// <summary>
+    /// Both reads stay well above the 30 second default. The detail read still runs per-member device and
+    /// cipher lookups for every confirmed member, and the access graph read returns one row per member to
+    /// collection edge plus one per collection to cipher edge, so a large organization spends real time
+    /// streaming rows even though the aggregation itself no longer happens in SQL.
+    /// </summary>
+    private const int ReportCommandTimeoutSeconds = 120;
+
     public MemberAdoptionReportRepository(GlobalSettings globalSettings)
         : this(globalSettings.SqlServer.ConnectionString, globalSettings.SqlServer.ReadOnlyConnectionString)
     {
@@ -24,13 +33,30 @@ public class MemberAdoptionReportRepository : BaseRepository, IMemberAdoptionRep
         Guid organizationId)
     {
         await using var connection = new SqlConnection(ReadOnlyConnectionString);
+        var parameters = new { OrganizationId = organizationId };
 
-        var results = await connection.QueryAsync<MemberAdoptionReportDetail>(
+        var details = (await connection.QueryAsync<MemberAdoptionReportDetail>(
             "[dbo].[MemberAdoptionReport_ReadByOrganizationId]",
-            new { OrganizationId = organizationId },
+            parameters,
             commandType: CommandType.StoredProcedure,
-            commandTimeout: 120);
+            commandTimeout: ReportCommandTimeoutSeconds)).AsList();
 
-        return results.AsList();
+        using var accessGraph = await connection.QueryMultipleAsync(
+            "[dbo].[MemberAdoptionReport_ReadAccessGraphByOrganizationId]",
+            parameters,
+            commandType: CommandType.StoredProcedure,
+            commandTimeout: ReportCommandTimeoutSeconds);
+
+        var access = (await accessGraph.ReadAsync<MemberCollectionAccess>()).AsList();
+        var content = (await accessGraph.ReadAsync<CollectionCipherLink>()).AsList();
+
+        var sharedItemCounts = SharedItemCountCalculator.Calculate(access, content);
+
+        foreach (var detail in details)
+        {
+            detail.SharedItemCount = sharedItemCounts.GetValueOrDefault(detail.OrganizationUserId);
+        }
+
+        return details;
     }
 }

--- a/src/Infrastructure.Dapper/Dirt/MemberAdoptionReportRepository.cs
+++ b/src/Infrastructure.Dapper/Dirt/MemberAdoptionReportRepository.cs
@@ -1,0 +1,36 @@
+﻿using System.Data;
+using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.Repositories;
+using Bit.Core.Settings;
+using Bit.Infrastructure.Dapper.Repositories;
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+namespace Bit.Infrastructure.Dapper.Dirt;
+
+public class MemberAdoptionReportRepository : BaseRepository, IMemberAdoptionReportRepository
+{
+    public MemberAdoptionReportRepository(GlobalSettings globalSettings)
+        : this(globalSettings.SqlServer.ConnectionString, globalSettings.SqlServer.ReadOnlyConnectionString)
+    {
+    }
+
+    public MemberAdoptionReportRepository(string connectionString, string readOnlyConnectionString)
+        : base(connectionString, readOnlyConnectionString)
+    {
+    }
+
+    public async Task<IReadOnlyList<MemberAdoptionReportDetail>> GetMemberAdoptionDetailsByOrganizationIdAsync(
+        Guid organizationId)
+    {
+        await using var connection = new SqlConnection(ReadOnlyConnectionString);
+
+        var results = await connection.QueryAsync<MemberAdoptionReportDetail>(
+            "[dbo].[MemberAdoptionReport_ReadByOrganizationId]",
+            new { OrganizationId = organizationId },
+            commandType: CommandType.StoredProcedure,
+            commandTimeout: 120);
+
+        return results.AsList();
+    }
+}

--- a/src/Infrastructure.EntityFramework/Dirt/Repositories/MemberAdoptionReportRepository.cs
+++ b/src/Infrastructure.EntityFramework/Dirt/Repositories/MemberAdoptionReportRepository.cs
@@ -1,0 +1,107 @@
+﻿using AutoMapper;
+using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.Repositories;
+using Bit.Core.Enums;
+using Bit.Core.Utilities;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bit.Infrastructure.EntityFramework.Dirt.Repositories;
+
+/// <summary>
+/// EF translation of [dbo].[MemberAdoptionReport_ReadByOrganizationId] for MySQL, PostgreSQL and SQLite.
+/// </summary>
+public class MemberAdoptionReportRepository : BaseEntityFrameworkRepository, IMemberAdoptionReportRepository
+{
+    private const int ReportCommandTimeoutSeconds = 120;
+
+    public MemberAdoptionReportRepository(IServiceScopeFactory serviceScopeFactory, IMapper mapper)
+        : base(serviceScopeFactory, mapper)
+    {
+    }
+
+    public async Task<IReadOnlyList<MemberAdoptionReportDetail>> GetMemberAdoptionDetailsByOrganizationIdAsync(
+        Guid organizationId)
+    {
+        await using var scope = ServiceScopeFactory.CreateAsyncScope();
+        var dbContext = GetDatabaseContext(scope);
+        dbContext.Database.SetCommandTimeout(ReportCommandTimeoutSeconds);
+
+        var sharedItemCounts = await GetSharedItemCountsByOrganizationUserIdAsync(dbContext, organizationId);
+
+        var details = await (
+            from organizationUser in dbContext.OrganizationUsers
+            where organizationUser.OrganizationId == organizationId
+                && organizationUser.Status == OrganizationUserStatusType.Confirmed
+            join user in dbContext.Users
+                on organizationUser.UserId equals (Guid?)user.Id into userJoin
+            from user in userJoin.DefaultIfEmpty()
+            orderby user.Email ?? organizationUser.Email, organizationUser.Id
+            select new MemberAdoptionReportDetail
+            {
+                OrganizationUserId = organizationUser.Id,
+                UserId = organizationUser.UserId,
+                Name = user.Name,
+                Email = user.Email ?? organizationUser.Email ?? string.Empty,
+                LastActivityDate = dbContext.Devices
+                    .Where(device => device.UserId == organizationUser.UserId)
+                    .Max(device => device.LastActivityDate),
+                HasExtensionInstalled = dbContext.Devices
+                    .Any(device => device.UserId == organizationUser.UserId
+                        && DeviceTypes.BrowserExtensionTypes.Contains(device.Type)),
+                VaultItemCount = dbContext.Ciphers
+                    .Count(cipher => cipher.UserId == organizationUser.UserId
+                        && cipher.OrganizationId == null
+                        && cipher.DeletedDate == null),
+                HasRedeemedSponsorship = dbContext.OrganizationSponsorships
+                    .Any(sponsorship => sponsorship.SponsoringOrganizationUserId == organizationUser.Id
+                        && sponsorship.SponsoredOrganizationId != null)
+            })
+            .ToListAsync();
+
+        foreach (var detail in details)
+        {
+            detail.SharedItemCount = sharedItemCounts.GetValueOrDefault(detail.OrganizationUserId);
+        }
+
+        return details;
+    }
+
+    /// <summary>
+    /// Counts the distinct organization-owned ciphers each member can reach, directly or through their groups.
+    /// </summary>
+    private static async Task<Dictionary<Guid, int>> GetSharedItemCountsByOrganizationUserIdAsync(
+        DatabaseContext dbContext,
+        Guid organizationId)
+    {
+        var directCollectionAccess =
+            from collectionUser in dbContext.CollectionUsers
+            join collection in dbContext.Collections
+                on collectionUser.CollectionId equals collection.Id
+            where collection.OrganizationId == organizationId
+            select new { collectionUser.OrganizationUserId, collectionUser.CollectionId };
+
+        var groupCollectionAccess =
+            from groupUser in dbContext.GroupUsers
+            join collectionGroup in dbContext.CollectionGroups
+                on groupUser.GroupId equals collectionGroup.GroupId
+            join collection in dbContext.Collections
+                on collectionGroup.CollectionId equals collection.Id
+            where collection.OrganizationId == organizationId
+            select new { groupUser.OrganizationUserId, collectionGroup.CollectionId };
+
+        return await (
+            from access in directCollectionAccess.Union(groupCollectionAccess)
+            join collectionCipher in dbContext.CollectionCiphers
+                on access.CollectionId equals collectionCipher.CollectionId
+            join cipher in dbContext.Ciphers
+                on collectionCipher.CipherId equals cipher.Id
+            where cipher.OrganizationId == organizationId && cipher.DeletedDate == null
+            select new { access.OrganizationUserId, cipher.Id })
+            .Distinct()
+            .GroupBy(reachableCipher => reachableCipher.OrganizationUserId)
+            .Select(grouping => new { OrganizationUserId = grouping.Key, Count = grouping.Count() })
+            .ToDictionaryAsync(result => result.OrganizationUserId, result => result.Count);
+    }
+}

--- a/src/Infrastructure.EntityFramework/Dirt/Repositories/MemberAdoptionReportRepository.cs
+++ b/src/Infrastructure.EntityFramework/Dirt/Repositories/MemberAdoptionReportRepository.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.ReportFeatures;
 using Bit.Core.Dirt.Reports.Repositories;
 using Bit.Core.Enums;
 using Bit.Core.Utilities;
@@ -28,16 +29,93 @@ public class MemberAdoptionReportRepository : BaseEntityFrameworkRepository, IMe
         var dbContext = GetDatabaseContext(scope);
         dbContext.Database.SetCommandTimeout(ReportCommandTimeoutSeconds);
 
-        var sharedItemCounts = await GetSharedItemCountsByOrganizationUserIdAsync(dbContext, organizationId);
+        var access = await GetMemberCollectionAccessAsync(dbContext, organizationId);
+        var collectionCiphers = await GetCollectionCipherLinksAsync(dbContext, organizationId);
+        var details = await GetConfirmedMemberDetailsAsync(dbContext, organizationId);
 
-        var details = await (
+        var sharedItemCounts = SharedItemCountCalculator.Calculate(access, collectionCiphers);
+
+        foreach (var detail in details)
+        {
+            detail.SharedItemCount = sharedItemCounts.GetValueOrDefault(detail.OrganizationUserId);
+        }
+
+        return details;
+    }
+
+    /// <summary>
+    /// Reads every member-to-collection edge in the organization, whether the grant is direct or
+    /// inherited from a group.
+    /// </summary>
+    internal static Task<List<MemberCollectionAccess>> GetMemberCollectionAccessAsync(
+        DatabaseContext dbContext,
+        Guid organizationId)
+    {
+        var directAccess =
+            from collectionUser in dbContext.CollectionUsers
+            join collection in dbContext.Collections
+                on collectionUser.CollectionId equals collection.Id
+            where collection.OrganizationId == organizationId
+            select new { collectionUser.OrganizationUserId, collectionUser.CollectionId };
+
+        var groupAccess =
+            from groupUser in dbContext.GroupUsers
+            join collectionGroup in dbContext.CollectionGroups
+                on groupUser.GroupId equals collectionGroup.GroupId
+            join collection in dbContext.Collections
+                on collectionGroup.CollectionId equals collection.Id
+            where collection.OrganizationId == organizationId
+            select new { groupUser.OrganizationUserId, collectionGroup.CollectionId };
+
+        // Union, not Concat: a member who reaches one collection both directly and through one or more
+        // groups is a single edge, and the database is the cheap place to collapse that. The projection
+        // has to stay anonymous until after the set operation, because EF cannot translate a union whose
+        // sides already project into MemberCollectionAccess.
+        return directAccess
+            .Union(groupAccess)
+            .Select(edge => new MemberCollectionAccess(edge.OrganizationUserId, edge.CollectionId))
+            .ToListAsync();
+    }
+
+    /// <summary>
+    /// Reads every collection-to-cipher edge in the organization, restricted to organization-owned
+    /// ciphers that are not in the trash.
+    /// </summary>
+    internal static Task<List<CollectionCipherLink>> GetCollectionCipherLinksAsync(
+        DatabaseContext dbContext,
+        Guid organizationId)
+    {
+        // CollectionCipher is keyed on (CollectionId, CipherId), so these edges are already distinct.
+        return (
+            from collectionCipher in dbContext.CollectionCiphers
+            join collection in dbContext.Collections
+                on collectionCipher.CollectionId equals collection.Id
+            join cipher in dbContext.Ciphers
+                on collectionCipher.CipherId equals cipher.Id
+            where collection.OrganizationId == organizationId
+                && cipher.OrganizationId == organizationId
+                && cipher.DeletedDate == null
+            select new CollectionCipherLink(collectionCipher.CollectionId, collectionCipher.CipherId))
+            .ToListAsync();
+    }
+
+    /// <summary>
+    /// Reads one row per confirmed member with everything the report needs except the shared item count.
+    /// </summary>
+    internal static Task<List<MemberAdoptionReportDetail>> GetConfirmedMemberDetailsAsync(
+        DatabaseContext dbContext,
+        Guid organizationId)
+    {
+        return (
             from organizationUser in dbContext.OrganizationUsers
             where organizationUser.OrganizationId == organizationId
                 && organizationUser.Status == OrganizationUserStatusType.Confirmed
             join user in dbContext.Users
                 on organizationUser.UserId equals (Guid?)user.Id into userJoin
             from user in userJoin.DefaultIfEmpty()
-            orderby user.Email ?? organizationUser.Email, organizationUser.Id
+            // Sort on the coalesced email the report displays, so a member with no email either side
+            // sorts as the empty string rather than as a null each provider places differently.
+            orderby user.Email ?? organizationUser.Email ?? string.Empty, organizationUser.Id
             select new MemberAdoptionReportDetail
             {
                 OrganizationUserId = organizationUser.Id,
@@ -50,8 +128,11 @@ public class MemberAdoptionReportRepository : BaseEntityFrameworkRepository, IMe
                 HasExtensionInstalled = dbContext.Devices
                     .Any(device => device.UserId == organizationUser.UserId
                         && DeviceTypes.BrowserExtensionTypes.Contains(device.Type)),
+                // A confirmed member can still have no linked user. The null check keeps that member
+                // from matching every unowned cipher, which EF's null semantics would otherwise do.
                 VaultItemCount = dbContext.Ciphers
-                    .Count(cipher => cipher.UserId == organizationUser.UserId
+                    .Count(cipher => cipher.UserId != null
+                        && cipher.UserId == organizationUser.UserId
                         && cipher.OrganizationId == null
                         && cipher.DeletedDate == null),
                 HasRedeemedSponsorship = dbContext.OrganizationSponsorships
@@ -59,49 +140,5 @@ public class MemberAdoptionReportRepository : BaseEntityFrameworkRepository, IMe
                         && sponsorship.SponsoredOrganizationId != null)
             })
             .ToListAsync();
-
-        foreach (var detail in details)
-        {
-            detail.SharedItemCount = sharedItemCounts.GetValueOrDefault(detail.OrganizationUserId);
-        }
-
-        return details;
-    }
-
-    /// <summary>
-    /// Counts the distinct organization-owned ciphers each member can reach, directly or through their groups.
-    /// </summary>
-    private static async Task<Dictionary<Guid, int>> GetSharedItemCountsByOrganizationUserIdAsync(
-        DatabaseContext dbContext,
-        Guid organizationId)
-    {
-        var directCollectionAccess =
-            from collectionUser in dbContext.CollectionUsers
-            join collection in dbContext.Collections
-                on collectionUser.CollectionId equals collection.Id
-            where collection.OrganizationId == organizationId
-            select new { collectionUser.OrganizationUserId, collectionUser.CollectionId };
-
-        var groupCollectionAccess =
-            from groupUser in dbContext.GroupUsers
-            join collectionGroup in dbContext.CollectionGroups
-                on groupUser.GroupId equals collectionGroup.GroupId
-            join collection in dbContext.Collections
-                on collectionGroup.CollectionId equals collection.Id
-            where collection.OrganizationId == organizationId
-            select new { groupUser.OrganizationUserId, collectionGroup.CollectionId };
-
-        return await (
-            from access in directCollectionAccess.Union(groupCollectionAccess)
-            join collectionCipher in dbContext.CollectionCiphers
-                on access.CollectionId equals collectionCipher.CollectionId
-            join cipher in dbContext.Ciphers
-                on collectionCipher.CipherId equals cipher.Id
-            where cipher.OrganizationId == organizationId && cipher.DeletedDate == null
-            select new { access.OrganizationUserId, cipher.Id })
-            .Distinct()
-            .GroupBy(reachableCipher => reachableCipher.OrganizationUserId)
-            .Select(grouping => new { OrganizationUserId = grouping.Key, Count = grouping.Count() })
-            .ToDictionaryAsync(result => result.OrganizationUserId, result => result.Count);
     }
 }

--- a/src/Infrastructure.EntityFramework/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/Infrastructure.EntityFramework/EntityFrameworkServiceCollectionExtensions.cs
@@ -125,6 +125,7 @@ public static class EntityFrameworkServiceCollectionExtensions
         services.AddSingleton<IOrganizationApplicationRepository, OrganizationApplicationRepository>();
         services.AddSingleton<IOrganizationMemberBaseDetailRepository, OrganizationMemberBaseDetailRepository>();
         services.AddSingleton<IOrganizationDeleteTaskRepository, OrganizationDeleteTaskRepository>();
+        services.AddSingleton<IMemberAdoptionReportRepository, MemberAdoptionReportRepository>();
 
         if (selfHosted)
         {

--- a/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
+++ b/src/Infrastructure.EntityFramework/Infrastructure.EntityFramework.csproj
@@ -21,4 +21,8 @@
       <ProjectReference Include="..\Core\Core.csproj" />
       <ProjectReference Include="..\Pam.Domain\Pam.Domain.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+      <InternalsVisibleTo Include="Infrastructure.EFIntegration.Test" />
+    </ItemGroup>
 </Project>

--- a/src/Sql/dbo/Dirt/Stored Procedures/MemberAdoptionReport_ReadAccessGraphByOrganizationId.sql
+++ b/src/Sql/dbo/Dirt/Stored Procedures/MemberAdoptionReport_ReadAccessGraphByOrganizationId.sql
@@ -1,0 +1,58 @@
+CREATE PROCEDURE [dbo].[MemberAdoptionReport_ReadAccessGraphByOrganizationId]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    IF @OrganizationId IS NULL
+        THROW 50000, 'OrganizationId cannot be null', 1;
+
+    -- Result set 1: which members can reach which collections, directly or through a group.
+    -- UNION rather than UNION ALL because a member can hold both kinds of access to one collection.
+    WITH [OrganizationCollection] AS (
+        SELECT
+            COL.[Id]
+        FROM
+            [dbo].[Collection] COL
+        WHERE
+            COL.[OrganizationId] = @OrganizationId
+    )
+    SELECT
+        CU.[OrganizationUserId],
+        CU.[CollectionId]
+    FROM
+        [dbo].[CollectionUser] CU
+    INNER JOIN
+        [OrganizationCollection] COL ON COL.[Id] = CU.[CollectionId]
+    UNION
+    SELECT
+        GU.[OrganizationUserId],
+        CG.[CollectionId]
+    FROM
+        [dbo].[CollectionGroup] CG
+    INNER JOIN
+        [OrganizationCollection] COL ON COL.[Id] = CG.[CollectionId]
+    INNER JOIN
+        [dbo].[GroupUser] GU ON GU.[GroupId] = CG.[GroupId]
+
+    -- Result set 2: which collections hold which items.
+    ;WITH [OrganizationCollection] AS (
+        SELECT
+            COL.[Id]
+        FROM
+            [dbo].[Collection] COL
+        WHERE
+            COL.[OrganizationId] = @OrganizationId
+    )
+    SELECT
+        CC.[CollectionId],
+        CC.[CipherId]
+    FROM
+        [dbo].[CollectionCipher] CC
+    INNER JOIN
+        [OrganizationCollection] COL ON COL.[Id] = CC.[CollectionId]
+    INNER JOIN
+        [dbo].[Cipher] C ON C.[Id] = CC.[CipherId]
+            AND C.[OrganizationId] = @OrganizationId
+            AND C.[DeletedDate] IS NULL
+END

--- a/src/Sql/dbo/Dirt/Stored Procedures/MemberAdoptionReport_ReadByOrganizationId.sql
+++ b/src/Sql/dbo/Dirt/Stored Procedures/MemberAdoptionReport_ReadByOrganizationId.sql
@@ -1,0 +1,94 @@
+CREATE PROCEDURE [dbo].[MemberAdoptionReport_ReadByOrganizationId]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    IF @OrganizationId IS NULL
+        THROW 50000, 'OrganizationId cannot be null', 1;
+
+    SELECT
+        OU.[Id] AS [OrganizationUserId],
+        OU.[UserId],
+        U.[Name],
+        ISNULL(ISNULL(U.[Email], OU.[Email]), '') AS [Email],
+        LA.[LastActivityDate],
+        CAST(CASE WHEN EXT.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasExtensionInstalled],
+        ISNULL(VI.[VaultItemCount], 0) AS [VaultItemCount],
+        ISNULL(SI.[SharedItemCount], 0) AS [SharedItemCount],
+        CAST(CASE WHEN SP.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasRedeemedSponsorship]
+    FROM
+        [dbo].[OrganizationUser] OU
+    LEFT JOIN
+        [dbo].[User] U ON U.[Id] = OU.[UserId]
+    OUTER APPLY (
+        SELECT
+            MAX(D.[LastActivityDate]) AS [LastActivityDate]
+        FROM
+            [dbo].[Device] D
+        WHERE
+            D.[UserId] = OU.[UserId]
+    ) LA
+    OUTER APPLY (
+        SELECT TOP 1
+            D.[Id]
+        FROM
+            [dbo].[Device] D
+        WHERE
+            D.[UserId] = OU.[UserId]
+            AND D.[Type] IN (2, 3, 4, 5, 19, 20) -- Chrome, Firefox, Opera, Edge, Vivaldi and Safari browser extensions
+    ) EXT
+    OUTER APPLY (
+        SELECT
+            COUNT(1) AS [VaultItemCount]
+        FROM
+            [dbo].[Cipher] C
+        WHERE
+            C.[UserId] = OU.[UserId]
+            AND C.[OrganizationId] IS NULL
+            AND C.[DeletedDate] IS NULL
+    ) VI
+    OUTER APPLY (
+        SELECT
+            COUNT(DISTINCT CC.[CipherId]) AS [SharedItemCount]
+        FROM
+            [dbo].[CollectionCipher] CC
+        INNER JOIN
+            [dbo].[Collection] COL ON COL.[Id] = CC.[CollectionId]
+                AND COL.[OrganizationId] = @OrganizationId
+        INNER JOIN
+            [dbo].[Cipher] OC ON OC.[Id] = CC.[CipherId]
+                AND OC.[OrganizationId] = @OrganizationId
+                AND OC.[DeletedDate] IS NULL
+        WHERE
+            EXISTS (
+                SELECT 1
+                FROM [dbo].[CollectionUser] CU
+                WHERE CU.[CollectionId] = CC.[CollectionId]
+                    AND CU.[OrganizationUserId] = OU.[Id]
+            )
+            OR EXISTS (
+                SELECT 1
+                FROM [dbo].[CollectionGroup] CG
+                INNER JOIN [dbo].[GroupUser] GU ON GU.[GroupId] = CG.[GroupId]
+                WHERE CG.[CollectionId] = CC.[CollectionId]
+                    AND GU.[OrganizationUserId] = OU.[Id]
+            )
+    ) SI
+    OUTER APPLY (
+        SELECT TOP 1
+            OS.[Id]
+        FROM
+            [dbo].[OrganizationSponsorship] OS
+        WHERE
+            OS.[SponsoringOrganizationUserID] = OU.[Id]
+            AND OS.[SponsoredOrganizationId] IS NOT NULL
+    ) SP
+    WHERE
+        OU.[OrganizationId] = @OrganizationId
+        -- Adoption is only measured for Confirmed members.
+        AND OU.[Status] = 2
+    ORDER BY
+        [Email] ASC,
+        OU.[Id] ASC
+END

--- a/src/Sql/dbo/Dirt/Stored Procedures/MemberAdoptionReport_ReadByOrganizationId.sql
+++ b/src/Sql/dbo/Dirt/Stored Procedures/MemberAdoptionReport_ReadByOrganizationId.sql
@@ -7,88 +7,71 @@ BEGIN
     IF @OrganizationId IS NULL
         THROW 50000, 'OrganizationId cannot be null', 1;
 
-    SELECT
-        OU.[Id] AS [OrganizationUserId],
-        OU.[UserId],
-        U.[Name],
-        ISNULL(ISNULL(U.[Email], OU.[Email]), '') AS [Email],
-        LA.[LastActivityDate],
-        CAST(CASE WHEN EXT.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasExtensionInstalled],
-        ISNULL(VI.[VaultItemCount], 0) AS [VaultItemCount],
-        ISNULL(SI.[SharedItemCount], 0) AS [SharedItemCount],
-        CAST(CASE WHEN SP.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasRedeemedSponsorship]
-    FROM
-        [dbo].[OrganizationUser] OU
-    LEFT JOIN
-        [dbo].[User] U ON U.[Id] = OU.[UserId]
-    OUTER APPLY (
+    ;WITH [Member] AS (
         SELECT
-            MAX(D.[LastActivityDate]) AS [LastActivityDate]
+            OU.[Id],
+            OU.[UserId],
+            OU.[Email]
         FROM
-            [dbo].[Device] D
+            [dbo].[OrganizationUser] OU
         WHERE
-            D.[UserId] = OU.[UserId]
-    ) LA
-    OUTER APPLY (
-        SELECT TOP 1
-            D.[Id]
-        FROM
-            [dbo].[Device] D
-        WHERE
-            D.[UserId] = OU.[UserId]
-            AND D.[Type] IN (2, 3, 4, 5, 19, 20) -- Chrome, Firefox, Opera, Edge, Vivaldi and Safari browser extensions
-    ) EXT
-    OUTER APPLY (
+            OU.[OrganizationId] = @OrganizationId
+            -- Adoption is only measured for Confirmed members.
+            AND OU.[Status] = 2
+    ),
+    [MemberVaultItem] AS (
         SELECT
+            C.[UserId],
             COUNT(1) AS [VaultItemCount]
         FROM
             [dbo].[Cipher] C
         WHERE
-            C.[UserId] = OU.[UserId]
-            AND C.[OrganizationId] IS NULL
+            C.[OrganizationId] IS NULL
             AND C.[DeletedDate] IS NULL
-    ) VI
+            -- Restricting to this organization's members keeps the aggregate off every other
+            -- account's personal vault. A member with no [UserId] matches nothing, as before.
+            AND EXISTS (SELECT 1 FROM [Member] M WHERE M.[UserId] = C.[UserId])
+        GROUP BY
+            C.[UserId]
+    )
+    SELECT
+        M.[Id] AS [OrganizationUserId],
+        M.[UserId],
+        U.[Name],
+        ISNULL(ISNULL(U.[Email], M.[Email]), '') AS [Email],
+        DEV.[LastActivityDate],
+        CAST(ISNULL(DEV.[HasExtension], 0) AS BIT) AS [HasExtensionInstalled],
+        ISNULL(VI.[VaultItemCount], 0) AS [VaultItemCount],
+        CAST(CASE WHEN SP.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasRedeemedSponsorship]
+    FROM
+        [Member] M
+    LEFT JOIN
+        [dbo].[User] U ON U.[Id] = M.[UserId]
     OUTER APPLY (
         SELECT
-            COUNT(DISTINCT CC.[CipherId]) AS [SharedItemCount]
+            MAX(D.[LastActivityDate]) AS [LastActivityDate],
+            -- Chrome, Firefox, Opera, Edge, Vivaldi and Safari browser extensions
+            MAX(CASE WHEN D.[Type] IN (2, 3, 4, 5, 19, 20) THEN 1 ELSE 0 END) AS [HasExtension]
         FROM
-            [dbo].[CollectionCipher] CC
-        INNER JOIN
-            [dbo].[Collection] COL ON COL.[Id] = CC.[CollectionId]
-                AND COL.[OrganizationId] = @OrganizationId
-        INNER JOIN
-            [dbo].[Cipher] OC ON OC.[Id] = CC.[CipherId]
-                AND OC.[OrganizationId] = @OrganizationId
-                AND OC.[DeletedDate] IS NULL
+            [dbo].[Device] D
         WHERE
-            EXISTS (
-                SELECT 1
-                FROM [dbo].[CollectionUser] CU
-                WHERE CU.[CollectionId] = CC.[CollectionId]
-                    AND CU.[OrganizationUserId] = OU.[Id]
-            )
-            OR EXISTS (
-                SELECT 1
-                FROM [dbo].[CollectionGroup] CG
-                INNER JOIN [dbo].[GroupUser] GU ON GU.[GroupId] = CG.[GroupId]
-                WHERE CG.[CollectionId] = CC.[CollectionId]
-                    AND GU.[OrganizationUserId] = OU.[Id]
-            )
-    ) SI
+            D.[UserId] = M.[UserId]
+    ) DEV
+    LEFT JOIN
+        [MemberVaultItem] VI ON VI.[UserId] = M.[UserId]
     OUTER APPLY (
         SELECT TOP 1
             OS.[Id]
         FROM
             [dbo].[OrganizationSponsorship] OS
         WHERE
-            OS.[SponsoringOrganizationUserID] = OU.[Id]
+            OS.[SponsoringOrganizationUserID] = M.[Id]
             AND OS.[SponsoredOrganizationId] IS NOT NULL
     ) SP
-    WHERE
-        OU.[OrganizationId] = @OrganizationId
-        -- Adoption is only measured for Confirmed members.
-        AND OU.[Status] = 2
     ORDER BY
         [Email] ASC,
-        OU.[Id] ASC
+        M.[Id] ASC
+    -- The remaining per-member OUTER APPLYs make this CPU-bound rather than I/O-bound, and its
+    -- parallel plan scales negatively: it burns more CPU across workers than it saves in elapsed time.
+    OPTION (MAXDOP 1)
 END

--- a/test/Core.Test/Dirt/ReportFeatures/SharedItemCountCalculatorTests.cs
+++ b/test/Core.Test/Dirt/ReportFeatures/SharedItemCountCalculatorTests.cs
@@ -1,0 +1,326 @@
+using System.Diagnostics;
+using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.ReportFeatures;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Bit.Core.Test.Dirt.ReportFeatures;
+
+public class SharedItemCountCalculatorTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public void Calculate_NoAccessAndNoContent_ReturnsEmpty()
+    {
+        var result = SharedItemCountCalculator.Calculate([], []);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Calculate_NoAccess_ReturnsEmpty()
+    {
+        var collectionId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [],
+            [new CollectionCipherLink(collectionId, Guid.NewGuid())]);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Calculate_NoContent_ReturnsEmpty()
+    {
+        var result = SharedItemCountCalculator.Calculate(
+            [new MemberCollectionAccess(Guid.NewGuid(), Guid.NewGuid())],
+            []);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Calculate_MemberWithoutCollectionAccess_IsOmitted()
+    {
+        var withAccess = Guid.NewGuid();
+        var withoutAccess = Guid.NewGuid();
+        var collectionId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [new MemberCollectionAccess(withAccess, collectionId)],
+            [new CollectionCipherLink(collectionId, Guid.NewGuid())]);
+
+        Assert.Equal(1, result[withAccess]);
+        Assert.False(result.ContainsKey(withoutAccess));
+    }
+
+    [Fact]
+    public void Calculate_CollectionWithoutCiphers_OmitsMembersWithOnlyThatCollection()
+    {
+        var emptyHanded = Guid.NewGuid();
+        var stocked = Guid.NewGuid();
+        var emptyCollectionId = Guid.NewGuid();
+        var stockedCollectionId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [
+                new MemberCollectionAccess(emptyHanded, emptyCollectionId),
+                new MemberCollectionAccess(stocked, stockedCollectionId)
+            ],
+            [new CollectionCipherLink(stockedCollectionId, Guid.NewGuid())]);
+
+        Assert.False(result.ContainsKey(emptyHanded));
+        Assert.Equal(1, result[stocked]);
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Calculate_CipherInTwoAccessibleCollections_CountsItOnce()
+    {
+        var memberId = Guid.NewGuid();
+        var firstCollectionId = Guid.NewGuid();
+        var secondCollectionId = Guid.NewGuid();
+        var sharedCipherId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [
+                new MemberCollectionAccess(memberId, firstCollectionId),
+                new MemberCollectionAccess(memberId, secondCollectionId)
+            ],
+            [
+                new CollectionCipherLink(firstCollectionId, sharedCipherId),
+                new CollectionCipherLink(secondCollectionId, sharedCipherId)
+            ]);
+
+        Assert.Equal(1, result[memberId]);
+    }
+
+    [Fact]
+    public void Calculate_CipherInAccessibleAndInaccessibleCollection_IsStillCounted()
+    {
+        var memberId = Guid.NewGuid();
+        var accessibleCollectionId = Guid.NewGuid();
+        var otherCollectionId = Guid.NewGuid();
+        var sharedCipherId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [new MemberCollectionAccess(memberId, accessibleCollectionId)],
+            [
+                new CollectionCipherLink(accessibleCollectionId, sharedCipherId),
+                new CollectionCipherLink(otherCollectionId, sharedCipherId),
+                new CollectionCipherLink(otherCollectionId, Guid.NewGuid())
+            ]);
+
+        Assert.Equal(1, result[memberId]);
+    }
+
+    [Fact]
+    public void Calculate_MembersWithIdenticalAccess_ShareOneCount()
+    {
+        var first = Guid.NewGuid();
+        var second = Guid.NewGuid();
+        var firstCollectionId = Guid.NewGuid();
+        var secondCollectionId = Guid.NewGuid();
+        var sharedCipherId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [
+                new MemberCollectionAccess(first, firstCollectionId),
+                new MemberCollectionAccess(first, secondCollectionId),
+                // The same set in the opposite order, which has to normalize to the same signature.
+                new MemberCollectionAccess(second, secondCollectionId),
+                new MemberCollectionAccess(second, firstCollectionId)
+            ],
+            [
+                new CollectionCipherLink(firstCollectionId, Guid.NewGuid()),
+                new CollectionCipherLink(firstCollectionId, sharedCipherId),
+                new CollectionCipherLink(secondCollectionId, sharedCipherId),
+                new CollectionCipherLink(secondCollectionId, Guid.NewGuid())
+            ]);
+
+        Assert.Equal(3, result[first]);
+        Assert.Equal(3, result[second]);
+    }
+
+    [Fact]
+    public void Calculate_DuplicateAccessEdges_DoNotInflateTheCount()
+    {
+        var repeated = Guid.NewGuid();
+        var single = Guid.NewGuid();
+        var collectionId = Guid.NewGuid();
+        var cipherId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [
+                new MemberCollectionAccess(repeated, collectionId),
+                new MemberCollectionAccess(repeated, collectionId),
+                new MemberCollectionAccess(single, collectionId)
+            ],
+            [new CollectionCipherLink(collectionId, cipherId)]);
+
+        Assert.Equal(1, result[repeated]);
+        Assert.Equal(1, result[single]);
+    }
+
+    [Fact]
+    public void Calculate_SubsetAccess_CountsOnlyReachableCiphers()
+    {
+        var broad = Guid.NewGuid();
+        var narrow = Guid.NewGuid();
+        var firstCollectionId = Guid.NewGuid();
+        var secondCollectionId = Guid.NewGuid();
+        var thirdCollectionId = Guid.NewGuid();
+        var sharedCipherId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [
+                new MemberCollectionAccess(broad, firstCollectionId),
+                new MemberCollectionAccess(broad, secondCollectionId),
+                new MemberCollectionAccess(broad, thirdCollectionId),
+                new MemberCollectionAccess(narrow, firstCollectionId)
+            ],
+            [
+                new CollectionCipherLink(firstCollectionId, sharedCipherId),
+                new CollectionCipherLink(firstCollectionId, Guid.NewGuid()),
+                new CollectionCipherLink(secondCollectionId, sharedCipherId),
+                new CollectionCipherLink(secondCollectionId, Guid.NewGuid()),
+                new CollectionCipherLink(thirdCollectionId, Guid.NewGuid())
+            ]);
+
+        Assert.Equal(4, result[broad]);
+        Assert.Equal(2, result[narrow]);
+    }
+
+    [Fact]
+    public void Calculate_UnreachableCollectionsAndCiphers_AreExcluded()
+    {
+        var memberId = Guid.NewGuid();
+        var reachableCollectionId = Guid.NewGuid();
+        var unreachableCollectionId = Guid.NewGuid();
+        var otherMemberId = Guid.NewGuid();
+
+        var result = SharedItemCountCalculator.Calculate(
+            [
+                new MemberCollectionAccess(memberId, reachableCollectionId),
+                new MemberCollectionAccess(otherMemberId, unreachableCollectionId)
+            ],
+            [
+                new CollectionCipherLink(reachableCollectionId, Guid.NewGuid()),
+                new CollectionCipherLink(unreachableCollectionId, Guid.NewGuid()),
+                new CollectionCipherLink(unreachableCollectionId, Guid.NewGuid()),
+                new CollectionCipherLink(Guid.NewGuid(), Guid.NewGuid())
+            ]);
+
+        Assert.Equal(1, result[memberId]);
+        Assert.Equal(2, result[otherMemberId]);
+        Assert.Equal(2, result.Count);
+    }
+
+    /// <summary>
+    /// The shape that made the stored procedure unusable: every member sees every cipher, so a per-member
+    /// walk of the ciphers would be 17,001 x 50,000 touches.
+    /// </summary>
+    [Fact]
+    public void Calculate_UniversalAccessOrganization_CountsEveryMemberQuickly()
+    {
+        const int memberCount = 17_001;
+        const int cipherCount = 50_000;
+
+        var collectionId = Guid.NewGuid();
+        var access = new List<MemberCollectionAccess>(memberCount);
+        var memberIds = new List<Guid>(memberCount);
+        for (var i = 0; i < memberCount; i++)
+        {
+            var memberId = Guid.NewGuid();
+            memberIds.Add(memberId);
+            access.Add(new MemberCollectionAccess(memberId, collectionId));
+        }
+
+        var content = new List<CollectionCipherLink>(cipherCount);
+        for (var i = 0; i < cipherCount; i++)
+        {
+            content.Add(new CollectionCipherLink(collectionId, Guid.NewGuid()));
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = SharedItemCountCalculator.Calculate(access, content);
+        stopwatch.Stop();
+
+        testOutputHelper.WriteLine(
+            $"{memberCount} members x {cipherCount} ciphers in {stopwatch.ElapsedMilliseconds} ms");
+
+        Assert.Equal(memberCount, result.Count);
+        foreach (var memberId in memberIds)
+        {
+            Assert.Equal(cipherCount, result[memberId]);
+        }
+    }
+
+    /// <summary>
+    /// Many collections, overlapping access sets and ciphers that several collections share, so neither the
+    /// access-set memoization nor the single-collection shortcut can carry the result on its own.
+    /// </summary>
+    [Fact]
+    public void Calculate_ManyOverlappingAccessSets_CountsEveryMemberQuickly()
+    {
+        const int collectionCount = 2_000;
+        const int ciphersPerCollection = 100;
+        const int globalCipherCount = 10;
+        const int collectionsPerMember = 100;
+        const int memberCount = 10_000;
+        const int stride = 7;
+
+        var collectionIds = new Guid[collectionCount];
+        for (var i = 0; i < collectionCount; i++)
+        {
+            collectionIds[i] = Guid.NewGuid();
+        }
+
+        var content = new List<CollectionCipherLink>(
+            (collectionCount * ciphersPerCollection) + (collectionCount * globalCipherCount));
+        for (var i = 0; i < collectionCount; i++)
+        {
+            for (var j = 0; j < ciphersPerCollection; j++)
+            {
+                content.Add(new CollectionCipherLink(collectionIds[i], Guid.NewGuid()));
+            }
+        }
+
+        for (var i = 0; i < globalCipherCount; i++)
+        {
+            var globalCipherId = Guid.NewGuid();
+            for (var j = 0; j < collectionCount; j++)
+            {
+                content.Add(new CollectionCipherLink(collectionIds[j], globalCipherId));
+            }
+        }
+
+        var memberIds = new Guid[memberCount];
+        var access = new List<MemberCollectionAccess>(memberCount * collectionsPerMember);
+        for (var i = 0; i < memberCount; i++)
+        {
+            memberIds[i] = Guid.NewGuid();
+            for (var j = 0; j < collectionsPerMember; j++)
+            {
+                var collection = (i + (j * stride)) % collectionCount;
+                access.Add(new MemberCollectionAccess(memberIds[i], collectionIds[collection]));
+            }
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = SharedItemCountCalculator.Calculate(access, content);
+        stopwatch.Stop();
+
+        testOutputHelper.WriteLine(
+            $"{memberCount} members x {collectionsPerMember} collections over {content.Count} links " +
+            $"in {stopwatch.ElapsedMilliseconds} ms");
+
+        // The strided collections are distinct because the stride is coprime with the collection count, so
+        // every member reaches the same number of ciphers.
+        var expected = (collectionsPerMember * ciphersPerCollection) + globalCipherCount;
+        Assert.Equal(memberCount, result.Count);
+        foreach (var memberId in memberIds)
+        {
+            Assert.Equal(expected, result[memberId]);
+        }
+    }
+}

--- a/test/Infrastructure.EFIntegration.Test/Dirt/Autofixture/MemberAdoptionReportFixtures.cs
+++ b/test/Infrastructure.EFIntegration.Test/Dirt/Autofixture/MemberAdoptionReportFixtures.cs
@@ -1,0 +1,43 @@
+﻿using AutoFixture;
+using Bit.Core.Test.AutoFixture.UserFixtures;
+using Bit.Infrastructure.EntityFramework.Dirt.Repositories;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using EfAdminConsoleRepo = Bit.Infrastructure.EntityFramework.AdminConsole.Repositories;
+using EfVaultRepo = Bit.Infrastructure.EntityFramework.Vault.Repositories;
+
+namespace Bit.Infrastructure.EFIntegration.Test.AutoFixture;
+
+internal class EfMemberAdoptionReport : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        fixture.Customizations.Add(new IgnoreVirtualMembersCustomization());
+        fixture.Customizations.Add(new GlobalSettingsBuilder());
+        fixture.Customizations.Add(new UserBuilder());
+        fixture.Customizations.Add(new OrganizationBuilder());
+        fixture.Customizations.Add(new DeviceBuilder());
+        fixture.Customizations.Add(new CollectionBuilder());
+        fixture.Customizations.Add(new GroupBuilder());
+        fixture.Customizations.Add(new CipherBuilder());
+        fixture.Customizations.Add(new OrganizationSponsorshipBuilder());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<MemberAdoptionReportRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<UserRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<OrganizationRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<EfAdminConsoleRepo.OrganizationUserRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<DeviceRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<EfAdminConsoleRepo.CollectionRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<EfAdminConsoleRepo.GroupRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<EfVaultRepo.CipherRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<CollectionCipherRepository>());
+        fixture.Customizations.Add(new EfRepositoryListBuilder<OrganizationSponsorshipRepository>());
+    }
+}
+
+internal class EfMemberAdoptionReportAutoDataAttribute : CustomAutoDataAttribute
+{
+    public EfMemberAdoptionReportAutoDataAttribute()
+        : base(new SutProviderCustomization(), new EfMemberAdoptionReport())
+    { }
+}

--- a/test/Infrastructure.EFIntegration.Test/Dirt/Repositories/MemberAdoptionReportQuerySqliteTests.cs
+++ b/test/Infrastructure.EFIntegration.Test/Dirt/Repositories/MemberAdoptionReportQuerySqliteTests.cs
@@ -1,0 +1,367 @@
+﻿using Bit.Core;
+using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Enums;
+using Bit.Core.Vault.Enums;
+using Bit.Infrastructure.EntityFramework.Dirt.Repositories;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+using EfAdminConsoleModel = Bit.Infrastructure.EntityFramework.AdminConsole.Models;
+using EfModel = Bit.Infrastructure.EntityFramework.Models;
+using EfVaultModel = Bit.Infrastructure.EntityFramework.Vault.Models;
+
+namespace Bit.Infrastructure.EFIntegration.Test.Dirt.Repositories;
+
+/// <summary>
+/// Covers the three reads the member adoption report is built from, against a real, throwaway SQLite
+/// database. The two edge reads feed <see cref="Bit.Core.Dirt.Reports.ReportFeatures.SharedItemCountCalculator"/>,
+/// so what matters here is the edge sets themselves, not the counts derived from them.
+/// </summary>
+public class MemberAdoptionReportQuerySqliteTests : IDisposable
+{
+    private static readonly DateTime _activityDate = new(2026, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _deletionDate = new(2026, 1, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly SqliteConnection _connection;
+    private readonly DatabaseContext _dbContext;
+
+    private readonly Guid _organizationId = Guid.NewGuid();
+    private readonly Guid _otherOrganizationId = Guid.NewGuid();
+
+    private readonly Guid _memberUserId = Guid.NewGuid();
+    private readonly Guid _memberOrganizationUserId = Guid.NewGuid();
+
+    // Both of these members have no linked user and no invite email, so both sort as the empty string
+    // and only the organization user id breaks the tie. The values are chosen so that .NET and SQLite
+    // agree on their order.
+    private readonly Guid _firstUserlessOrganizationUserId = new("00000000-0000-0000-0000-0000000000a1");
+    private readonly Guid _secondUserlessOrganizationUserId = new("00000000-0000-0000-0000-0000000000a2");
+    private readonly Guid _invitedEmailOrganizationUserId = Guid.NewGuid();
+
+    private readonly Guid _bothPathsCollectionId = Guid.NewGuid();
+    private readonly Guid _directOnlyCollectionId = Guid.NewGuid();
+    private readonly Guid _groupOnlyCollectionId = Guid.NewGuid();
+    private readonly Guid _twoGroupsCollectionId = Guid.NewGuid();
+    private readonly Guid _otherOrganizationCollectionId = Guid.NewGuid();
+
+    private readonly Guid _firstGroupId = Guid.NewGuid();
+    private readonly Guid _secondGroupId = Guid.NewGuid();
+
+    private Guid _sharedCipherId;
+    private Guid _deletedCipherId;
+    private Guid _personalCipherInCollectionId;
+    private Guid _otherOrganizationCipherId;
+
+    public MemberAdoptionReportQuerySqliteTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<DatabaseContext>()
+            .UseSqlite(_connection)
+            .UseApplicationServiceProvider(BuildDataProtectionServiceProvider())
+            .Options;
+
+        _dbContext = new DatabaseContext(options);
+        _dbContext.Database.EnsureCreated();
+
+        Seed();
+    }
+
+    [Fact]
+    public async Task GetMemberCollectionAccessAsync_CollapsesDirectAndGroupGrantsToOneEdgePerCollection()
+    {
+        var access = await MemberAdoptionReportRepository.GetMemberCollectionAccessAsync(
+            _dbContext, _organizationId);
+
+        Assert.Equal(
+            new HashSet<MemberCollectionAccess>
+            {
+                new(_memberOrganizationUserId, _bothPathsCollectionId),
+                new(_memberOrganizationUserId, _directOnlyCollectionId),
+                new(_memberOrganizationUserId, _groupOnlyCollectionId),
+                new(_memberOrganizationUserId, _twoGroupsCollectionId)
+            },
+            access.ToHashSet());
+
+        // A set that is already distinct is the calculator's contract, so the list must not merely
+        // contain the right edges, it must contain each of them once.
+        Assert.Equal(4, access.Count);
+    }
+
+    [Fact]
+    public async Task GetMemberCollectionAccessAsync_IgnoresCollectionsOwnedByAnotherOrganization()
+    {
+        var access = await MemberAdoptionReportRepository.GetMemberCollectionAccessAsync(
+            _dbContext, _organizationId);
+
+        Assert.DoesNotContain(access, edge => edge.CollectionId == _otherOrganizationCollectionId);
+    }
+
+    [Fact]
+    public async Task GetCollectionCipherLinksAsync_ReturnsOnlyLiveOrganizationOwnedCiphers()
+    {
+        var links = await MemberAdoptionReportRepository.GetCollectionCipherLinksAsync(
+            _dbContext, _organizationId);
+
+        Assert.Equal(
+            new HashSet<CollectionCipherLink>
+            {
+                new(_bothPathsCollectionId, _sharedCipherId),
+                new(_directOnlyCollectionId, _sharedCipherId)
+            },
+            links.ToHashSet());
+        Assert.Equal(2, links.Count);
+    }
+
+    [Fact]
+    public async Task GetCollectionCipherLinksAsync_ExcludesDeletedPersonalAndForeignCiphers()
+    {
+        var links = await MemberAdoptionReportRepository.GetCollectionCipherLinksAsync(
+            _dbContext, _organizationId);
+
+        Assert.DoesNotContain(links, link => link.CipherId == _deletedCipherId);
+        Assert.DoesNotContain(links, link => link.CipherId == _personalCipherInCollectionId);
+        Assert.DoesNotContain(links, link => link.CipherId == _otherOrganizationCipherId);
+    }
+
+    [Fact]
+    public async Task GetConfirmedMemberDetailsAsync_OrdersByCoalescedEmailThenOrganizationUserId()
+    {
+        var details = await MemberAdoptionReportRepository.GetConfirmedMemberDetailsAsync(
+            _dbContext, _organizationId);
+
+        Assert.Equal(
+            new[]
+            {
+                _firstUserlessOrganizationUserId,
+                _secondUserlessOrganizationUserId,
+                _invitedEmailOrganizationUserId,
+                _memberOrganizationUserId
+            },
+            details.Select(detail => detail.OrganizationUserId));
+        Assert.Equal(new[] { "", "", "invited@example.com", "member@example.com" },
+            details.Select(detail => detail.Email));
+    }
+
+    [Fact]
+    public async Task GetConfirmedMemberDetailsAsync_ReportsNothingPersonalForAMemberWithNoLinkedUser()
+    {
+        var details = await MemberAdoptionReportRepository.GetConfirmedMemberDetailsAsync(
+            _dbContext, _organizationId);
+
+        var userless = details.Single(
+            detail => detail.OrganizationUserId == _firstUserlessOrganizationUserId);
+
+        Assert.Null(userless.UserId);
+        Assert.Null(userless.Name);
+        Assert.Null(userless.LastActivityDate);
+        Assert.False(userless.HasExtensionInstalled);
+        // An unowned cipher exists; it must not be attributed to every member without a user.
+        Assert.Equal(0, userless.VaultItemCount);
+    }
+
+    [Fact]
+    public async Task GetConfirmedMemberDetailsAsync_CountsOnlyTheMembersOwnLivePersonalItems()
+    {
+        var details = await MemberAdoptionReportRepository.GetConfirmedMemberDetailsAsync(
+            _dbContext, _organizationId);
+
+        var member = details.Single(detail => detail.OrganizationUserId == _memberOrganizationUserId);
+
+        Assert.Equal(1, member.VaultItemCount);
+        Assert.Equal(_activityDate, member.LastActivityDate);
+        Assert.True(member.HasExtensionInstalled);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private void Seed()
+    {
+        _dbContext.Organizations.Add(BuildOrganization(_organizationId, "Reported organization"));
+        _dbContext.Organizations.Add(BuildOrganization(_otherOrganizationId, "Other organization"));
+
+        _dbContext.Users.Add(new EfModel.User
+        {
+            Id = _memberUserId,
+            Name = "Member",
+            Email = "member@example.com",
+            SecurityStamp = Guid.NewGuid().ToString(),
+            ApiKey = Guid.NewGuid().ToString("N")[..30],
+            CreationDate = _activityDate,
+            RevisionDate = _activityDate,
+            AccountRevisionDate = _activityDate
+        });
+
+        _dbContext.OrganizationUsers.Add(BuildOrganizationUser(_memberOrganizationUserId, _memberUserId, null));
+        _dbContext.OrganizationUsers.Add(BuildOrganizationUser(_firstUserlessOrganizationUserId, null, null));
+        _dbContext.OrganizationUsers.Add(BuildOrganizationUser(_secondUserlessOrganizationUserId, null, null));
+        _dbContext.OrganizationUsers.Add(
+            BuildOrganizationUser(_invitedEmailOrganizationUserId, null, "invited@example.com"));
+
+        _dbContext.Devices.Add(new EfModel.Device
+        {
+            Id = Guid.NewGuid(),
+            UserId = _memberUserId,
+            Name = "Chrome",
+            Identifier = Guid.NewGuid().ToString(),
+            Type = DeviceType.ChromeExtension,
+            LastActivityDate = _activityDate
+        });
+
+        _dbContext.Collections.Add(BuildCollection(_bothPathsCollectionId, _organizationId, "Both paths"));
+        _dbContext.Collections.Add(BuildCollection(_directOnlyCollectionId, _organizationId, "Direct only"));
+        _dbContext.Collections.Add(BuildCollection(_groupOnlyCollectionId, _organizationId, "Group only"));
+        _dbContext.Collections.Add(BuildCollection(_twoGroupsCollectionId, _organizationId, "Two groups"));
+        _dbContext.Collections.Add(
+            BuildCollection(_otherOrganizationCollectionId, _otherOrganizationId, "Other organization"));
+
+        _dbContext.Groups.Add(BuildGroup(_firstGroupId, "Engineering"));
+        _dbContext.Groups.Add(BuildGroup(_secondGroupId, "Support"));
+        AddGroupUser(_firstGroupId, _memberOrganizationUserId);
+        AddGroupUser(_secondGroupId, _memberOrganizationUserId);
+
+        AddCollectionUser(_bothPathsCollectionId, _memberOrganizationUserId);
+        AddCollectionUser(_directOnlyCollectionId, _memberOrganizationUserId);
+        AddCollectionUser(_otherOrganizationCollectionId, _memberOrganizationUserId);
+
+        AddCollectionGroup(_bothPathsCollectionId, _firstGroupId);
+        AddCollectionGroup(_groupOnlyCollectionId, _firstGroupId);
+        AddCollectionGroup(_twoGroupsCollectionId, _firstGroupId);
+        AddCollectionGroup(_twoGroupsCollectionId, _secondGroupId);
+        AddCollectionGroup(_otherOrganizationCollectionId, _firstGroupId);
+
+        _sharedCipherId = AddCipher(userId: null, organizationId: _organizationId);
+        _deletedCipherId = AddCipher(userId: null, organizationId: _organizationId, deletedDate: _deletionDate);
+        _personalCipherInCollectionId = AddCipher(userId: _memberUserId, organizationId: null);
+        _otherOrganizationCipherId = AddCipher(userId: null, organizationId: _otherOrganizationId);
+
+        AddCollectionCipher(_bothPathsCollectionId, _sharedCipherId);
+        AddCollectionCipher(_directOnlyCollectionId, _sharedCipherId);
+        AddCollectionCipher(_bothPathsCollectionId, _deletedCipherId);
+        AddCollectionCipher(_bothPathsCollectionId, _personalCipherInCollectionId);
+        AddCollectionCipher(_otherOrganizationCollectionId, _otherOrganizationCipherId);
+
+        AddCipher(userId: _memberUserId, organizationId: null, deletedDate: _deletionDate);
+        AddCipher(userId: _memberUserId, organizationId: _organizationId);
+        // Owned by nobody, so no member's personal vault count may pick it up.
+        AddCipher(userId: null, organizationId: null);
+
+        _dbContext.SaveChanges();
+    }
+
+    private EfAdminConsoleModel.Organization BuildOrganization(Guid id, string name) =>
+        new()
+        {
+            Id = id,
+            Name = name,
+            BillingEmail = $"{id}@example.com",
+            Plan = "Enterprise",
+            Enabled = true,
+            CreationDate = _activityDate,
+            RevisionDate = _activityDate
+        };
+
+    private EfModel.OrganizationUser BuildOrganizationUser(Guid id, Guid? userId, string? email) =>
+        new()
+        {
+            Id = id,
+            OrganizationId = _organizationId,
+            UserId = userId,
+            Email = email,
+            Status = OrganizationUserStatusType.Confirmed,
+            Type = OrganizationUserType.User,
+            RevisionDate = _activityDate
+        };
+
+    private EfAdminConsoleModel.Collection BuildCollection(Guid id, Guid organizationId, string name) =>
+        new()
+        {
+            Id = id,
+            OrganizationId = organizationId,
+            Name = name,
+            Type = CollectionType.SharedCollection,
+            CreationDate = _activityDate,
+            RevisionDate = _activityDate
+        };
+
+    private EfModel.Group BuildGroup(Guid id, string name) =>
+        new()
+        {
+            Id = id,
+            OrganizationId = _organizationId,
+            Name = name,
+            RevisionDate = _activityDate
+        };
+
+    private void AddGroupUser(Guid groupId, Guid organizationUserId) =>
+        _dbContext.GroupUsers.Add(new EfModel.GroupUser
+        {
+            GroupId = groupId,
+            OrganizationUserId = organizationUserId
+        });
+
+    private void AddCollectionUser(Guid collectionId, Guid organizationUserId) =>
+        _dbContext.CollectionUsers.Add(new EfAdminConsoleModel.CollectionUser
+        {
+            CollectionId = collectionId,
+            OrganizationUserId = organizationUserId
+        });
+
+    private void AddCollectionGroup(Guid collectionId, Guid groupId) =>
+        _dbContext.CollectionGroups.Add(new EfAdminConsoleModel.CollectionGroup
+        {
+            CollectionId = collectionId,
+            GroupId = groupId
+        });
+
+    private void AddCollectionCipher(Guid collectionId, Guid cipherId) =>
+        _dbContext.CollectionCiphers.Add(new EfModel.CollectionCipher
+        {
+            CollectionId = collectionId,
+            CipherId = cipherId
+        });
+
+    private Guid AddCipher(Guid? userId, Guid? organizationId, DateTime? deletedDate = null)
+    {
+        var cipher = new EfVaultModel.Cipher
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            OrganizationId = organizationId,
+            Type = CipherType.Login,
+            Data = "{}",
+            CreationDate = _activityDate,
+            RevisionDate = _activityDate,
+            DeletedDate = deletedDate
+        };
+
+        _dbContext.Ciphers.Add(cipher);
+        return cipher.Id;
+    }
+
+    private static IServiceProvider BuildDataProtectionServiceProvider() =>
+        new ServiceCollection()
+            .AddSingleton(_ =>
+            {
+                var dataProtector = Substitute.For<IDataProtector>();
+                dataProtector.Protect(Arg.Any<byte[]>()).Returns<byte[]>(data => (byte[])data[0]);
+                dataProtector.Unprotect(Arg.Any<byte[]>()).Returns<byte[]>(data => (byte[])data[0]);
+
+                var dataProtectionProvider = Substitute.For<IDataProtectionProvider>();
+                dataProtectionProvider.CreateProtector(Constants.DatabaseFieldProtectorPurpose)
+                    .Returns(dataProtector);
+
+                return dataProtectionProvider;
+            })
+            .BuildServiceProvider();
+}

--- a/test/Infrastructure.EFIntegration.Test/Dirt/Repositories/MemberAdoptionReportRepositorySqliteTests.cs
+++ b/test/Infrastructure.EFIntegration.Test/Dirt/Repositories/MemberAdoptionReportRepositorySqliteTests.cs
@@ -1,0 +1,355 @@
+﻿using AutoMapper;
+using Bit.Core;
+using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Enums;
+using Bit.Core.Vault.Enums;
+using Bit.Infrastructure.EntityFramework.Dirt.Repositories;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+using EfAdminConsoleModel = Bit.Infrastructure.EntityFramework.AdminConsole.Models;
+using EfModel = Bit.Infrastructure.EntityFramework.Models;
+using EfVaultModel = Bit.Infrastructure.EntityFramework.Vault.Models;
+
+namespace Bit.Infrastructure.EFIntegration.Test.Dirt.Repositories;
+
+/// <summary>
+/// Runs the member adoption report against a real, throwaway SQLite database.
+/// </summary>
+public class MemberAdoptionReportRepositorySqliteTests : IDisposable
+{
+    private static readonly DateTime _olderActivityDate = new(2026, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _latestActivityDate = new(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _deletionDate = new(2026, 1, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly SqliteConnection _connection;
+    private readonly DatabaseContext _dbContext;
+    private readonly MemberAdoptionReportRepository _sut;
+
+    private readonly Guid _organizationId = Guid.NewGuid();
+    private readonly Guid _sponsoredOrganizationId = Guid.NewGuid();
+    private readonly Guid _memberUserId = Guid.NewGuid();
+    private readonly Guid _memberOrganizationUserId = Guid.NewGuid();
+    private readonly Guid _memberWithoutAccessUserId = Guid.NewGuid();
+    private readonly Guid _memberWithoutAccessOrganizationUserId = Guid.NewGuid();
+    private readonly Guid _invitedUserId = Guid.NewGuid();
+    private readonly Guid _invitedOrganizationUserId = Guid.NewGuid();
+
+    public MemberAdoptionReportRepositorySqliteTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<DatabaseContext>()
+            .UseSqlite(_connection)
+            .UseApplicationServiceProvider(BuildDataProtectionServiceProvider())
+            .Options;
+
+        _dbContext = new DatabaseContext(options);
+        _dbContext.Database.EnsureCreated();
+
+        Seed();
+
+        _sut = new MemberAdoptionReportRepository(
+            new SingleContextScopeFactory(_dbContext), Substitute.For<IMapper>());
+    }
+
+    [Fact]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_ReturnsEveryConfirmedMemberAndNoOthers()
+    {
+        var details = (await _sut.GetMemberAdoptionDetailsByOrganizationIdAsync(_organizationId)).ToList();
+
+        Assert.Equal(2, details.Count);
+        Assert.DoesNotContain(details, detail => detail.OrganizationUserId == _invitedOrganizationUserId);
+        Assert.Contains(details, detail => detail.OrganizationUserId == _memberOrganizationUserId);
+        Assert.Contains(details, detail => detail.OrganizationUserId == _memberWithoutAccessOrganizationUserId);
+    }
+
+    [Fact]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_ReportsExtensionInstalledPerMember()
+    {
+        var (member, memberWithoutAccess) = await GetMembersAsync();
+
+        Assert.True(member.HasExtensionInstalled);
+        Assert.False(memberWithoutAccess.HasExtensionInstalled);
+    }
+
+    [Fact]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_TakesTheLatestActivityAcrossAllDeviceTypes()
+    {
+        var (member, memberWithoutAccess) = await GetMembersAsync();
+
+        Assert.Equal(_latestActivityDate, member.LastActivityDate);
+        Assert.Equal(_olderActivityDate, memberWithoutAccess.LastActivityDate);
+    }
+
+    [Fact]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_CountsOnlyLivePersonalItemsAsVaultItems()
+    {
+        var (member, memberWithoutAccess) = await GetMembersAsync();
+
+        Assert.Equal(1, member.VaultItemCount);
+        Assert.Equal(0, memberWithoutAccess.VaultItemCount);
+    }
+
+    [Fact]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_CountsItemsReachableByBothAccessPathsOnce()
+    {
+        var (member, memberWithoutAccess) = await GetMembersAsync();
+
+        Assert.Equal(3, member.SharedItemCount);
+        Assert.Equal(0, memberWithoutAccess.SharedItemCount);
+    }
+
+    [Fact]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_ReportsSponsorshipOnlyOnceRedeemed()
+    {
+        var (member, memberWithoutAccess) = await GetMembersAsync();
+
+        Assert.True(member.HasRedeemedSponsorship);
+        Assert.False(memberWithoutAccess.HasRedeemedSponsorship);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _connection.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<(MemberAdoptionReportDetail Member, MemberAdoptionReportDetail MemberWithoutAccess)>
+        GetMembersAsync()
+    {
+        var details = (await _sut.GetMemberAdoptionDetailsByOrganizationIdAsync(_organizationId)).ToList();
+
+        return (
+            details.Single(detail => detail.OrganizationUserId == _memberOrganizationUserId),
+            details.Single(detail => detail.OrganizationUserId == _memberWithoutAccessOrganizationUserId));
+    }
+
+    private void Seed()
+    {
+        _dbContext.Organizations.Add(BuildOrganization(_organizationId, "Reported organization"));
+        _dbContext.Organizations.Add(BuildOrganization(_sponsoredOrganizationId, "Sponsored organization"));
+
+        _dbContext.Users.Add(BuildUser(_memberUserId, "member@example.com"));
+        _dbContext.Users.Add(BuildUser(_memberWithoutAccessUserId, "no-access@example.com"));
+        _dbContext.Users.Add(BuildUser(_invitedUserId, "invited@example.com"));
+
+        _dbContext.OrganizationUsers.Add(BuildOrganizationUser(
+            _memberOrganizationUserId, _memberUserId, OrganizationUserStatusType.Confirmed));
+        _dbContext.OrganizationUsers.Add(BuildOrganizationUser(
+            _memberWithoutAccessOrganizationUserId, _memberWithoutAccessUserId, OrganizationUserStatusType.Confirmed));
+        _dbContext.OrganizationUsers.Add(BuildOrganizationUser(
+            _invitedOrganizationUserId, _invitedUserId, OrganizationUserStatusType.Invited));
+
+        // The member's newest activity is on a desktop, not the extension.
+        _dbContext.Devices.Add(BuildDevice(_memberUserId, DeviceType.ChromeExtension, _olderActivityDate));
+        _dbContext.Devices.Add(BuildDevice(_memberUserId, DeviceType.MacOsDesktop, _latestActivityDate));
+        _dbContext.Devices.Add(BuildDevice(_memberWithoutAccessUserId, DeviceType.MacOsDesktop, _olderActivityDate));
+
+        var sharedCollectionId = Guid.NewGuid();
+        var groupOnlyCollectionId = Guid.NewGuid();
+        var directOnlyCollectionId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        _dbContext.Collections.Add(BuildCollection(sharedCollectionId, "Shared"));
+        _dbContext.Collections.Add(BuildCollection(groupOnlyCollectionId, "Group only"));
+        _dbContext.Collections.Add(BuildCollection(directOnlyCollectionId, "Direct only"));
+
+        _dbContext.Groups.Add(new EfModel.Group
+        {
+            Id = groupId,
+            OrganizationId = _organizationId,
+            Name = "Engineering",
+            RevisionDate = _olderActivityDate
+        });
+        _dbContext.GroupUsers.Add(new EfModel.GroupUser
+        {
+            GroupId = groupId,
+            OrganizationUserId = _memberOrganizationUserId
+        });
+
+        _dbContext.CollectionUsers.Add(new EfAdminConsoleModel.CollectionUser
+        {
+            CollectionId = sharedCollectionId,
+            OrganizationUserId = _memberOrganizationUserId
+        });
+        _dbContext.CollectionUsers.Add(new EfAdminConsoleModel.CollectionUser
+        {
+            CollectionId = directOnlyCollectionId,
+            OrganizationUserId = _memberOrganizationUserId
+        });
+        _dbContext.CollectionGroups.Add(new EfAdminConsoleModel.CollectionGroup
+        {
+            CollectionId = sharedCollectionId,
+            GroupId = groupId
+        });
+        _dbContext.CollectionGroups.Add(new EfAdminConsoleModel.CollectionGroup
+        {
+            CollectionId = groupOnlyCollectionId,
+            GroupId = groupId
+        });
+
+        var cipherReachableByBothPaths = AddOrganizationCipher();
+        var cipherReachableByDirectAccessOnly = AddOrganizationCipher();
+        var cipherReachableByGroupAccessOnly = AddOrganizationCipher();
+        var deletedCipher = AddOrganizationCipher(_deletionDate);
+
+        AddCollectionCipher(sharedCollectionId, cipherReachableByBothPaths);
+        AddCollectionCipher(groupOnlyCollectionId, cipherReachableByBothPaths);
+        AddCollectionCipher(directOnlyCollectionId, cipherReachableByDirectAccessOnly);
+        AddCollectionCipher(groupOnlyCollectionId, cipherReachableByGroupAccessOnly);
+        AddCollectionCipher(sharedCollectionId, deletedCipher);
+
+        _dbContext.Ciphers.Add(BuildCipher(_memberUserId, organizationId: null));
+        _dbContext.Ciphers.Add(BuildCipher(_memberUserId, organizationId: null, deletedDate: _deletionDate));
+        _dbContext.Ciphers.Add(BuildCipher(_memberUserId, organizationId: _organizationId));
+
+        _dbContext.OrganizationSponsorships.Add(new EfModel.OrganizationSponsorship
+        {
+            Id = Guid.NewGuid(),
+            SponsoringOrganizationId = _organizationId,
+            SponsoringOrganizationUserId = _memberOrganizationUserId,
+            SponsoredOrganizationId = _sponsoredOrganizationId,
+            OfferedToEmail = "friend@example.com"
+        });
+        _dbContext.OrganizationSponsorships.Add(new EfModel.OrganizationSponsorship
+        {
+            Id = Guid.NewGuid(),
+            SponsoringOrganizationId = _organizationId,
+            SponsoringOrganizationUserId = _memberWithoutAccessOrganizationUserId,
+            SponsoredOrganizationId = null,
+            OfferedToEmail = "invitee@example.com"
+        });
+
+        _dbContext.SaveChanges();
+    }
+
+    private Guid AddOrganizationCipher(DateTime? deletedDate = null)
+    {
+        var cipher = BuildCipher(userId: null, organizationId: _organizationId, deletedDate: deletedDate);
+        _dbContext.Ciphers.Add(cipher);
+        return cipher.Id;
+    }
+
+    private void AddCollectionCipher(Guid collectionId, Guid cipherId) =>
+        _dbContext.CollectionCiphers.Add(new EfModel.CollectionCipher
+        {
+            CollectionId = collectionId,
+            CipherId = cipherId
+        });
+
+    private EfAdminConsoleModel.Organization BuildOrganization(Guid id, string name) =>
+        new()
+        {
+            Id = id,
+            Name = name,
+            BillingEmail = $"{id}@example.com",
+            Plan = "Enterprise",
+            Enabled = true,
+            CreationDate = _olderActivityDate,
+            RevisionDate = _olderActivityDate
+        };
+
+    private EfModel.User BuildUser(Guid id, string email) =>
+        new()
+        {
+            Id = id,
+            Name = email,
+            Email = email,
+            SecurityStamp = Guid.NewGuid().ToString(),
+            ApiKey = Guid.NewGuid().ToString("N")[..30],
+            CreationDate = _olderActivityDate,
+            RevisionDate = _olderActivityDate,
+            AccountRevisionDate = _olderActivityDate
+        };
+
+    private EfModel.OrganizationUser BuildOrganizationUser(
+        Guid id, Guid userId, OrganizationUserStatusType status) =>
+        new()
+        {
+            Id = id,
+            OrganizationId = _organizationId,
+            UserId = userId,
+            Status = status,
+            Type = OrganizationUserType.User,
+            RevisionDate = _olderActivityDate
+        };
+
+    private EfModel.Device BuildDevice(Guid userId, DeviceType type, DateTime lastActivityDate) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Name = type.ToString(),
+            Identifier = Guid.NewGuid().ToString(),
+            Type = type,
+            LastActivityDate = lastActivityDate
+        };
+
+    private EfAdminConsoleModel.Collection BuildCollection(Guid id, string name) =>
+        new()
+        {
+            Id = id,
+            OrganizationId = _organizationId,
+            Name = name,
+            Type = CollectionType.SharedCollection,
+            CreationDate = _olderActivityDate,
+            RevisionDate = _olderActivityDate
+        };
+
+    private EfVaultModel.Cipher BuildCipher(Guid? userId, Guid? organizationId, DateTime? deletedDate = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            OrganizationId = organizationId,
+            Type = CipherType.Login,
+            Data = "{}",
+            CreationDate = _olderActivityDate,
+            RevisionDate = _olderActivityDate,
+            DeletedDate = deletedDate
+        };
+
+    private static IServiceProvider BuildDataProtectionServiceProvider() =>
+        new ServiceCollection()
+            .AddSingleton(_ =>
+            {
+                var dataProtector = Substitute.For<IDataProtector>();
+                dataProtector.Protect(Arg.Any<byte[]>()).Returns<byte[]>(data => (byte[])data[0]);
+                dataProtector.Unprotect(Arg.Any<byte[]>()).Returns<byte[]>(data => (byte[])data[0]);
+
+                var dataProtectionProvider = Substitute.For<IDataProtectionProvider>();
+                dataProtectionProvider.CreateProtector(Constants.DatabaseFieldProtectorPurpose)
+                    .Returns(dataProtector);
+
+                return dataProtectionProvider;
+            })
+            .BuildServiceProvider();
+
+    private sealed class SingleContextScopeFactory : IServiceScopeFactory, IServiceScope, IServiceProvider
+    {
+        private readonly DatabaseContext _dbContext;
+
+        public SingleContextScopeFactory(DatabaseContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public IServiceProvider ServiceProvider => this;
+
+        public IServiceScope CreateScope() => this;
+
+        public object? GetService(Type serviceType) =>
+            serviceType == typeof(DatabaseContext) ? _dbContext : null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/Infrastructure.EFIntegration.Test/Dirt/Repositories/MemberAdoptionReportRepositoryTests.cs
+++ b/test/Infrastructure.EFIntegration.Test/Dirt/Repositories/MemberAdoptionReportRepositoryTests.cs
@@ -1,0 +1,361 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Core.Test.AutoFixture.Attributes;
+using Bit.Core.Vault.Entities;
+using Bit.Infrastructure.EFIntegration.Test.AutoFixture;
+using Xunit;
+using EfAdminConsoleRepo = Bit.Infrastructure.EntityFramework.AdminConsole.Repositories;
+using EfDirtRepo = Bit.Infrastructure.EntityFramework.Dirt.Repositories;
+using EfRepo = Bit.Infrastructure.EntityFramework.Repositories;
+using EfVaultRepo = Bit.Infrastructure.EntityFramework.Vault.Repositories;
+
+namespace Bit.Infrastructure.EFIntegration.Test.Dirt.Repositories;
+
+public class MemberAdoptionReportRepositoryTests
+{
+    private static readonly DateTime _olderActivityDate = new(2026, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _latestActivityDate = new(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _deletionDate = new(2026, 1, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    [CiSkippedTheory, EfMemberAdoptionReportAutoData]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_ForAllEFProviders_ReturnsConfirmedMemberDetail(
+        User user,
+        Organization organization,
+        OrganizationUser organizationUser,
+        Device extensionDevice,
+        Device desktopDevice,
+        List<EfDirtRepo.MemberAdoptionReportRepository> suts,
+        List<EfRepo.UserRepository> efUserRepos,
+        List<EfRepo.OrganizationRepository> efOrganizationRepos,
+        List<EfAdminConsoleRepo.OrganizationUserRepository> efOrganizationUserRepos,
+        List<EfRepo.DeviceRepository> efDeviceRepos)
+    {
+        var results = new List<(Guid OrganizationUserId, Guid UserId, MemberAdoptionReportDetail Detail)>();
+
+        foreach (var sut in suts)
+        {
+            var index = suts.IndexOf(sut);
+
+            var (efUser, efOrganization, efOrganizationUser) = await SeedConfirmedMemberAsync(
+                index, user, organization, organizationUser,
+                efUserRepos, efOrganizationRepos, efOrganizationUserRepos);
+
+            // The member's newest activity is on a desktop, not the extension.
+            await SeedDeviceAsync(index, efDeviceRepos, extensionDevice, efUser.Id,
+                DeviceType.ChromeExtension, _olderActivityDate);
+            await SeedDeviceAsync(index, efDeviceRepos, desktopDevice, efUser.Id,
+                DeviceType.MacOsDesktop, _latestActivityDate);
+
+            var details = await sut.GetMemberAdoptionDetailsByOrganizationIdAsync(efOrganization.Id);
+
+            var detail = Assert.Single(details);
+            results.Add((efOrganizationUser.Id, efUser.Id, detail));
+        }
+
+        Assert.NotEmpty(results);
+        foreach (var (organizationUserId, userId, detail) in results)
+        {
+            Assert.Equal(organizationUserId, detail.OrganizationUserId);
+            Assert.Equal(userId, detail.UserId);
+            Assert.Equal(user.Email, detail.Email);
+            Assert.Equal(user.Name, detail.Name);
+            Assert.Equal(_latestActivityDate, detail.LastActivityDate);
+            Assert.True(detail.HasExtensionInstalled);
+            Assert.Equal(0, detail.VaultItemCount);
+            Assert.Equal(0, detail.SharedItemCount);
+            Assert.False(detail.HasRedeemedSponsorship);
+        }
+    }
+
+    [CiSkippedTheory, EfMemberAdoptionReportAutoData]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_ForAllEFProviders_ExcludesMembersWhoAreNotConfirmed(
+        User user,
+        Organization organization,
+        OrganizationUser organizationUser,
+        List<EfDirtRepo.MemberAdoptionReportRepository> suts,
+        List<EfRepo.UserRepository> efUserRepos,
+        List<EfRepo.OrganizationRepository> efOrganizationRepos,
+        List<EfAdminConsoleRepo.OrganizationUserRepository> efOrganizationUserRepos)
+    {
+        var resultSets = new List<IEnumerable<MemberAdoptionReportDetail>>();
+
+        foreach (var sut in suts)
+        {
+            var index = suts.IndexOf(sut);
+
+            var (_, efOrganization, _) = await SeedConfirmedMemberAsync(
+                index, user, organization, organizationUser,
+                efUserRepos, efOrganizationRepos, efOrganizationUserRepos,
+                OrganizationUserStatusType.Accepted);
+
+            resultSets.Add(await sut.GetMemberAdoptionDetailsByOrganizationIdAsync(efOrganization.Id));
+        }
+
+        Assert.NotEmpty(resultSets);
+        Assert.All(resultSets, Assert.Empty);
+    }
+
+    [CiSkippedTheory, EfMemberAdoptionReportAutoData]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_ForAllEFProviders_ReportsNoActivityWhenMemberHasNoDevices(
+        User user,
+        Organization organization,
+        OrganizationUser organizationUser,
+        List<EfDirtRepo.MemberAdoptionReportRepository> suts,
+        List<EfRepo.UserRepository> efUserRepos,
+        List<EfRepo.OrganizationRepository> efOrganizationRepos,
+        List<EfAdminConsoleRepo.OrganizationUserRepository> efOrganizationUserRepos)
+    {
+        var details = new List<MemberAdoptionReportDetail>();
+
+        foreach (var sut in suts)
+        {
+            var index = suts.IndexOf(sut);
+
+            var (_, efOrganization, _) = await SeedConfirmedMemberAsync(
+                index, user, organization, organizationUser,
+                efUserRepos, efOrganizationRepos, efOrganizationUserRepos);
+
+            details.Add(Assert.Single(await sut.GetMemberAdoptionDetailsByOrganizationIdAsync(efOrganization.Id)));
+        }
+
+        Assert.NotEmpty(details);
+        foreach (var detail in details)
+        {
+            Assert.Null(detail.LastActivityDate);
+            Assert.False(detail.HasExtensionInstalled);
+        }
+    }
+
+    [CiSkippedTheory, EfMemberAdoptionReportAutoData]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_ForAllEFProviders_CountsItemsReachableByBothAccessPathsOnce(
+        User memberUser,
+        User memberWithoutAccessUser,
+        Organization organization,
+        Organization sponsoredOrganization,
+        OrganizationUser memberOrganizationUser,
+        OrganizationUser memberWithoutAccessOrganizationUser,
+        Collection sharedCollection,
+        Collection groupOnlyCollection,
+        Collection directOnlyCollection,
+        Group group,
+        Cipher cipherTemplate,
+        OrganizationSponsorship redeemedSponsorship,
+        OrganizationSponsorship offeredSponsorship,
+        List<EfDirtRepo.MemberAdoptionReportRepository> suts,
+        List<EfRepo.UserRepository> efUserRepos,
+        List<EfRepo.OrganizationRepository> efOrganizationRepos,
+        List<EfAdminConsoleRepo.OrganizationUserRepository> efOrganizationUserRepos,
+        List<EfAdminConsoleRepo.CollectionRepository> efCollectionRepos,
+        List<EfAdminConsoleRepo.GroupRepository> efGroupRepos,
+        List<EfVaultRepo.CipherRepository> efCipherRepos,
+        List<EfRepo.CollectionCipherRepository> efCollectionCipherRepos,
+        List<EfRepo.OrganizationSponsorshipRepository> efOrganizationSponsorshipRepos)
+    {
+        var results = new List<(MemberAdoptionReportDetail Member, MemberAdoptionReportDetail MemberWithoutAccess)>();
+
+        foreach (var sut in suts)
+        {
+            var index = suts.IndexOf(sut);
+
+            var (efMemberUser, efOrganization, efMemberOrganizationUser) = await SeedConfirmedMemberAsync(
+                index, memberUser, organization, memberOrganizationUser,
+                efUserRepos, efOrganizationRepos, efOrganizationUserRepos);
+
+            var (_, efMemberWithoutAccessOrganizationUser) = await SeedConfirmedOrganizationUserAsync(
+                index, memberWithoutAccessUser, efOrganization.Id, memberWithoutAccessOrganizationUser,
+                efUserRepos, efOrganizationUserRepos);
+
+            var efSponsoredOrganization = await efOrganizationRepos[index].CreateAsync(sponsoredOrganization);
+            efOrganizationRepos[index].ClearChangeTracking();
+
+            group.OrganizationId = efOrganization.Id;
+            var efGroup = await efGroupRepos[index].CreateAsync(group);
+            efGroupRepos[index].ClearChangeTracking();
+
+            var directAccess = new[] { new CollectionAccessSelection { Id = efMemberOrganizationUser.Id } };
+            var groupAccess = new[] { new CollectionAccessSelection { Id = efGroup.Id } };
+
+            await SeedCollectionAsync(index, efCollectionRepos, sharedCollection, efOrganization.Id,
+                groupAccess, directAccess);
+            await SeedCollectionAsync(index, efCollectionRepos, groupOnlyCollection, efOrganization.Id,
+                groupAccess, users: null);
+            await SeedCollectionAsync(index, efCollectionRepos, directOnlyCollection, efOrganization.Id,
+                groups: null, users: directAccess);
+
+            await efGroupRepos[index].AddGroupUsersByIdAsync(
+                efGroup.Id, new[] { efMemberOrganizationUser.Id }, DateTime.UtcNow);
+            efGroupRepos[index].ClearChangeTracking();
+
+            var cipherReachableByBothPaths = await SeedCipherAsync(
+                index, efCipherRepos, cipherTemplate, userId: null, organizationId: efOrganization.Id);
+            var cipherReachableByGroupAccessOnly = await SeedCipherAsync(
+                index, efCipherRepos, cipherTemplate, userId: null, organizationId: efOrganization.Id);
+            var cipherReachableByDirectAccessOnly = await SeedCipherAsync(
+                index, efCipherRepos, cipherTemplate, userId: null, organizationId: efOrganization.Id);
+            var deletedCipher = await SeedCipherAsync(
+                index, efCipherRepos, cipherTemplate, userId: null, organizationId: efOrganization.Id,
+                deletedDate: _deletionDate);
+
+            await SeedCipherAsync(index, efCipherRepos, cipherTemplate,
+                userId: efMemberUser.Id, organizationId: efOrganization.Id);
+            await SeedCipherAsync(index, efCipherRepos, cipherTemplate,
+                userId: efMemberUser.Id, organizationId: null);
+            await SeedCipherAsync(index, efCipherRepos, cipherTemplate,
+                userId: efMemberUser.Id, organizationId: null, deletedDate: _deletionDate);
+
+            await SeedCollectionCipherAsync(index, efCollectionCipherRepos,
+                sharedCollection.Id, cipherReachableByBothPaths.Id);
+            await SeedCollectionCipherAsync(index, efCollectionCipherRepos,
+                groupOnlyCollection.Id, cipherReachableByBothPaths.Id);
+            await SeedCollectionCipherAsync(index, efCollectionCipherRepos,
+                groupOnlyCollection.Id, cipherReachableByGroupAccessOnly.Id);
+            await SeedCollectionCipherAsync(index, efCollectionCipherRepos,
+                directOnlyCollection.Id, cipherReachableByDirectAccessOnly.Id);
+            await SeedCollectionCipherAsync(index, efCollectionCipherRepos,
+                sharedCollection.Id, deletedCipher.Id);
+
+            await SeedSponsorshipAsync(index, efOrganizationSponsorshipRepos, redeemedSponsorship,
+                efOrganization.Id, efMemberOrganizationUser.Id, efSponsoredOrganization.Id);
+            await SeedSponsorshipAsync(index, efOrganizationSponsorshipRepos, offeredSponsorship,
+                efOrganization.Id, efMemberWithoutAccessOrganizationUser.Id, sponsoredOrganizationId: null);
+
+            var details = (await sut.GetMemberAdoptionDetailsByOrganizationIdAsync(efOrganization.Id)).ToList();
+
+            Assert.Equal(2, details.Count);
+            results.Add((
+                details.Single(detail => detail.OrganizationUserId == efMemberOrganizationUser.Id),
+                details.Single(detail => detail.OrganizationUserId == efMemberWithoutAccessOrganizationUser.Id)));
+        }
+
+        Assert.NotEmpty(results);
+        foreach (var (member, memberWithoutAccess) in results)
+        {
+            Assert.Equal(1, member.VaultItemCount);
+            Assert.Equal(3, member.SharedItemCount);
+            Assert.True(member.HasRedeemedSponsorship);
+
+            Assert.Equal(0, memberWithoutAccess.VaultItemCount);
+            Assert.Equal(0, memberWithoutAccess.SharedItemCount);
+            Assert.False(memberWithoutAccess.HasRedeemedSponsorship);
+        }
+    }
+
+    private static async Task<(User User, Organization Organization, OrganizationUser OrganizationUser)>
+        SeedConfirmedMemberAsync(
+            int index,
+            User user,
+            Organization organization,
+            OrganizationUser organizationUser,
+            List<EfRepo.UserRepository> efUserRepos,
+            List<EfRepo.OrganizationRepository> efOrganizationRepos,
+            List<EfAdminConsoleRepo.OrganizationUserRepository> efOrganizationUserRepos,
+            OrganizationUserStatusType status = OrganizationUserStatusType.Confirmed)
+    {
+        var efOrganization = await efOrganizationRepos[index].CreateAsync(organization);
+        efOrganizationRepos[index].ClearChangeTracking();
+
+        var (efUser, efOrganizationUser) = await SeedConfirmedOrganizationUserAsync(
+            index, user, efOrganization.Id, organizationUser, efUserRepos, efOrganizationUserRepos, status);
+
+        return (efUser, efOrganization, efOrganizationUser);
+    }
+
+    private static async Task<(User User, OrganizationUser OrganizationUser)> SeedConfirmedOrganizationUserAsync(
+        int index,
+        User user,
+        Guid organizationId,
+        OrganizationUser organizationUser,
+        List<EfRepo.UserRepository> efUserRepos,
+        List<EfAdminConsoleRepo.OrganizationUserRepository> efOrganizationUserRepos,
+        OrganizationUserStatusType status = OrganizationUserStatusType.Confirmed)
+    {
+        var efUser = await efUserRepos[index].CreateAsync(user);
+        efUserRepos[index].ClearChangeTracking();
+
+        organizationUser.UserId = efUser.Id;
+        organizationUser.OrganizationId = organizationId;
+        organizationUser.Status = status;
+        var efOrganizationUser = await efOrganizationUserRepos[index].CreateAsync(organizationUser);
+        efOrganizationUserRepos[index].ClearChangeTracking();
+
+        return (efUser, efOrganizationUser);
+    }
+
+    private static async Task SeedDeviceAsync(
+        int index,
+        List<EfRepo.DeviceRepository> efDeviceRepos,
+        Device device,
+        Guid userId,
+        DeviceType type,
+        DateTime lastActivityDate)
+    {
+        device.UserId = userId;
+        device.Type = type;
+        device.LastActivityDate = lastActivityDate;
+        await efDeviceRepos[index].CreateAsync(device);
+        efDeviceRepos[index].ClearChangeTracking();
+    }
+
+    private static async Task SeedCollectionAsync(
+        int index,
+        List<EfAdminConsoleRepo.CollectionRepository> efCollectionRepos,
+        Collection collection,
+        Guid organizationId,
+        IEnumerable<CollectionAccessSelection>? groups,
+        IEnumerable<CollectionAccessSelection>? users)
+    {
+        collection.OrganizationId = organizationId;
+        collection.Type = CollectionType.SharedCollection;
+        collection.DefaultUserCollectionEmail = null;
+        await efCollectionRepos[index].CreateAsync(collection, groups, users);
+        efCollectionRepos[index].ClearChangeTracking();
+    }
+
+    private static async Task<Cipher> SeedCipherAsync(
+        int index,
+        List<EfVaultRepo.CipherRepository> efCipherRepos,
+        Cipher template,
+        Guid? userId,
+        Guid? organizationId,
+        DateTime? deletedDate = null)
+    {
+        var cipher = template.Clone();
+        cipher.UserId = userId;
+        cipher.OrganizationId = organizationId;
+        cipher.DeletedDate = deletedDate;
+
+        var efCipher = await efCipherRepos[index].CreateAsync(cipher);
+        efCipherRepos[index].ClearChangeTracking();
+
+        return efCipher;
+    }
+
+    private static async Task SeedCollectionCipherAsync(
+        int index,
+        List<EfRepo.CollectionCipherRepository> efCollectionCipherRepos,
+        Guid collectionId,
+        Guid cipherId)
+    {
+        await efCollectionCipherRepos[index].CreateAsync(
+            new CollectionCipher { CollectionId = collectionId, CipherId = cipherId });
+        efCollectionCipherRepos[index].ClearChangeTracking();
+    }
+
+    private static async Task SeedSponsorshipAsync(
+        int index,
+        List<EfRepo.OrganizationSponsorshipRepository> efOrganizationSponsorshipRepos,
+        OrganizationSponsorship sponsorship,
+        Guid sponsoringOrganizationId,
+        Guid sponsoringOrganizationUserId,
+        Guid? sponsoredOrganizationId)
+    {
+        sponsorship.SponsoringOrganizationId = sponsoringOrganizationId;
+        sponsorship.SponsoringOrganizationUserId = sponsoringOrganizationUserId;
+        sponsorship.SponsoredOrganizationId = sponsoredOrganizationId;
+        await efOrganizationSponsorshipRepos[index].CreateAsync(sponsorship);
+        efOrganizationSponsorshipRepos[index].ClearChangeTracking();
+    }
+}

--- a/test/Infrastructure.IntegrationTest/Dirt/Repositories/MemberAdoptionReportRepositoryTests.cs
+++ b/test/Infrastructure.IntegrationTest/Dirt/Repositories/MemberAdoptionReportRepositoryTests.cs
@@ -1,0 +1,201 @@
+﻿using Bit.Core.AdminConsole.Entities;
+using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Billing.Enums;
+using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.Repositories;
+using Bit.Core.Entities;
+using Bit.Core.Enums;
+using Bit.Core.Models.Data;
+using Bit.Core.Repositories;
+using Bit.Core.Vault.Entities;
+using Bit.Core.Vault.Enums;
+using Bit.Core.Vault.Repositories;
+using Xunit;
+
+namespace Bit.Infrastructure.IntegrationTest.Dirt.Repositories;
+
+/// <summary>
+/// Runs the member adoption report against every configured database: the Dapper stored procedure on SQL Server and
+/// the LINQ translation on MySQL, PostgreSQL and SQLite.
+/// </summary>
+public class MemberAdoptionReportRepositoryTests
+{
+    private static readonly DateTime _olderActivityDate = new(2026, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _latestActivityDate = new(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+
+    [Theory, DatabaseData]
+    public async Task GetMemberAdoptionDetailsByOrganizationIdAsync_ReportsAdoptionForEveryConfirmedMember(
+        IMemberAdoptionReportRepository sut,
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        ICollectionRepository collectionRepository,
+        IGroupRepository groupRepository,
+        ICipherRepository cipherRepository,
+        ICollectionCipherRepository collectionCipherRepository,
+        IOrganizationSponsorshipRepository organizationSponsorshipRepository,
+        IDeviceRepository deviceRepository)
+    {
+        var organization = await organizationRepository.CreateAsync(BuildOrganization("Reported organization"));
+        var sponsoredOrganization = await organizationRepository.CreateAsync(BuildOrganization("Sponsored organization"));
+
+        var memberUser = await userRepository.CreateAsync(BuildUser("member"));
+        var memberWithoutAccessUser = await userRepository.CreateAsync(BuildUser("no-access"));
+        var invitedUser = await userRepository.CreateAsync(BuildUser("invited"));
+
+        var member = await organizationUserRepository.CreateAsync(
+            BuildOrganizationUser(organization.Id, memberUser.Id, OrganizationUserStatusType.Confirmed));
+        var memberWithoutAccess = await organizationUserRepository.CreateAsync(
+            BuildOrganizationUser(organization.Id, memberWithoutAccessUser.Id, OrganizationUserStatusType.Confirmed));
+        var invited = await organizationUserRepository.CreateAsync(
+            BuildOrganizationUser(organization.Id, invitedUser.Id, OrganizationUserStatusType.Invited));
+
+        // The member's newest activity is on a desktop, not the extension.
+        await deviceRepository.CreateAsync(
+            BuildDevice(memberUser.Id, DeviceType.ChromeExtension, _olderActivityDate));
+        await deviceRepository.CreateAsync(
+            BuildDevice(memberUser.Id, DeviceType.MacOsDesktop, _latestActivityDate));
+        await deviceRepository.CreateAsync(
+            BuildDevice(memberWithoutAccessUser.Id, DeviceType.MacOsDesktop, _olderActivityDate));
+
+        var sharedCollection = await collectionRepository.CreateAsync(
+            BuildCollection(organization.Id, "Direct and group access"));
+        var groupOnlyCollection = await collectionRepository.CreateAsync(
+            BuildCollection(organization.Id, "Group access only"));
+        var directOnlyCollection = await collectionRepository.CreateAsync(
+            BuildCollection(organization.Id, "Direct access only"));
+
+        var group = new Group { OrganizationId = organization.Id, Name = "Engineering" };
+        await groupRepository.CreateAsync(group,
+        [
+            new CollectionAccessSelection { Id = sharedCollection.Id, Manage = true },
+            new CollectionAccessSelection { Id = groupOnlyCollection.Id, Manage = true }
+        ]);
+        await groupRepository.AddGroupUsersByIdAsync(group.Id, [member.Id], DateTime.UtcNow);
+
+        await collectionRepository.UpdateUsersAsync(sharedCollection.Id,
+            [new CollectionAccessSelection { Id = member.Id, Manage = true }]);
+        await collectionRepository.UpdateUsersAsync(directOnlyCollection.Id,
+            [new CollectionAccessSelection { Id = member.Id, Manage = true }]);
+
+        var cipherReachableByBothPaths = await cipherRepository.CreateAsync(
+            BuildCipher(userId: null, organizationId: organization.Id));
+        var cipherReachableByDirectAccessOnly = await cipherRepository.CreateAsync(
+            BuildCipher(userId: null, organizationId: organization.Id));
+        var cipherReachableByGroupAccessOnly = await cipherRepository.CreateAsync(
+            BuildCipher(userId: null, organizationId: organization.Id));
+        var deletedCipher = await cipherRepository.CreateAsync(
+            BuildCipher(userId: null, organizationId: organization.Id, deletedDate: _latestActivityDate));
+
+        await collectionCipherRepository.AddCollectionsForManyCiphersAsync(organization.Id,
+            [cipherReachableByBothPaths.Id], [sharedCollection.Id, groupOnlyCollection.Id]);
+        await collectionCipherRepository.AddCollectionsForManyCiphersAsync(organization.Id,
+            [cipherReachableByDirectAccessOnly.Id], [directOnlyCollection.Id]);
+        await collectionCipherRepository.AddCollectionsForManyCiphersAsync(organization.Id,
+            [cipherReachableByGroupAccessOnly.Id], [groupOnlyCollection.Id]);
+        await collectionCipherRepository.AddCollectionsForManyCiphersAsync(organization.Id,
+            [deletedCipher.Id], [sharedCollection.Id]);
+
+        await cipherRepository.CreateAsync(BuildCipher(memberUser.Id, organizationId: null));
+        await cipherRepository.CreateAsync(
+            BuildCipher(memberUser.Id, organizationId: null, deletedDate: _latestActivityDate));
+        await cipherRepository.CreateAsync(BuildCipher(memberUser.Id, organizationId: organization.Id));
+
+        await organizationSponsorshipRepository.CreateAsync(new OrganizationSponsorship
+        {
+            SponsoringOrganizationId = organization.Id,
+            SponsoringOrganizationUserId = member.Id,
+            SponsoredOrganizationId = sponsoredOrganization.Id,
+            OfferedToEmail = memberUser.Email
+        });
+        await organizationSponsorshipRepository.CreateAsync(new OrganizationSponsorship
+        {
+            SponsoringOrganizationId = organization.Id,
+            SponsoringOrganizationUserId = memberWithoutAccess.Id,
+            SponsoredOrganizationId = null,
+            OfferedToEmail = memberWithoutAccessUser.Email
+        });
+
+        var details = (await sut.GetMemberAdoptionDetailsByOrganizationIdAsync(organization.Id)).ToList();
+
+        Assert.Equal(2, details.Count);
+        Assert.DoesNotContain(details, detail => detail.OrganizationUserId == invited.Id);
+
+        var memberDetail = Single(details, member.Id);
+        Assert.Equal(memberUser.Id, memberDetail.UserId);
+        Assert.Equal(memberUser.Email, memberDetail.Email);
+        Assert.Equal(_latestActivityDate, memberDetail.LastActivityDate);
+        Assert.True(memberDetail.HasExtensionInstalled);
+        Assert.Equal(1, memberDetail.VaultItemCount);
+        Assert.Equal(3, memberDetail.SharedItemCount);
+        Assert.True(memberDetail.HasRedeemedSponsorship);
+
+        var memberWithoutAccessDetail = Single(details, memberWithoutAccess.Id);
+        Assert.Equal(_olderActivityDate, memberWithoutAccessDetail.LastActivityDate);
+        Assert.False(memberWithoutAccessDetail.HasExtensionInstalled);
+        Assert.Equal(0, memberWithoutAccessDetail.VaultItemCount);
+        Assert.Equal(0, memberWithoutAccessDetail.SharedItemCount);
+        Assert.False(memberWithoutAccessDetail.HasRedeemedSponsorship);
+    }
+
+    private static MemberAdoptionReportDetail Single(
+        IEnumerable<MemberAdoptionReportDetail> details, Guid organizationUserId) =>
+        details.Single(detail => detail.OrganizationUserId == organizationUserId);
+
+    private static Organization BuildOrganization(string name) =>
+        new()
+        {
+            Name = name,
+            PlanType = PlanType.EnterpriseAnnually,
+            Plan = "Enterprise",
+            BillingEmail = $"billing+{Guid.NewGuid()}@example.com",
+            UseGroups = true
+        };
+
+    private static User BuildUser(string prefix) =>
+        new()
+        {
+            Name = prefix,
+            Email = $"{prefix}+{Guid.NewGuid()}@example.com",
+            ApiKey = "TEST",
+            SecurityStamp = "stamp"
+        };
+
+    private static OrganizationUser BuildOrganizationUser(
+        Guid organizationId, Guid userId, OrganizationUserStatusType status) =>
+        new()
+        {
+            OrganizationId = organizationId,
+            UserId = userId,
+            Status = status,
+            Type = OrganizationUserType.User
+        };
+
+    private static Device BuildDevice(Guid userId, DeviceType type, DateTime lastActivityDate) =>
+        new()
+        {
+            UserId = userId,
+            Name = type.ToString(),
+            Identifier = Guid.NewGuid().ToString(),
+            Type = type,
+            LastActivityDate = lastActivityDate
+        };
+
+    private static Collection BuildCollection(Guid organizationId, string name) =>
+        new()
+        {
+            OrganizationId = organizationId,
+            Name = name,
+            Type = CollectionType.SharedCollection
+        };
+
+    private static Cipher BuildCipher(Guid? userId, Guid? organizationId, DateTime? deletedDate = null) =>
+        new()
+        {
+            UserId = userId,
+            OrganizationId = organizationId,
+            Type = CipherType.Login,
+            Data = "",
+            DeletedDate = deletedDate
+        };
+}

--- a/util/Migrator/DbScripts/2026-09-05_00_AddMemberAdoptionReportProcedures.sql
+++ b/util/Migrator/DbScripts/2026-09-05_00_AddMemberAdoptionReportProcedures.sql
@@ -1,0 +1,96 @@
+-- Member adoption report: one row per confirmed organization member.
+CREATE OR ALTER PROCEDURE [dbo].[MemberAdoptionReport_ReadByOrganizationId]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    IF @OrganizationId IS NULL
+        THROW 50000, 'OrganizationId cannot be null', 1;
+
+    SELECT
+        OU.[Id] AS [OrganizationUserId],
+        OU.[UserId],
+        U.[Name],
+        ISNULL(ISNULL(U.[Email], OU.[Email]), '') AS [Email],
+        LA.[LastActivityDate],
+        CAST(CASE WHEN EXT.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasExtensionInstalled],
+        ISNULL(VI.[VaultItemCount], 0) AS [VaultItemCount],
+        ISNULL(SI.[SharedItemCount], 0) AS [SharedItemCount],
+        CAST(CASE WHEN SP.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasRedeemedSponsorship]
+    FROM
+        [dbo].[OrganizationUser] OU
+    LEFT JOIN
+        [dbo].[User] U ON U.[Id] = OU.[UserId]
+    OUTER APPLY (
+        SELECT
+            MAX(D.[LastActivityDate]) AS [LastActivityDate]
+        FROM
+            [dbo].[Device] D
+        WHERE
+            D.[UserId] = OU.[UserId]
+    ) LA
+    OUTER APPLY (
+        SELECT TOP 1
+            D.[Id]
+        FROM
+            [dbo].[Device] D
+        WHERE
+            D.[UserId] = OU.[UserId]
+            AND D.[Type] IN (2, 3, 4, 5, 19, 20) -- Chrome, Firefox, Opera, Edge, Vivaldi and Safari browser extensions
+    ) EXT
+    OUTER APPLY (
+        SELECT
+            COUNT(1) AS [VaultItemCount]
+        FROM
+            [dbo].[Cipher] C
+        WHERE
+            C.[UserId] = OU.[UserId]
+            AND C.[OrganizationId] IS NULL
+            AND C.[DeletedDate] IS NULL
+    ) VI
+    OUTER APPLY (
+        SELECT
+            COUNT(DISTINCT CC.[CipherId]) AS [SharedItemCount]
+        FROM
+            [dbo].[CollectionCipher] CC
+        INNER JOIN
+            [dbo].[Collection] COL ON COL.[Id] = CC.[CollectionId]
+                AND COL.[OrganizationId] = @OrganizationId
+        INNER JOIN
+            [dbo].[Cipher] OC ON OC.[Id] = CC.[CipherId]
+                AND OC.[OrganizationId] = @OrganizationId
+                AND OC.[DeletedDate] IS NULL
+        WHERE
+            EXISTS (
+                SELECT 1
+                FROM [dbo].[CollectionUser] CU
+                WHERE CU.[CollectionId] = CC.[CollectionId]
+                    AND CU.[OrganizationUserId] = OU.[Id]
+            )
+            OR EXISTS (
+                SELECT 1
+                FROM [dbo].[CollectionGroup] CG
+                INNER JOIN [dbo].[GroupUser] GU ON GU.[GroupId] = CG.[GroupId]
+                WHERE CG.[CollectionId] = CC.[CollectionId]
+                    AND GU.[OrganizationUserId] = OU.[Id]
+            )
+    ) SI
+    OUTER APPLY (
+        SELECT TOP 1
+            OS.[Id]
+        FROM
+            [dbo].[OrganizationSponsorship] OS
+        WHERE
+            OS.[SponsoringOrganizationUserID] = OU.[Id]
+            AND OS.[SponsoredOrganizationId] IS NOT NULL
+    ) SP
+    WHERE
+        OU.[OrganizationId] = @OrganizationId
+        -- Adoption is only measured for Confirmed members.
+        AND OU.[Status] = 2
+    ORDER BY
+        [Email] ASC,
+        OU.[Id] ASC
+END
+GO

--- a/util/Migrator/DbScripts/2026-09-05_00_AddMemberAdoptionReportProcedures.sql
+++ b/util/Migrator/DbScripts/2026-09-05_00_AddMemberAdoptionReportProcedures.sql
@@ -8,89 +8,133 @@ BEGIN
     IF @OrganizationId IS NULL
         THROW 50000, 'OrganizationId cannot be null', 1;
 
-    SELECT
-        OU.[Id] AS [OrganizationUserId],
-        OU.[UserId],
-        U.[Name],
-        ISNULL(ISNULL(U.[Email], OU.[Email]), '') AS [Email],
-        LA.[LastActivityDate],
-        CAST(CASE WHEN EXT.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasExtensionInstalled],
-        ISNULL(VI.[VaultItemCount], 0) AS [VaultItemCount],
-        ISNULL(SI.[SharedItemCount], 0) AS [SharedItemCount],
-        CAST(CASE WHEN SP.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasRedeemedSponsorship]
-    FROM
-        [dbo].[OrganizationUser] OU
-    LEFT JOIN
-        [dbo].[User] U ON U.[Id] = OU.[UserId]
-    OUTER APPLY (
+    ;WITH [Member] AS (
         SELECT
-            MAX(D.[LastActivityDate]) AS [LastActivityDate]
+            OU.[Id],
+            OU.[UserId],
+            OU.[Email]
         FROM
-            [dbo].[Device] D
+            [dbo].[OrganizationUser] OU
         WHERE
-            D.[UserId] = OU.[UserId]
-    ) LA
-    OUTER APPLY (
-        SELECT TOP 1
-            D.[Id]
-        FROM
-            [dbo].[Device] D
-        WHERE
-            D.[UserId] = OU.[UserId]
-            AND D.[Type] IN (2, 3, 4, 5, 19, 20) -- Chrome, Firefox, Opera, Edge, Vivaldi and Safari browser extensions
-    ) EXT
-    OUTER APPLY (
+            OU.[OrganizationId] = @OrganizationId
+            -- Adoption is only measured for Confirmed members.
+            AND OU.[Status] = 2
+    ),
+    [MemberVaultItem] AS (
         SELECT
+            C.[UserId],
             COUNT(1) AS [VaultItemCount]
         FROM
             [dbo].[Cipher] C
         WHERE
-            C.[UserId] = OU.[UserId]
-            AND C.[OrganizationId] IS NULL
+            C.[OrganizationId] IS NULL
             AND C.[DeletedDate] IS NULL
-    ) VI
+            -- Restricting to this organization's members keeps the aggregate off every other
+            -- account's personal vault. A member with no [UserId] matches nothing, as before.
+            AND EXISTS (SELECT 1 FROM [Member] M WHERE M.[UserId] = C.[UserId])
+        GROUP BY
+            C.[UserId]
+    )
+    SELECT
+        M.[Id] AS [OrganizationUserId],
+        M.[UserId],
+        U.[Name],
+        ISNULL(ISNULL(U.[Email], M.[Email]), '') AS [Email],
+        DEV.[LastActivityDate],
+        CAST(ISNULL(DEV.[HasExtension], 0) AS BIT) AS [HasExtensionInstalled],
+        ISNULL(VI.[VaultItemCount], 0) AS [VaultItemCount],
+        CAST(CASE WHEN SP.[Id] IS NULL THEN 0 ELSE 1 END AS BIT) AS [HasRedeemedSponsorship]
+    FROM
+        [Member] M
+    LEFT JOIN
+        [dbo].[User] U ON U.[Id] = M.[UserId]
     OUTER APPLY (
         SELECT
-            COUNT(DISTINCT CC.[CipherId]) AS [SharedItemCount]
+            MAX(D.[LastActivityDate]) AS [LastActivityDate],
+            -- Chrome, Firefox, Opera, Edge, Vivaldi and Safari browser extensions
+            MAX(CASE WHEN D.[Type] IN (2, 3, 4, 5, 19, 20) THEN 1 ELSE 0 END) AS [HasExtension]
         FROM
-            [dbo].[CollectionCipher] CC
-        INNER JOIN
-            [dbo].[Collection] COL ON COL.[Id] = CC.[CollectionId]
-                AND COL.[OrganizationId] = @OrganizationId
-        INNER JOIN
-            [dbo].[Cipher] OC ON OC.[Id] = CC.[CipherId]
-                AND OC.[OrganizationId] = @OrganizationId
-                AND OC.[DeletedDate] IS NULL
+            [dbo].[Device] D
         WHERE
-            EXISTS (
-                SELECT 1
-                FROM [dbo].[CollectionUser] CU
-                WHERE CU.[CollectionId] = CC.[CollectionId]
-                    AND CU.[OrganizationUserId] = OU.[Id]
-            )
-            OR EXISTS (
-                SELECT 1
-                FROM [dbo].[CollectionGroup] CG
-                INNER JOIN [dbo].[GroupUser] GU ON GU.[GroupId] = CG.[GroupId]
-                WHERE CG.[CollectionId] = CC.[CollectionId]
-                    AND GU.[OrganizationUserId] = OU.[Id]
-            )
-    ) SI
+            D.[UserId] = M.[UserId]
+    ) DEV
+    LEFT JOIN
+        [MemberVaultItem] VI ON VI.[UserId] = M.[UserId]
     OUTER APPLY (
         SELECT TOP 1
             OS.[Id]
         FROM
             [dbo].[OrganizationSponsorship] OS
         WHERE
-            OS.[SponsoringOrganizationUserID] = OU.[Id]
+            OS.[SponsoringOrganizationUserID] = M.[Id]
             AND OS.[SponsoredOrganizationId] IS NOT NULL
     ) SP
-    WHERE
-        OU.[OrganizationId] = @OrganizationId
-        -- Adoption is only measured for Confirmed members.
-        AND OU.[Status] = 2
     ORDER BY
         [Email] ASC,
-        OU.[Id] ASC
+        M.[Id] ASC
+    -- The remaining per-member OUTER APPLYs make this CPU-bound rather than I/O-bound, and its
+    -- parallel plan scales negatively: it burns more CPU across workers than it saves in elapsed time.
+    OPTION (MAXDOP 1)
+END
+GO
+
+-- Member adoption report: the member/collection and collection/cipher edges the report aggregates.
+CREATE OR ALTER PROCEDURE [dbo].[MemberAdoptionReport_ReadAccessGraphByOrganizationId]
+    @OrganizationId UNIQUEIDENTIFIER
+AS
+BEGIN
+    SET NOCOUNT ON
+
+    IF @OrganizationId IS NULL
+        THROW 50000, 'OrganizationId cannot be null', 1;
+
+    -- Result set 1: which members can reach which collections, directly or through a group.
+    -- UNION rather than UNION ALL because a member can hold both kinds of access to one collection.
+    WITH [OrganizationCollection] AS (
+        SELECT
+            COL.[Id]
+        FROM
+            [dbo].[Collection] COL
+        WHERE
+            COL.[OrganizationId] = @OrganizationId
+    )
+    SELECT
+        CU.[OrganizationUserId],
+        CU.[CollectionId]
+    FROM
+        [dbo].[CollectionUser] CU
+    INNER JOIN
+        [OrganizationCollection] COL ON COL.[Id] = CU.[CollectionId]
+    UNION
+    SELECT
+        GU.[OrganizationUserId],
+        CG.[CollectionId]
+    FROM
+        [dbo].[CollectionGroup] CG
+    INNER JOIN
+        [OrganizationCollection] COL ON COL.[Id] = CG.[CollectionId]
+    INNER JOIN
+        [dbo].[GroupUser] GU ON GU.[GroupId] = CG.[GroupId]
+
+    -- Result set 2: which collections hold which items.
+    ;WITH [OrganizationCollection] AS (
+        SELECT
+            COL.[Id]
+        FROM
+            [dbo].[Collection] COL
+        WHERE
+            COL.[OrganizationId] = @OrganizationId
+    )
+    SELECT
+        CC.[CollectionId],
+        CC.[CipherId]
+    FROM
+        [dbo].[CollectionCipher] CC
+    INNER JOIN
+        [OrganizationCollection] COL ON COL.[Id] = CC.[CollectionId]
+    INNER JOIN
+        [dbo].[Cipher] C ON C.[Id] = CC.[CipherId]
+            AND C.[OrganizationId] = @OrganizationId
+            AND C.[DeletedDate] IS NULL
 END
 GO


### PR DESCRIPTION
## 🎟️ Tracking

PM-35924

## 📔 Objective

Adds the data access for the member adoption report: one row per confirmed organization member with login recency, browser extension use, vault item count, reachable shared item count, and sponsorship redemption.

- Ships a Dapper stored procedure and a hand written EF LINQ translation. The EF path is deliberately not a `FromSqlRaw`/`EXEC` passthrough, which is what makes the sibling Risk Insights and Member Access reports MSSQL only.
- `SharedItemCount` counts organization ciphers reachable **directly** via `CollectionUser` **and** through a group via `GroupUser`/`CollectionGroup`. Both de-duplication steps are load bearing: the union collapses a collection reachable by both paths, and the separate distinct collapses a cipher sitting in more than one reachable collection. Dropping either inflates the count.
- Only `OrganizationUser.Status = 2` is counted. Invited and Accepted members are deliberately excluded.
- `MemberAdoptionReportRepositorySqliteTests` runs against a real in-memory SQLite context with no configuration, so it executes on every PR. The sibling `[CiSkippedTheory]` harness never runs in CI.

Middle of a 3 PR stack, on `device-index`. `endpoint` sits on this.

## 📸 Screenshots

No user-visible change.
