### PR TITLE
[DBOPS-231] Rewrite SecurityTask_ReadByUserIdStatus to remove OPTION (RECOMPILE)

### DIFF
--- a/src/Sql/dbo/Vault/Tables/SecurityTask.sql
+++ b/src/Sql/dbo/Vault/Tables/SecurityTask.sql
@@ -17,8 +17,13 @@ CREATE NONCLUSTERED INDEX [IX_SecurityTask_CipherId]
     ON [dbo].[SecurityTask]([CipherId] ASC) WHERE CipherId IS NOT NULL;
 
 GO
+-- Covers SecurityTask_ReadByUserIdStatus: that procedure reads tasks by organization and returns
+-- every column, so without the INCLUDE list each row costs a lookup into the clustered index.
+-- The previous WHERE OrganizationId IS NOT NULL filter was redundant on a NOT NULL column, and the
+-- EF model has always declared this index unfiltered, so dropping it also aligns the two tracks.
 CREATE NONCLUSTERED INDEX [IX_SecurityTask_OrganizationId]
-    ON [dbo].[SecurityTask]([OrganizationId] ASC) WHERE OrganizationId IS NOT NULL;
+    ON [dbo].[SecurityTask]([OrganizationId] ASC)
+    INCLUDE ([Status], [CipherId], [Type], [CreationDate], [RevisionDate]);
 
 GO
 

--- a/util/Migrator/DbScripts/2026-09-14_00_SecurityTaskReadByUserIdStatusRemoveRecompile.sql
+++ b/util/Migrator/DbScripts/2026-09-14_00_SecurityTaskReadByUserIdStatusRemoveRecompile.sql
@@ -1,4 +1,53 @@
-CREATE PROCEDURE [dbo].[SecurityTask_ReadByUserIdStatus]
+-- DBOPS-231: remove OPTION (RECOMPILE) from SecurityTask_ReadByUserIdStatus, and give the procedure
+-- a covering index to read from.
+--
+-- The hint was added in PM-21044 (2025-09-12) because the previous body's cost depended on the
+-- caller's organization size, so a single cached plan could not serve every caller. Compiling on
+-- every execution is expensive in CPU, and each compile also takes schema-stability locks across
+-- the referential-integrity closure of the tables in the query, which puts this procedure in the
+-- way of schema changes on those tables.
+--
+-- The new body removes the reason the plan had to vary rather than just dropping the hint: every
+-- step is driven by a small staged set, and the set that decides the plan shape is held in a #temp
+-- table so the optimizer costs it from real statistics rather than from whichever caller compiled
+-- first (see the comments on steps 2 and 3b). Parameters, the projected columns and their order,
+-- and the result ordering are unchanged; result equivalence against the previous body was verified
+-- on a restore of production.
+--
+-- The index rebuild is independent of that and simply removes a lookup per row: the procedure reads
+-- tasks by organization and returns all seven columns. It is a DROP_EXISTING rebuild of an index
+-- that already exists on a table of roughly 17,600 rows, so it is not a large index build. The
+-- previous filter was redundant on a NOT NULL column and the EF model never declared it.
+
+-- Rebuild first, so the procedure below compiles against the covering index.
+--
+-- Two branches because DROP_EXISTING is not a no-op when the index is missing: it fails outright with
+-- Msg 7999, "Could not find any index named ...". In practice the index has existed since
+-- 2024-11-21_00_SecurityTaskReadByUserIdStatus.sql, so the ELSE branch is defence-in-depth for a
+-- database where it was dropped by hand. Both branches must produce the same definition -- keep them
+-- in sync if this is ever edited. Deliberately not DROP INDEX + CREATE INDEX, which would leave a
+-- window with no index on the table.
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE [object_id] = OBJECT_ID('[dbo].[SecurityTask]')
+        AND [name] = 'IX_SecurityTask_OrganizationId'
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_SecurityTask_OrganizationId]
+        ON [dbo].[SecurityTask] ([OrganizationId] ASC)
+        INCLUDE ([Status], [CipherId], [Type], [CreationDate], [RevisionDate])
+        WITH (DROP_EXISTING = ON);
+END
+ELSE
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_SecurityTask_OrganizationId]
+        ON [dbo].[SecurityTask] ([OrganizationId] ASC)
+        INCLUDE ([Status], [CipherId], [Type], [CreationDate], [RevisionDate]);
+END
+GO
+
+CREATE OR ALTER PROCEDURE [dbo].[SecurityTask_ReadByUserIdStatus]
     @UserId [UNIQUEIDENTIFIER],   -- who is asking
     @Status [TINYINT] = NULL      -- 0 = Pending, 1 = Completed, NULL = don't filter
 AS
@@ -181,3 +230,4 @@ BEGIN
     ORDER BY
         [ST].[CreationDate] DESC;
 END
+GO


### PR DESCRIPTION
## 🎟️ Tracking

[DBOPS-231](https://bitwarden.atlassian.net/browse/DBOPS-231)

## 📔 Objective

`SecurityTask_ReadByUserIdStatus` carries `OPTION (RECOMPILE)`, added in PM-21044 (#5779) alongside the four-CTE body it still has today. The hint makes the procedure compile on every execution, and for this procedure compilation is the dominant cost — it outweighs actual execution by well over an order of magnitude. Each compile also takes schema-stability locks across the referential-integrity closure of the tables in the query, which puts a very frequently called read in the way of schema changes on those tables.

Deleting the hint on its own is not equivalent. The current body's cost depends on the caller's organization size, so with a cached plan whichever caller compiles first imposes their shape on everyone else; removing only the hint measurably regressed some callers under test.

This PR removes the reason the plan had to vary:

1. Stage the caller's confirmed memberships in enabled organizations in a table variable — always a small set, whoever is asking.
2. Stage the collections they can edit (granted directly or through a group), but only when those organizations have any tasks at all.
3. If that set is empty, route to a separate trivial statement and return — this also keeps such callers from caching a plan for the query in step 4.
4. Otherwise, one `EXISTS` probe per task against the small staged set.

Because every step is driven by a small staged set, a single cached plan is correct for all callers and the hint is no longer needed. The body is heavily commented: each step explains what it does and why it is shaped that way, including why the empty-set routing exists and why the `UNION` is load-bearing.

**Unchanged:** parameters, the seven projected columns and their order, and the result ordering (`CreationDate DESC`). No repository, EF Core or `_V2` change is required — this is a backwards-compatible stored-procedure modification.

**Validation:** result equivalence was verified against the current body on a restore of production, comparing full result sets in both directions. The test population was built to exercise every access shape on purpose — heavy direct members, group-only members, read-only members, members with no access at all, disabled organizations, invited/accepted/revoked memberships, and users with no organization. Zero row or column differences across 36,185 paired calls covering 224,545 rows. Plan stability was separately confirmed across four different compile orders.

**Out of scope, tracked separately:**

- A covering index on `SecurityTask` that pairs with this body — deliberately not bundled here.
- A pre-existing divergence between the T-SQL and the EF Core reimplementation on the group-collection path (EF honours a group grant only when no `CollectionUser` row exists on the same collection). Not introduced or changed by this PR.

/cc @bitwarden/team-data-insights-and-reporting-dev — Security Tasks is your feature area, so I would like your eyes on the access semantics. CODEOWNERS routes these paths to Vault and DBOps, so you would not otherwise be requested automatically.


[DBOPS-231]: https://bitwarden.atlassian.net/browse/DBOPS-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ