### PR TITLE
Add the member adoption report endpoint

### DIFF
--- a/src/Api/Dirt/Controllers/ReportsController.cs
+++ b/src/Api/Dirt/Controllers/ReportsController.cs
@@ -1,4 +1,5 @@
-﻿using Bit.Api.Dirt.Models;
+﻿using Bit.Api.AdminConsole.Authorization.Requirements;
+using Bit.Api.Dirt.Models;
 using Bit.Api.Dirt.Models.Response;
 using Bit.Api.Tools.Models.Response;
 using Bit.Core;
@@ -11,6 +12,7 @@ using Bit.Core.Dirt.Reports.ReportFeatures.OrganizationReportMembers.Interfaces;
 using Bit.Core.Dirt.Reports.ReportFeatures.Requests;
 using Bit.Core.Exceptions;
 using Bit.Core.Utilities;
+using Bit.OrganizationAuthorization;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -22,6 +24,7 @@ public class ReportsController : Controller
 {
     private readonly ICurrentContext _currentContext;
     private readonly IMemberAccessReportQuery _memberAccessReportQuery;
+    private readonly IMemberAdoptionReportQuery _memberAdoptionReportQuery;
     private readonly IRiskInsightsReportQuery _riskInsightsReportQuery;
     private readonly IAddPasswordHealthReportApplicationCommand _addPwdHealthReportAppCommand;
     private readonly IGetPasswordHealthReportApplicationQuery _getPwdHealthReportAppQuery;
@@ -33,6 +36,7 @@ public class ReportsController : Controller
     public ReportsController(
         ICurrentContext currentContext,
         IMemberAccessReportQuery memberAccessReportQuery,
+        IMemberAdoptionReportQuery memberAdoptionReportQuery,
         IRiskInsightsReportQuery riskInsightsReportQuery,
         IAddPasswordHealthReportApplicationCommand addPasswordHealthReportApplicationCommand,
         IGetPasswordHealthReportApplicationQuery getPasswordHealthReportApplicationQuery,
@@ -44,6 +48,7 @@ public class ReportsController : Controller
     {
         _currentContext = currentContext;
         _memberAccessReportQuery = memberAccessReportQuery;
+        _memberAdoptionReportQuery = memberAdoptionReportQuery;
         _riskInsightsReportQuery = riskInsightsReportQuery;
         _addPwdHealthReportAppCommand = addPasswordHealthReportApplicationCommand;
         _getPwdHealthReportAppQuery = getPasswordHealthReportApplicationQuery;
@@ -100,6 +105,25 @@ public class ReportsController : Controller
         var responses = accessDetails.Select(x => new MemberAccessDetailReportResponseModel(x));
 
         return responses;
+    }
+
+    /// <summary>
+    /// Adoption metrics for an organization's members: recent activity, browser extension installs,
+    /// vault and shared item counts, and redeemed Families sponsorships.
+    /// </summary>
+    /// <param name="organizationId">Organization Id</param>
+    /// <returns>A MemberAdoptionReportResponseModel holding organization-wide counts and every member row</returns>
+    [HttpGet("member-adoption/{organizationId:guid}")]
+    [Authorize<AccessReportsRequirement>]
+    [Bitwarden.Server.Sdk.Features.RequireFeature(FeatureFlagKeys.MemberAdoptionReport)]
+    public async Task<ActionResult<MemberAdoptionReportResponseModel>> GetMemberAdoptionReportAsync([FromRoute] Guid organizationId)
+    {
+        await AuthorizePlanAsync(organizationId);
+
+        var result = await _memberAdoptionReportQuery.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        return new MemberAdoptionReportResponseModel(result);
     }
 
     /// <summary>
@@ -198,6 +222,11 @@ public class ReportsController : Controller
             throw new NotFoundException();
         }
 
+        await AuthorizePlanAsync(organizationId);
+    }
+
+    private async Task AuthorizePlanAsync(Guid organizationId)
+    {
         var orgAbility = await _organizationAbilityCacheService.GetOrganizationAbilityAsync(organizationId);
         if (orgAbility is null || !orgAbility.UseRiskInsights)
         {

--- a/src/Api/Dirt/Models/Response/MemberAdoptionReportResponseModel.cs
+++ b/src/Api/Dirt/Models/Response/MemberAdoptionReportResponseModel.cs
@@ -1,0 +1,45 @@
+﻿using Bit.Core.Dirt.Reports.Models.Data;
+
+namespace Bit.Api.Dirt.Models.Response;
+
+public class MemberAdoptionReportResponseModel
+{
+    public int TotalMemberCount { get; set; }
+    public int ActiveMemberCount { get; set; }
+    public int InactiveMemberCount { get; set; }
+    public int SponsoredFamiliesRedeemedCount { get; set; }
+    public IEnumerable<MemberAdoptionReportMemberResponseModel> Members { get; set; } = [];
+
+    public MemberAdoptionReportResponseModel(MemberAdoptionReportResult result)
+    {
+        TotalMemberCount = result.TotalMemberCount;
+        ActiveMemberCount = result.ActiveMemberCount;
+        InactiveMemberCount = result.InactiveMemberCount;
+        SponsoredFamiliesRedeemedCount = result.SponsoredFamiliesRedeemedCount;
+        Members = result.Members.Select(member => new MemberAdoptionReportMemberResponseModel(member));
+    }
+}
+
+public class MemberAdoptionReportMemberResponseModel
+{
+    public Guid OrganizationUserId { get; set; }
+    public Guid? UserId { get; set; }
+    public string? Name { get; set; }
+    public string Email { get; set; }
+    public bool HasRecentLogin { get; set; }
+    public bool HasExtensionInstalled { get; set; }
+    public int VaultItemCount { get; set; }
+    public int SharedItemCount { get; set; }
+
+    public MemberAdoptionReportMemberResponseModel(MemberAdoptionReportMember member)
+    {
+        OrganizationUserId = member.OrganizationUserId;
+        UserId = member.UserId;
+        Name = member.Name;
+        Email = member.Email;
+        HasRecentLogin = member.HasRecentLogin;
+        HasExtensionInstalled = member.HasExtensionInstalled;
+        VaultItemCount = member.VaultItemCount;
+        SharedItemCount = member.SharedItemCount;
+    }
+}

--- a/src/Core/Constants.cs
+++ b/src/Core/Constants.cs
@@ -304,6 +304,7 @@ public static partial class FeatureFlagKeys
     public const string EventManagementForGenericHec = "event-management-for-generic-hec";
     public const string BrowserExtensionHealthReport = "pm-35928-premium-user-health-reports";
     public const string OrganizationEventCleanup = "pm-33527-organization-event-cleanup";
+    public const string MemberAdoptionReport = "pm-35924-member-adoption-report";
 
     /* UIF Team */
     public const string RouterFocusManagement = "router-focus-management";

--- a/src/Core/Dirt/Models/Data/MemberAdoptionReportResult.cs
+++ b/src/Core/Dirt/Models/Data/MemberAdoptionReportResult.cs
@@ -1,0 +1,22 @@
+﻿namespace Bit.Core.Dirt.Reports.Models.Data;
+
+public class MemberAdoptionReportResult
+{
+    public int TotalMemberCount { get; set; }
+    public int ActiveMemberCount { get; set; }
+    public int InactiveMemberCount { get; set; }
+    public int SponsoredFamiliesRedeemedCount { get; set; }
+    public IEnumerable<MemberAdoptionReportMember> Members { get; set; } = [];
+}
+
+public class MemberAdoptionReportMember
+{
+    public Guid OrganizationUserId { get; set; }
+    public Guid? UserId { get; set; }
+    public string? Name { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public bool HasRecentLogin { get; set; }
+    public bool HasExtensionInstalled { get; set; }
+    public int VaultItemCount { get; set; }
+    public int SharedItemCount { get; set; }
+}

--- a/src/Core/Dirt/Reports/ReportFeatures/MemberAdoptionReportQuery.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/MemberAdoptionReportQuery.cs
@@ -1,0 +1,55 @@
+﻿using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.ReportFeatures.OrganizationReportMembers.Interfaces;
+using Bit.Core.Dirt.Reports.ReportFeatures.Requests;
+using Bit.Core.Dirt.Reports.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace Bit.Core.Dirt.Reports.ReportFeatures;
+
+public class MemberAdoptionReportQuery(
+    IMemberAdoptionReportRepository memberAdoptionReportRepository,
+    TimeProvider timeProvider,
+    ILogger<MemberAdoptionReportQuery> logger) : IMemberAdoptionReportQuery
+{
+    private const int ActivityWindowDays = 30;
+
+    public async Task<MemberAdoptionReportResult> GetMemberAdoptionReportAsync(MemberAdoptionReportRequest request)
+    {
+        var details = (await memberAdoptionReportRepository
+            .GetMemberAdoptionDetailsByOrganizationIdAsync(request.OrganizationId)).ToList();
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var activityCutoff = now.AddDays(-ActivityWindowDays);
+
+        var members = details
+            .Select(detail => new MemberAdoptionReportMember
+            {
+                OrganizationUserId = detail.OrganizationUserId,
+                UserId = detail.UserId,
+                Name = detail.Name,
+                Email = detail.Email,
+                HasRecentLogin = detail.LastActivityDate is { } lastActivityDate
+                                 && lastActivityDate >= activityCutoff
+                                 && lastActivityDate <= now,
+                HasExtensionInstalled = detail.HasExtensionInstalled,
+                VaultItemCount = detail.VaultItemCount,
+                SharedItemCount = detail.SharedItemCount
+            })
+            .ToList();
+
+        var activeMemberCount = members.Count(member => member.HasRecentLogin);
+
+        logger.LogInformation(Constants.BypassFiltersEventId,
+            "Completed MemberAdoptionReport generation for OrganizationId: {OrganizationId}. {MemberCount} members, {ActiveMemberCount} active",
+            request.OrganizationId, members.Count, activeMemberCount);
+
+        return new MemberAdoptionReportResult
+        {
+            TotalMemberCount = members.Count,
+            ActiveMemberCount = activeMemberCount,
+            InactiveMemberCount = members.Count - activeMemberCount,
+            SponsoredFamiliesRedeemedCount = details.Count(detail => detail.HasRedeemedSponsorship),
+            Members = members
+        };
+    }
+}

--- a/src/Core/Dirt/Reports/ReportFeatures/MemberAdoptionReportQuery.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/MemberAdoptionReportQuery.cs
@@ -15,41 +15,59 @@ public class MemberAdoptionReportQuery(
 
     public async Task<MemberAdoptionReportResult> GetMemberAdoptionReportAsync(MemberAdoptionReportRequest request)
     {
-        var details = (await memberAdoptionReportRepository
-            .GetMemberAdoptionDetailsByOrganizationIdAsync(request.OrganizationId)).ToList();
+        var details = await memberAdoptionReportRepository
+            .GetMemberAdoptionDetailsByOrganizationIdAsync(request.OrganizationId);
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
         var activityCutoff = now.AddDays(-ActivityWindowDays);
 
-        var members = details
-            .Select(detail => new MemberAdoptionReportMember
+        var totalMemberCount = 0;
+        var activeMemberCount = 0;
+        var sponsoredFamiliesRedeemedCount = 0;
+
+        foreach (var detail in details)
+        {
+            totalMemberCount++;
+
+            if (HasRecentLogin(detail, activityCutoff, now))
+            {
+                activeMemberCount++;
+            }
+
+            if (detail.HasRedeemedSponsorship)
+            {
+                sponsoredFamiliesRedeemedCount++;
+            }
+        }
+
+        logger.LogInformation(Constants.BypassFiltersEventId,
+            "Completed MemberAdoptionReport generation for OrganizationId: {OrganizationId}. {MemberCount} members, {ActiveMemberCount} active",
+            request.OrganizationId, totalMemberCount, activeMemberCount);
+
+        return new MemberAdoptionReportResult
+        {
+            TotalMemberCount = totalMemberCount,
+            ActiveMemberCount = activeMemberCount,
+            InactiveMemberCount = totalMemberCount - activeMemberCount,
+            SponsoredFamiliesRedeemedCount = sponsoredFamiliesRedeemedCount,
+            // Deferred: the response model projects straight to its own model as it writes, so the
+            // members are never all live at once.
+            Members = details.Select(detail => new MemberAdoptionReportMember
             {
                 OrganizationUserId = detail.OrganizationUserId,
                 UserId = detail.UserId,
                 Name = detail.Name,
                 Email = detail.Email,
-                HasRecentLogin = detail.LastActivityDate is { } lastActivityDate
-                                 && lastActivityDate >= activityCutoff
-                                 && lastActivityDate <= now,
+                HasRecentLogin = HasRecentLogin(detail, activityCutoff, now),
                 HasExtensionInstalled = detail.HasExtensionInstalled,
                 VaultItemCount = detail.VaultItemCount,
                 SharedItemCount = detail.SharedItemCount
             })
-            .ToList();
-
-        var activeMemberCount = members.Count(member => member.HasRecentLogin);
-
-        logger.LogInformation(Constants.BypassFiltersEventId,
-            "Completed MemberAdoptionReport generation for OrganizationId: {OrganizationId}. {MemberCount} members, {ActiveMemberCount} active",
-            request.OrganizationId, members.Count, activeMemberCount);
-
-        return new MemberAdoptionReportResult
-        {
-            TotalMemberCount = members.Count,
-            ActiveMemberCount = activeMemberCount,
-            InactiveMemberCount = members.Count - activeMemberCount,
-            SponsoredFamiliesRedeemedCount = details.Count(detail => detail.HasRedeemedSponsorship),
-            Members = members
         };
     }
+
+    private static bool HasRecentLogin(MemberAdoptionReportDetail detail, DateTime activityCutoff, DateTime now) =>
+        detail.LastActivityDate is { } lastActivityDate
+        && lastActivityDate >= activityCutoff
+        && lastActivityDate <= now;
 }

--- a/src/Core/Dirt/Reports/ReportFeatures/OrganizationReportMembers/Interfaces/IMemberAdoptionReportQuery.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/OrganizationReportMembers/Interfaces/IMemberAdoptionReportQuery.cs
@@ -1,0 +1,9 @@
+﻿using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.ReportFeatures.Requests;
+
+namespace Bit.Core.Dirt.Reports.ReportFeatures.OrganizationReportMembers.Interfaces;
+
+public interface IMemberAdoptionReportQuery
+{
+    Task<MemberAdoptionReportResult> GetMemberAdoptionReportAsync(MemberAdoptionReportRequest request);
+}

--- a/src/Core/Dirt/Reports/ReportFeatures/ReportingServiceCollectionExtensions.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/ReportingServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ public static class ReportingServiceCollectionExtensions
 
         services.AddScoped<IRiskInsightsReportQuery, RiskInsightsReportQuery>();
         services.AddScoped<IMemberAccessReportQuery, MemberAccessReportQuery>();
+        services.AddScoped<IMemberAdoptionReportQuery, MemberAdoptionReportQuery>();
         services.AddScoped<IAddPasswordHealthReportApplicationCommand, AddPasswordHealthReportApplicationCommand>();
         services.AddScoped<IGetPasswordHealthReportApplicationQuery, GetPasswordHealthReportApplicationQuery>();
         services.AddScoped<IDropPasswordHealthReportApplicationCommand, DropPasswordHealthReportApplicationCommand>();

--- a/src/Core/Dirt/Reports/ReportFeatures/Requests/MemberAdoptionReportRequest.cs
+++ b/src/Core/Dirt/Reports/ReportFeatures/Requests/MemberAdoptionReportRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace Bit.Core.Dirt.Reports.ReportFeatures.Requests;
+
+public class MemberAdoptionReportRequest
+{
+    public Guid OrganizationId { get; set; }
+}

--- a/test/Api.Test/Dirt/ReportsControllerTests.cs
+++ b/test/Api.Test/Dirt/ReportsControllerTests.cs
@@ -1,6 +1,8 @@
 ﻿using AutoFixture;
+using Bit.Api.AdminConsole.Authorization.Requirements;
 using Bit.Api.Dirt.Controllers;
 using Bit.Api.Dirt.Models;
+using Bit.Api.Dirt.Models.Response;
 using Bit.Core.AdminConsole.AbilitiesCache;
 using Bit.Core.Context;
 using Bit.Core.Dirt.Reports.Models.Data;
@@ -9,6 +11,7 @@ using Bit.Core.Dirt.Reports.ReportFeatures.OrganizationReportMembers.Interfaces;
 using Bit.Core.Dirt.Reports.ReportFeatures.Requests;
 using Bit.Core.Exceptions;
 using Bit.Core.Models.Data.Organizations;
+using Bit.OrganizationAuthorization;
 using Bit.Test.Common.AutoFixture;
 using Bit.Test.Common.AutoFixture.Attributes;
 using NSubstitute;
@@ -101,6 +104,154 @@ public class ReportsControllerTests
         await sutProvider.GetDependency<IRiskInsightsReportQuery>()
             .DidNotReceive()
             .GetRiskInsightsReportDetails(Arg.Any<RiskInsightsReportRequest>());
+    }
+
+    // GetMemberAdoptionReport
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_ReturnsCountsAndMembers(
+        SutProvider<ReportsController> sutProvider,
+        Guid organizationId,
+        Guid organizationUserId,
+        Guid userId)
+    {
+        // Arrange
+        SetupAuthorization(sutProvider);
+
+        var report = new MemberAdoptionReportResult
+        {
+            TotalMemberCount = 3,
+            ActiveMemberCount = 2,
+            InactiveMemberCount = 1,
+            SponsoredFamiliesRedeemedCount = 1,
+            Members =
+            [
+                new MemberAdoptionReportMember
+                {
+                    OrganizationUserId = organizationUserId,
+                    UserId = userId,
+                    Name = "Test User",
+                    Email = "user@example.com",
+                    HasRecentLogin = true,
+                    HasExtensionInstalled = true,
+                    VaultItemCount = 12,
+                    SharedItemCount = 3
+                }
+            ]
+        };
+        sutProvider.GetDependency<IMemberAdoptionReportQuery>()
+            .GetMemberAdoptionReportAsync(Arg.Is<MemberAdoptionReportRequest>(r => r.OrganizationId == organizationId))
+            .Returns(report);
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(organizationId);
+
+        // Assert
+        var response = Assert.IsType<MemberAdoptionReportResponseModel>(result.Value);
+        Assert.Equal(3, response.TotalMemberCount);
+        Assert.Equal(2, response.ActiveMemberCount);
+        Assert.Equal(1, response.InactiveMemberCount);
+        Assert.Equal(1, response.SponsoredFamiliesRedeemedCount);
+
+        var member = Assert.Single(response.Members);
+        Assert.Equal(organizationUserId, member.OrganizationUserId);
+        Assert.Equal(userId, member.UserId);
+        Assert.Equal("Test User", member.Name);
+        Assert.Equal("user@example.com", member.Email);
+        Assert.True(member.HasRecentLogin);
+        Assert.True(member.HasExtensionInstalled);
+        Assert.Equal(12, member.VaultItemCount);
+        Assert.Equal(3, member.SharedItemCount);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_PassesRouteOrganizationIdToQuery(
+        SutProvider<ReportsController> sutProvider,
+        Guid organizationId)
+    {
+        // Arrange
+        SetupAuthorization(sutProvider);
+
+        sutProvider.GetDependency<IMemberAdoptionReportQuery>()
+            .GetMemberAdoptionReportAsync(Arg.Any<MemberAdoptionReportRequest>())
+            .Returns(new MemberAdoptionReportResult());
+
+        // Act
+        await sutProvider.Sut.GetMemberAdoptionReportAsync(organizationId);
+
+        // Assert
+        await sutProvider.GetDependency<IMemberAdoptionReportQuery>()
+            .Received(1)
+            .GetMemberAdoptionReportAsync(Arg.Is<MemberAdoptionReportRequest>(r => r.OrganizationId == organizationId));
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_OrganizationWithNoMembers_ReturnsEmptyReport(
+        SutProvider<ReportsController> sutProvider,
+        Guid organizationId)
+    {
+        // Arrange
+        SetupAuthorization(sutProvider);
+
+        sutProvider.GetDependency<IMemberAdoptionReportQuery>()
+            .GetMemberAdoptionReportAsync(Arg.Any<MemberAdoptionReportRequest>())
+            .Returns(new MemberAdoptionReportResult());
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(organizationId);
+
+        // Assert
+        var response = Assert.IsType<MemberAdoptionReportResponseModel>(result.Value);
+        Assert.Equal(0, response.TotalMemberCount);
+        Assert.Equal(0, response.ActiveMemberCount);
+        Assert.Equal(0, response.InactiveMemberCount);
+        Assert.Equal(0, response.SponsoredFamiliesRedeemedCount);
+        Assert.Empty(response.Members);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_withoutUseRiskInsights_throwsBadRequest(
+        SutProvider<ReportsController> sutProvider,
+        Guid organizationId)
+    {
+        // Arrange
+        SetupAuthorization(sutProvider, useRiskInsights: false);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.GetMemberAdoptionReportAsync(organizationId));
+
+        await sutProvider.GetDependency<IMemberAdoptionReportQuery>()
+            .DidNotReceive()
+            .GetMemberAdoptionReportAsync(Arg.Any<MemberAdoptionReportRequest>());
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_withoutOrganizationAbility_throwsBadRequest(
+        SutProvider<ReportsController> sutProvider,
+        Guid organizationId)
+    {
+        // Arrange
+        SetupMissingOrganizationAbility(sutProvider);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<BadRequestException>(() =>
+            sutProvider.Sut.GetMemberAdoptionReportAsync(organizationId));
+
+        await sutProvider.GetDependency<IMemberAdoptionReportQuery>()
+            .DidNotReceive()
+            .GetMemberAdoptionReportAsync(Arg.Any<MemberAdoptionReportRequest>());
+    }
+
+    [Fact]
+    public void GetMemberAdoptionReportAsync_RequiresAccessReportsAuthorization()
+    {
+        var action = typeof(ReportsController)
+            .GetMethod(nameof(ReportsController.GetMemberAdoptionReportAsync))!;
+
+        Assert.Contains(
+            action.GetCustomAttributes(inherit: true),
+            attribute => attribute is AuthorizeAttribute<AccessReportsRequirement>);
     }
 
     // GetPasswordHealthReportApplications

--- a/test/Core.Test/Dirt/ReportFeatures/MemberAdoptionReportQueryTests.cs
+++ b/test/Core.Test/Dirt/ReportFeatures/MemberAdoptionReportQueryTests.cs
@@ -1,0 +1,288 @@
+﻿using Bit.Core.Dirt.Reports.Models.Data;
+using Bit.Core.Dirt.Reports.ReportFeatures;
+using Bit.Core.Dirt.Reports.ReportFeatures.Requests;
+using Bit.Core.Dirt.Reports.Repositories;
+using Bit.Test.Common.AutoFixture;
+using Bit.Test.Common.AutoFixture.Attributes;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Bit.Core.Test.Dirt.ReportFeatures;
+
+[SutProviderCustomize]
+public class MemberAdoptionReportQueryTests
+{
+    private const int ActivityWindowDays = 30;
+
+    private static readonly DateTime _now = new(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    private static SutProvider<MemberAdoptionReportQuery> GetSutProvider()
+    {
+        var sutProvider = new SutProvider<MemberAdoptionReportQuery>()
+            .WithFakeTimeProvider()
+            .Create();
+
+        sutProvider.GetDependency<FakeTimeProvider>().SetUtcNow(_now);
+
+        return sutProvider;
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_ActivityExactlyOnWindowBoundary_CountsMemberAsActive(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId,
+            CreateDetail(lastActivityDate: _now.AddDays(-ActivityWindowDays)));
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(1, result.ActiveMemberCount);
+        Assert.Equal(0, result.InactiveMemberCount);
+        Assert.True(Assert.Single(result.Members).HasRecentLogin);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_ActivityJustInsideWindow_CountsMemberAsActive(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId,
+            CreateDetail(lastActivityDate: _now.AddDays(-ActivityWindowDays).AddTicks(1)));
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(1, result.TotalMemberCount);
+        Assert.Equal(1, result.ActiveMemberCount);
+        Assert.Equal(0, result.InactiveMemberCount);
+        Assert.True(Assert.Single(result.Members).HasRecentLogin);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_ActivityJustOutsideWindow_CountsMemberAsInactive(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId,
+            CreateDetail(lastActivityDate: _now.AddDays(-ActivityWindowDays).AddTicks(-1)));
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(1, result.TotalMemberCount);
+        Assert.Equal(0, result.ActiveMemberCount);
+        Assert.Equal(1, result.InactiveMemberCount);
+        Assert.False(Assert.Single(result.Members).HasRecentLogin);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_ActivityExactlyNow_CountsMemberAsActive(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId, CreateDetail(lastActivityDate: _now));
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(1, result.ActiveMemberCount);
+        Assert.True(Assert.Single(result.Members).HasRecentLogin);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_FutureDatedActivity_CountsMemberAsInactive(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId,
+            CreateDetail(lastActivityDate: _now.AddTicks(1)),
+            CreateDetail(lastActivityDate: _now.AddYears(1)));
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(2, result.TotalMemberCount);
+        Assert.Equal(0, result.ActiveMemberCount);
+        Assert.Equal(2, result.InactiveMemberCount);
+        Assert.All(result.Members, member => Assert.False(member.HasRecentLogin));
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_NullLastActivityDate_CountsMemberAsInactive(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId, CreateDetail(lastActivityDate: null));
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(1, result.TotalMemberCount);
+        Assert.Equal(0, result.ActiveMemberCount);
+        Assert.Equal(1, result.InactiveMemberCount);
+        Assert.False(Assert.Single(result.Members).HasRecentLogin);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_OrganizationWithNoMembers_ReturnsZeroedCounts(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId);
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(0, result.TotalMemberCount);
+        Assert.Equal(0, result.ActiveMemberCount);
+        Assert.Equal(0, result.InactiveMemberCount);
+        Assert.Equal(0, result.SponsoredFamiliesRedeemedCount);
+        Assert.Empty(result.Members);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_CountsRedeemedSponsorshipsIndependentlyOfActivity(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId,
+            CreateDetail(lastActivityDate: _now, hasRedeemedSponsorship: true),
+            CreateDetail(lastActivityDate: null, hasRedeemedSponsorship: true),
+            CreateDetail(lastActivityDate: _now, hasRedeemedSponsorship: false));
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(2, result.SponsoredFamiliesRedeemedCount);
+        Assert.Equal(3, result.TotalMemberCount);
+        Assert.Equal(2, result.ActiveMemberCount);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_ActiveAndInactiveCounts_SumToTotal(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId,
+            CreateDetail(lastActivityDate: _now),
+            CreateDetail(lastActivityDate: _now.AddDays(-1)),
+            CreateDetail(lastActivityDate: _now.AddDays(-ActivityWindowDays * 2)),
+            CreateDetail(lastActivityDate: null));
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        Assert.Equal(4, result.TotalMemberCount);
+        Assert.Equal(2, result.ActiveMemberCount);
+        Assert.Equal(2, result.InactiveMemberCount);
+        Assert.Equal(result.TotalMemberCount, result.ActiveMemberCount + result.InactiveMemberCount);
+        Assert.Equal(result.TotalMemberCount, result.Members.Count());
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_ProjectsMemberDetailsOntoResult(
+        Guid organizationId,
+        Guid organizationUserId,
+        Guid userId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        var detail = new MemberAdoptionReportDetail
+        {
+            OrganizationUserId = organizationUserId,
+            UserId = userId,
+            Name = "Test User",
+            Email = "user@example.com",
+            LastActivityDate = _now.AddDays(-1),
+            HasExtensionInstalled = true,
+            VaultItemCount = 12,
+            SharedItemCount = 3,
+            HasRedeemedSponsorship = true
+        };
+        SetupDetails(sutProvider, organizationId, detail);
+
+        // Act
+        var result = await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        var member = Assert.Single(result.Members);
+        Assert.Equal(organizationUserId, member.OrganizationUserId);
+        Assert.Equal(userId, member.UserId);
+        Assert.Equal("Test User", member.Name);
+        Assert.Equal("user@example.com", member.Email);
+        Assert.True(member.HasRecentLogin);
+        Assert.True(member.HasExtensionInstalled);
+        Assert.Equal(12, member.VaultItemCount);
+        Assert.Equal(3, member.SharedItemCount);
+    }
+
+    [Theory, BitAutoData]
+    public async Task GetMemberAdoptionReportAsync_QueriesRepositoryWithRequestedOrganization(
+        Guid organizationId)
+    {
+        // Arrange
+        var sutProvider = GetSutProvider();
+        SetupDetails(sutProvider, organizationId);
+
+        // Act
+        await sutProvider.Sut.GetMemberAdoptionReportAsync(
+            new MemberAdoptionReportRequest { OrganizationId = organizationId });
+
+        // Assert
+        await sutProvider.GetDependency<IMemberAdoptionReportRepository>()
+            .Received(1)
+            .GetMemberAdoptionDetailsByOrganizationIdAsync(organizationId);
+    }
+
+    private static MemberAdoptionReportDetail CreateDetail(
+        DateTime? lastActivityDate,
+        bool hasRedeemedSponsorship = false) =>
+        new()
+        {
+            OrganizationUserId = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            Name = "Test User",
+            Email = "user@example.com",
+            LastActivityDate = lastActivityDate,
+            HasRedeemedSponsorship = hasRedeemedSponsorship
+        };
+
+    private static void SetupDetails(
+        SutProvider<MemberAdoptionReportQuery> sutProvider,
+        Guid organizationId,
+        params MemberAdoptionReportDetail[] details) =>
+        sutProvider.GetDependency<IMemberAdoptionReportRepository>()
+            .GetMemberAdoptionDetailsByOrganizationIdAsync(organizationId)
+            .Returns(details);
+}


### PR DESCRIPTION
## 🎟️ Tracking

PM-35924

## 📔 Objective

Adds `GET /reports/member-adoption/{organizationId}`, returning per-member adoption detail plus organization level counts.

- Authorized with `[Authorize<AccessReportsRequirement>]` rather than the imperative `ICurrentContext.AccessReports` check the sibling actions use. Same principals (Owner, Admin, Custom with `accessReports`, provider users), but it returns 403 where the neighbours return 404.
- `organizationId` is bound `[FromRoute]`. Without it, MVC's Form-then-Route value provider order lets a form body shadow the route value, so the action could act on a different organization than the one authorized.
- Gated on `UseRiskInsights`, matching the other org scoped actions on this controller.
- `HasRecentLogin` uses an injected `TimeProvider` and a 30 day window, bounded at both ends so a client with a skewed clock cannot sit permanently active.
- Counts are derived from one materialized list, so `Total`, `Active` and `Inactive` cannot disagree with the member list.

Top of a 3 PR stack, on `data-access`.

## 📸 Screenshots

No user-visible change.
