### PR TITLE
QA-2360: Add organization cipher seeder scenes for remaining item types

### DIFF
--- a/util/Seeder/Scenes/OrganizationBankAccountCipherScene.cs
+++ b/util/Seeder/Scenes/OrganizationBankAccountCipherScene.cs
@@ -1,0 +1,88 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Repositories;
+using Bit.Core.Vault.Enums;
+using Bit.Core.Vault.Repositories;
+using Bit.Seeder.Factories;
+using Bit.Seeder.Models;
+using Bit.Seeder.Services;
+
+namespace Bit.Seeder.Scenes;
+
+public class OrganizationBankAccountCipherScene(
+    IOrganizationRepository organizationRepository,
+    ICipherRepository cipherRepository,
+    IManglerService manglerService)
+    : IScene<OrganizationBankAccountCipherScene.Request, OrganizationBankAccountCipherScene.Result>
+{
+    public class Request
+    {
+        [Required]
+        public required Guid OrganizationId { get; set; }
+        [Required]
+        public required string OrganizationKeyB64 { get; set; }
+        [Required]
+        public required IEnumerable<Guid> CollectionIds { get; set; }
+        [Required]
+        public required string Name { get; set; }
+        public string? BankName { get; set; }
+        public string? NameOnAccount { get; set; }
+        public string? AccountType { get; set; }
+        public string? AccountNumber { get; set; }
+        public string? RoutingNumber { get; set; }
+        public string? BranchNumber { get; set; }
+        public string? Pin { get; set; }
+        public string? SwiftCode { get; set; }
+        public string? Iban { get; set; }
+        public string? BankContactPhone { get; set; }
+        public string? Notes { get; set; }
+        public bool Reprompt { get; set; }
+    }
+
+    public class Result
+    {
+        public required Guid CipherId { get; init; }
+    }
+
+    public async Task<SceneResult<Result>> SeedAsync(Request request)
+    {
+        var organization = await organizationRepository.GetByIdAsync(request.OrganizationId);
+        if (organization == null)
+        {
+            throw new InvalidOperationException($"Organization {request.OrganizationId} not found.");
+        }
+
+        var bankAccount = new BankAccountViewDto
+        {
+            BankName = request.BankName,
+            NameOnAccount = request.NameOnAccount,
+            AccountType = request.AccountType,
+            AccountNumber = request.AccountNumber,
+            RoutingNumber = request.RoutingNumber,
+            BranchNumber = request.BranchNumber,
+            Pin = request.Pin,
+            SwiftCode = request.SwiftCode,
+            Iban = request.Iban,
+            BankContactPhone = request.BankContactPhone
+        };
+        var cipher = BankAccountCipherSeeder.Create(new CipherSeed
+        {
+            Type = CipherType.BankAccount,
+            Name = request.Name,
+            Notes = request.Notes,
+            Reprompt = request.Reprompt ? CipherRepromptType.Password : CipherRepromptType.None,
+            EncryptionKey = request.OrganizationKeyB64,
+            OrganizationId = request.OrganizationId,
+            UserId = null,
+            BankAccount = bankAccount
+        });
+
+        await cipherRepository.CreateAsync(cipher, request.CollectionIds);
+
+        return new SceneResult<Result>(
+            result: new Result
+            {
+                CipherId = cipher.Id
+            },
+            mangleMap: manglerService.GetMangleMap());
+    }
+}

--- a/util/Seeder/Scenes/OrganizationDriversLicenseCipherScene.cs
+++ b/util/Seeder/Scenes/OrganizationDriversLicenseCipherScene.cs
@@ -1,0 +1,90 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Repositories;
+using Bit.Core.Vault.Enums;
+using Bit.Core.Vault.Repositories;
+using Bit.Seeder.Factories;
+using Bit.Seeder.Models;
+using Bit.Seeder.Services;
+
+namespace Bit.Seeder.Scenes;
+
+public class OrganizationDriversLicenseCipherScene(
+    IOrganizationRepository organizationRepository,
+    ICipherRepository cipherRepository,
+    IManglerService manglerService)
+    : IScene<OrganizationDriversLicenseCipherScene.Request, OrganizationDriversLicenseCipherScene.Result>
+{
+    public class Request
+    {
+        [Required]
+        public required Guid OrganizationId { get; set; }
+        [Required]
+        public required string OrganizationKeyB64 { get; set; }
+        [Required]
+        public required IEnumerable<Guid> CollectionIds { get; set; }
+        [Required]
+        public required string Name { get; set; }
+        public string? FirstName { get; set; }
+        public string? MiddleName { get; set; }
+        public string? LastName { get; set; }
+        public string? DateOfBirth { get; set; }
+        public string? LicenseNumber { get; set; }
+        public string? IssuingCountry { get; set; }
+        public string? IssuingState { get; set; }
+        public string? IssueDate { get; set; }
+        public string? IssuingAuthority { get; set; }
+        public string? ExpirationDate { get; set; }
+        public string? LicenseClass { get; set; }
+        public string? Notes { get; set; }
+        public bool Reprompt { get; set; }
+    }
+
+    public class Result
+    {
+        public required Guid CipherId { get; init; }
+    }
+
+    public async Task<SceneResult<Result>> SeedAsync(Request request)
+    {
+        var organization = await organizationRepository.GetByIdAsync(request.OrganizationId);
+        if (organization == null)
+        {
+            throw new InvalidOperationException($"Organization {request.OrganizationId} not found.");
+        }
+
+        var driversLicense = new DriversLicenseViewDto
+        {
+            FirstName = request.FirstName,
+            MiddleName = request.MiddleName,
+            LastName = request.LastName,
+            DateOfBirth = request.DateOfBirth,
+            LicenseNumber = request.LicenseNumber,
+            IssuingCountry = request.IssuingCountry,
+            IssuingState = request.IssuingState,
+            IssueDate = request.IssueDate,
+            IssuingAuthority = request.IssuingAuthority,
+            ExpirationDate = request.ExpirationDate,
+            LicenseClass = request.LicenseClass
+        };
+        var cipher = DriversLicenseCipherSeeder.Create(new CipherSeed
+        {
+            Type = CipherType.DriversLicense,
+            Name = request.Name,
+            Notes = request.Notes,
+            Reprompt = request.Reprompt ? CipherRepromptType.Password : CipherRepromptType.None,
+            EncryptionKey = request.OrganizationKeyB64,
+            OrganizationId = request.OrganizationId,
+            UserId = null,
+            DriversLicense = driversLicense
+        });
+
+        await cipherRepository.CreateAsync(cipher, request.CollectionIds);
+
+        return new SceneResult<Result>(
+            result: new Result
+            {
+                CipherId = cipher.Id
+            },
+            mangleMap: manglerService.GetMangleMap());
+    }
+}

--- a/util/Seeder/Scenes/OrganizationIdentityCipherScene.cs
+++ b/util/Seeder/Scenes/OrganizationIdentityCipherScene.cs
@@ -1,0 +1,104 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Repositories;
+using Bit.Core.Vault.Enums;
+using Bit.Core.Vault.Repositories;
+using Bit.Seeder.Factories;
+using Bit.Seeder.Models;
+using Bit.Seeder.Services;
+
+namespace Bit.Seeder.Scenes;
+
+public class OrganizationIdentityCipherScene(
+    IOrganizationRepository organizationRepository,
+    ICipherRepository cipherRepository,
+    IManglerService manglerService)
+    : IScene<OrganizationIdentityCipherScene.Request, OrganizationIdentityCipherScene.Result>
+{
+    public class Request
+    {
+        [Required]
+        public required Guid OrganizationId { get; set; }
+        [Required]
+        public required string OrganizationKeyB64 { get; set; }
+        [Required]
+        public required IEnumerable<Guid> CollectionIds { get; set; }
+        [Required]
+        public required string Name { get; set; }
+        public string? Title { get; set; }
+        public string? FirstName { get; set; }
+        public string? MiddleName { get; set; }
+        public string? LastName { get; set; }
+        public string? Username { get; set; }
+        public string? Company { get; set; }
+        public string? SSN { get; set; }
+        public string? PassportNumber { get; set; }
+        public string? LicenseNumber { get; set; }
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+        public string? Address1 { get; set; }
+        public string? Address2 { get; set; }
+        public string? Address3 { get; set; }
+        public string? City { get; set; }
+        public string? State { get; set; }
+        public string? PostalCode { get; set; }
+        public string? Country { get; set; }
+        public string? Notes { get; set; }
+        public bool Reprompt { get; set; }
+    }
+
+    public class Result
+    {
+        public required Guid CipherId { get; init; }
+    }
+
+    public async Task<SceneResult<Result>> SeedAsync(Request request)
+    {
+        var organization = await organizationRepository.GetByIdAsync(request.OrganizationId);
+        if (organization == null)
+        {
+            throw new InvalidOperationException($"Organization {request.OrganizationId} not found.");
+        }
+
+        var identity = new IdentityViewDto
+        {
+            Title = request.Title,
+            FirstName = request.FirstName,
+            MiddleName = request.MiddleName,
+            LastName = request.LastName,
+            Username = request.Username,
+            Company = request.Company,
+            SSN = request.SSN,
+            PassportNumber = request.PassportNumber,
+            LicenseNumber = request.LicenseNumber,
+            Email = request.Email,
+            Phone = request.Phone,
+            Address1 = request.Address1,
+            Address2 = request.Address2,
+            Address3 = request.Address3,
+            City = request.City,
+            State = request.State,
+            PostalCode = request.PostalCode,
+            Country = request.Country,
+        };
+        var cipher = IdentityCipherSeeder.Create(new CipherSeed
+        {
+            Type = CipherType.Identity,
+            Name = request.Name,
+            Notes = request.Notes,
+            Reprompt = request.Reprompt ? CipherRepromptType.Password : CipherRepromptType.None,
+            EncryptionKey = request.OrganizationKeyB64,
+            OrganizationId = request.OrganizationId,
+            UserId = null,
+            Identity = identity
+        });
+
+        await cipherRepository.CreateAsync(cipher, request.CollectionIds);
+
+        return new SceneResult<Result>(
+            result: new Result
+            {
+                CipherId = cipher.Id
+            },
+            mangleMap: manglerService.GetMangleMap());
+    }
+}

--- a/util/Seeder/Scenes/OrganizationPassportCipherScene.cs
+++ b/util/Seeder/Scenes/OrganizationPassportCipherScene.cs
@@ -1,0 +1,94 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Repositories;
+using Bit.Core.Vault.Enums;
+using Bit.Core.Vault.Repositories;
+using Bit.Seeder.Factories;
+using Bit.Seeder.Models;
+using Bit.Seeder.Services;
+
+namespace Bit.Seeder.Scenes;
+
+public class OrganizationPassportCipherScene(
+    IOrganizationRepository organizationRepository,
+    ICipherRepository cipherRepository,
+    IManglerService manglerService)
+    : IScene<OrganizationPassportCipherScene.Request, OrganizationPassportCipherScene.Result>
+{
+    public class Request
+    {
+        [Required]
+        public required Guid OrganizationId { get; set; }
+        [Required]
+        public required string OrganizationKeyB64 { get; set; }
+        [Required]
+        public required IEnumerable<Guid> CollectionIds { get; set; }
+        [Required]
+        public required string Name { get; set; }
+        public string? Surname { get; set; }
+        public string? GivenName { get; set; }
+        public string? DateOfBirth { get; set; }
+        public string? Sex { get; set; }
+        public string? BirthPlace { get; set; }
+        public string? Nationality { get; set; }
+        public string? PassportNumber { get; set; }
+        public string? PassportType { get; set; }
+        public string? IssuingCountry { get; set; }
+        public string? IssuingAuthority { get; set; }
+        public string? IssueDate { get; set; }
+        public string? ExpirationDate { get; set; }
+        public string? NationalIdentificationNumber { get; set; }
+        public string? Notes { get; set; }
+        public bool Reprompt { get; set; }
+    }
+
+    public class Result
+    {
+        public required Guid CipherId { get; init; }
+    }
+
+    public async Task<SceneResult<Result>> SeedAsync(Request request)
+    {
+        var organization = await organizationRepository.GetByIdAsync(request.OrganizationId);
+        if (organization == null)
+        {
+            throw new InvalidOperationException($"Organization {request.OrganizationId} not found.");
+        }
+
+        var passport = new PassportViewDto
+        {
+            Surname = request.Surname,
+            GivenName = request.GivenName,
+            DateOfBirth = request.DateOfBirth,
+            Sex = request.Sex,
+            BirthPlace = request.BirthPlace,
+            Nationality = request.Nationality,
+            PassportNumber = request.PassportNumber,
+            PassportType = request.PassportType,
+            IssuingCountry = request.IssuingCountry,
+            IssuingAuthority = request.IssuingAuthority,
+            IssueDate = request.IssueDate,
+            ExpirationDate = request.ExpirationDate,
+            NationalIdentificationNumber = request.NationalIdentificationNumber
+        };
+        var cipher = PassportCipherSeeder.Create(new CipherSeed
+        {
+            Type = CipherType.Passport,
+            Name = request.Name,
+            Notes = request.Notes,
+            Reprompt = request.Reprompt ? CipherRepromptType.Password : CipherRepromptType.None,
+            EncryptionKey = request.OrganizationKeyB64,
+            OrganizationId = request.OrganizationId,
+            UserId = null,
+            Passport = passport
+        });
+
+        await cipherRepository.CreateAsync(cipher, request.CollectionIds);
+
+        return new SceneResult<Result>(
+            result: new Result
+            {
+                CipherId = cipher.Id
+            },
+            mangleMap: manglerService.GetMangleMap());
+    }
+}

--- a/util/Seeder/Scenes/OrganizationSecureNoteCipherScene.cs
+++ b/util/Seeder/Scenes/OrganizationSecureNoteCipherScene.cs
@@ -1,0 +1,64 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Bit.Core.Repositories;
+using Bit.Core.Vault.Enums;
+using Bit.Core.Vault.Repositories;
+using Bit.Seeder.Factories;
+using Bit.Seeder.Models;
+using Bit.Seeder.Services;
+
+namespace Bit.Seeder.Scenes;
+
+public class OrganizationSecureNoteCipherScene(
+    IOrganizationRepository organizationRepository,
+    ICipherRepository cipherRepository,
+    IManglerService manglerService)
+    : IScene<OrganizationSecureNoteCipherScene.Request, OrganizationSecureNoteCipherScene.Result>
+{
+    public class Request
+    {
+        [Required]
+        public required Guid OrganizationId { get; set; }
+        [Required]
+        public required string OrganizationKeyB64 { get; set; }
+        [Required]
+        public required IEnumerable<Guid> CollectionIds { get; set; }
+        [Required]
+        public required string Name { get; set; }
+        public string? Notes { get; set; }
+        public bool Reprompt { get; set; }
+    }
+
+    public class Result
+    {
+        public required Guid CipherId { get; init; }
+    }
+
+    public async Task<SceneResult<Result>> SeedAsync(Request request)
+    {
+        var organization = await organizationRepository.GetByIdAsync(request.OrganizationId);
+        if (organization == null)
+        {
+            throw new InvalidOperationException($"Organization {request.OrganizationId} not found.");
+        }
+
+        var cipher = SecureNoteCipherSeeder.Create(new CipherSeed
+        {
+            Type = CipherType.SecureNote,
+            Name = request.Name,
+            Notes = request.Notes,
+            Reprompt = request.Reprompt ? CipherRepromptType.Password : CipherRepromptType.None,
+            EncryptionKey = request.OrganizationKeyB64,
+            OrganizationId = request.OrganizationId,
+            UserId = null
+        });
+
+        await cipherRepository.CreateAsync(cipher, request.CollectionIds);
+
+        return new SceneResult<Result>(
+            result: new Result
+            {
+                CipherId = cipher.Id
+            },
+            mangleMap: manglerService.GetMangleMap());
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/QA-2360

## 📔 Objective
Adds the remaining organization-owned cipher seeder scenes so the seeder can create org ciphers of every item type (login + card already existed):
- `OrganizationSecureNoteCipherScene`
- `OrganizationIdentityCipherScene`
- `OrganizationPassportCipherScene`
- `OrganizationDriversLicenseCipherScene`
- `OrganizationBankAccountCipherScene`

Each mirrors the existing `OrganizationCardCipherScene` (#8294): resolve the org, build the type's view DTO, seed via the matching `{Type}CipherSeeder` with the org key and `UserId` null, and persist to the requested collections. Type-specific fields come from the corresponding `User{Type}CipherScene`.

Per direction from Ned/Andrew these are per-type scenes following the card example; a later refactor may consolidate them into a single parameterized `OrganizationItemTypeCipherScene`.

No new tests — cipher-seeder coverage already exists in `RustSdkCipherTests` (per the #8294 review, which removed a redundant per-factory test).

## 📸 Screenshots
N/A — seeder/back-end only, no UI.