### PR TITLE
feat(saml): SimpleSaml local assertion encryption

### DIFF
--- a/AppHost/BuilderExtensions.cs
+++ b/AppHost/BuilderExtensions.cs
@@ -123,12 +123,6 @@ public static class BuilderExtensions
         if (!int.TryParse(builder.Required("Idp:Port"), out var port))
             throw new InvalidOperationException("Invalid value for Idp:Port.");
 
-        // Docker Compose solves this prerequisite with an ephemeral container.
-        // AppHost can copy the file directly; permissions are correct for the container.
-        var samlRemotePath = Path.Combine(builder.Required("WorkingDirectory"), "saml20-sp-remote.php");
-        if (!File.Exists(samlRemotePath))
-            File.Copy($"{samlRemotePath}.example", samlRemotePath);
-
         // This is hardcoded to localhost because the browser needs to navigate to the published SSO address,
         // not the internal Aspire endpoint reference (aspire.dev.internal). The port is still detected dynamically.
         var ssoBaseUrl = $"http://localhost:{builder.GetBitwardenServicePort("sso")}/saml2";
@@ -144,7 +138,8 @@ public static class BuilderExtensions
                 ReferenceExpression.Create($"{ssoBaseUrl}/{orgId.Resource}/Acs"))
             .WithBindMount($"{builder.Required("WorkingDirectory")}/authsources.php",
                 "/var/www/simplesamlphp/config/authsources.php")
-            .WithBindMount(samlRemotePath, "/var/www/simplesamlphp/config/saml20-sp-remote.php")
+            .WithBindMount($"{builder.Required("WorkingDirectory")}/saml20-sp-remote.php",
+                "/var/www/simplesamlphp/metadata/saml20-sp-remote.php")
             .WithExplicitStart();
     }
 

--- a/AppHost/BuilderExtensions.cs
+++ b/AppHost/BuilderExtensions.cs
@@ -123,6 +123,12 @@ public static class BuilderExtensions
         if (!int.TryParse(builder.Required("Idp:Port"), out var port))
             throw new InvalidOperationException("Invalid value for Idp:Port.");
 
+        // Docker Compose solves this prerequisite with an ephemeral container.
+        // AppHost can copy the file directly; permissions are correct for the container.
+        var samlRemotePath = Path.Combine(builder.Required("WorkingDirectory"), "saml20-sp-remote.php");
+        if (!File.Exists(samlRemotePath))
+            File.Copy($"{samlRemotePath}.example", samlRemotePath);
+
         // This is hardcoded to localhost because the browser needs to navigate to the published SSO address,
         // not the internal Aspire endpoint reference (aspire.dev.internal). The port is still detected dynamically.
         var ssoBaseUrl = $"http://localhost:{builder.GetBitwardenServicePort("sso")}/saml2";
@@ -138,6 +144,7 @@ public static class BuilderExtensions
                 ReferenceExpression.Create($"{ssoBaseUrl}/{orgId.Resource}/Acs"))
             .WithBindMount($"{builder.Required("WorkingDirectory")}/authsources.php",
                 "/var/www/simplesamlphp/config/authsources.php")
+            .WithBindMount(samlRemotePath, "/var/www/simplesamlphp/config/saml20-sp-remote.php")
             .WithExplicitStart();
     }
 

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -5,6 +5,7 @@ secrets.json
 # Docker container configurations
 .env
 authsources.php
+saml20-sp-remote.php
 
 # Development certificates
 identity_server_dev.crt

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -86,6 +86,14 @@ services:
       - mariadb
       - ef
 
+  idp-init:
+    image: kenchan0130/simplesamlphp:1.19.8
+    volumes:
+      - ./:/workdir
+    command: sh -c '[ -f /workdir/saml20-sp-remote.php ] || cp /workdir/saml20-sp-remote.php.example /workdir/saml20-sp-remote.php'
+    profiles:
+      - idp
+
   idp:
     image: kenchan0130/simplesamlphp:1.19.8
     ports:
@@ -94,6 +102,9 @@ services:
       SIMPLESAMLPHP_SP_ENTITY_ID: ${IDP_SP_ENTITY_ID}
       SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: ${IDP_SP_ACS_URL}
       SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: null
+    depends_on:
+      idp-init:
+        condition: service_completed_successfully
     volumes:
       - ./authsources.php:/var/www/simplesamlphp/config/authsources.php
       - ./saml20-sp-remote.php:/var/www/simplesamlphp/metadata/saml20-sp-remote.php

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -96,6 +96,7 @@ services:
       SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: null
     volumes:
       - ./authsources.php:/var/www/simplesamlphp/config/authsources.php
+      - ./saml20-sp-remote.php:/var/www/simplesamlphp/metadata/saml20-sp-remote.php
     profiles:
       - idp
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -86,14 +86,6 @@ services:
       - mariadb
       - ef
 
-  idp-init:
-    image: kenchan0130/simplesamlphp:1.19.8
-    volumes:
-      - ./:/workdir
-    command: sh -c '[ -f /workdir/saml20-sp-remote.php ] || cp /workdir/saml20-sp-remote.php.example /workdir/saml20-sp-remote.php'
-    profiles:
-      - idp
-
   idp:
     image: kenchan0130/simplesamlphp:1.19.8
     ports:
@@ -102,9 +94,6 @@ services:
       SIMPLESAMLPHP_SP_ENTITY_ID: ${IDP_SP_ENTITY_ID}
       SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE: ${IDP_SP_ACS_URL}
       SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE: null
-    depends_on:
-      idp-init:
-        condition: service_completed_successfully
     volumes:
       - ./authsources.php:/var/www/simplesamlphp/config/authsources.php
       - ./saml20-sp-remote.php:/var/www/simplesamlphp/metadata/saml20-sp-remote.php

--- a/dev/saml20-sp-remote.php.example
+++ b/dev/saml20-sp-remote.php.example
@@ -1,0 +1,29 @@
+<?php
+/**
+ * SAML 2.0 remote SP metadata for SimpleSAMLphp.
+ *
+ * Assertion encryption will default to FALSE. Change assertion.encryption to TRUE
+ * and paste your certifiacate data to 'certData' below to enable.
+ *
+ * Copy this file to saml20-sp-remote.php to enable encrypted assertions on the local IdP.
+ * The image's built-in template has no certData, so the IdP has no key to encrypt to without this override.
+ *
+ * Get certData with:
+ *   openssl x509 -in dev/identity_server_dev.crt -outform der | base64 | tr -d '\n'
+ *
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-sp-remote
+ */
+
+if (!getenv('SIMPLESAMLPHP_SP_ENTITY_ID')) {
+    throw new UnexpectedValueException('SIMPLESAMLPHP_SP_ENTITY_ID is not defined as an environment variable.');
+}
+if (!getenv('SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE')) {
+    throw new UnexpectedValueException('SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE is not defined as an environment variable.');
+}
+
+$metadata[getenv('SIMPLESAMLPHP_SP_ENTITY_ID')] = array(
+    'AssertionConsumerService' => getenv('SIMPLESAMLPHP_SP_ASSERTION_CONSUMER_SERVICE'),
+    'SingleLogoutService' => getenv('SIMPLESAMLPHP_SP_SINGLE_LOGOUT_SERVICE'),
+    'assertion.encryption' => FALSE,
+    'certData' => 'PASTE_BASE64_DER_CERTIFICATE_HERE',
+);

--- a/dev/saml20-sp-remote.php.example
+++ b/dev/saml20-sp-remote.php.example
@@ -5,9 +5,6 @@
  * Assertion encryption will default to FALSE. Change assertion.encryption to TRUE
  * and paste your certificate data to 'certData' below to enable.
  *
- * Docker-compose idp-init runs before idp stands up. It copies this file to saml20-sp-remote.php to
- * enable encrypted assertion configuration for the local IdP.
- *
  * Get certData with:
  *   openssl x509 -in dev/identity_server_dev.crt -outform der | base64 | tr -d '\n'
  *

--- a/dev/saml20-sp-remote.php.example
+++ b/dev/saml20-sp-remote.php.example
@@ -3,10 +3,10 @@
  * SAML 2.0 remote SP metadata for SimpleSAMLphp.
  *
  * Assertion encryption will default to FALSE. Change assertion.encryption to TRUE
- * and paste your certifiacate data to 'certData' below to enable.
+ * and paste your certificate data to 'certData' below to enable.
  *
- * Copy this file to saml20-sp-remote.php to enable encrypted assertions on the local IdP.
- * The image's built-in template has no certData, so the IdP has no key to encrypt to without this override.
+ * Docker-compose idp-init runs before idp stands up. It copies this file to saml20-sp-remote.php to
+ * enable encrypted assertion configuration for the local IdP.
  *
  * Get certData with:
  *   openssl x509 -in dev/identity_server_dev.crt -outform der | base64 | tr -d '\n'


### PR DESCRIPTION
## 🎟️ Tracking

[PM-43087](https://bitwarden.atlassian.net/browse/PM-43087)

## 📔 Objective

- Adds the ability to configure SAML2.0 assertion encryption for the local SimpleSaml testing IdP in a standardized way, following the auth sources pattern.
- Gitignores the resultant `saml20-sp-remote.php` file for local configuration.

Verified via docker compose and Aspire Apphost.

:octocat: [Contributing docs related PR](https://github.com/bitwarden/contributing-docs/pull/858)


[PM-43087]: https://bitwarden.atlassian.net/browse/PM-43087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ