### PR TITLE
[PM-43021] fix: Align server domain name validation with the web client

### DIFF
--- a/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
@@ -91,7 +91,7 @@ public class OrganizationDomainController : Controller
         var organizationDomain = new OrganizationDomain
         {
             OrganizationId = orgId,
-            DomainName = model.DomainName.ToLower()
+            DomainName = model.DomainName.ToLowerInvariant()
         };
 
         organizationDomain = await _createOrganizationDomainCommand.CreateAsync(organizationDomain);

--- a/src/Core/Utilities/DomainNameAttribute.cs
+++ b/src/Core/Utilities/DomainNameAttribute.cs
@@ -13,7 +13,7 @@ public class DomainNameValidatorAttribute : ValidationAttribute
 {
     // Mirrors the web client's domainNameValidator; keep the two in sync:
     // bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/validators/domain-name.validator.ts
-    // - Must not start with a URL scheme or "www."
+    // - Must not start with a URL scheme or "www." (the "www." rule is also enforced case-insensitively below)
     // - Labels contain ASCII letters, numbers, and hyphens; are 1-63 characters; and cannot start or end with a hyphen
     // - Requires at least one dot; the top-level label is two or more ASCII letters
     private static readonly Regex _domainNameRegex = new(
@@ -53,6 +53,13 @@ public class DomainNameValidatorAttribute : ValidationAttribute
 
         // Check for control characters or other dangerous characters
         if (domainName.Any(c => char.IsControl(c) || c == '<' || c == '>' || c == '"' || c == '\'' || c == '&'))
+        {
+            return false;
+        }
+
+        // The regex is case-sensitive, so a "WWW." prefix would pass its lookahead and then be lowercased on save
+        // into a value this validator rejects. Reject the prefix regardless of case.
+        if (domainName.StartsWith("www.", StringComparison.OrdinalIgnoreCase))
         {
             return false;
         }

--- a/src/Core/Utilities/DomainNameAttribute.cs
+++ b/src/Core/Utilities/DomainNameAttribute.cs
@@ -6,20 +6,19 @@ namespace Bit.Core.Utilities;
 /// <summary>
 /// https://bitwarden.atlassian.net/browse/VULN-376
 /// Domain names are vulnerable to XSS attacks if not properly validated.
-/// Domain names can contain letters, numbers, dots, and hyphens.
-/// Domain names maybe internationalized (IDN) and contain unicode characters.
+/// Domain names can contain ASCII letters, numbers, dots, and hyphens.
+/// Internationalized domain names must be submitted in their ASCII ("xn--") form.
 /// </summary>
 public class DomainNameValidatorAttribute : ValidationAttribute
 {
-    // RFC 1123 compliant domain name regex
-    // - Allows alphanumeric characters and hyphens
-    // - Cannot start or end with a hyphen
-    // - Each label (part between dots) must be 1-63 characters
-    // - Total length should not exceed 253 characters
-    // - Supports internationalized domain names (IDN) - which is why this regex includes unicode ranges
+    // Mirrors the web client's domainNameValidator; keep the two in sync:
+    // bitwarden_license/bit-web/src/app/admin-console/organizations/manage/domain-verification/domain-add-edit-dialog/validators/domain-name.validator.ts
+    // - Must not start with a URL scheme or "www."
+    // - Labels contain ASCII letters, numbers, and hyphens; are 1-63 characters; and cannot start or end with a hyphen
+    // - Requires at least one dot; the top-level label is two or more ASCII letters
     private static readonly Regex _domainNameRegex = new(
-        @"^(?:[a-zA-Z0-9\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF](?:[a-zA-Z0-9\-\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{0,61}[a-zA-Z0-9\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])?\.)*[a-zA-Z0-9\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF](?:[a-zA-Z0-9\-\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{0,61}[a-zA-Z0-9\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])?$",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase
+        @"^(?!(http(s)?:\/\/|www\.))([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$",
+        RegexOptions.Compiled
     );
 
     public DomainNameValidatorAttribute()

--- a/test/Core.Test/Utilities/DomainNameAttributeTests.cs
+++ b/test/Core.Test/Utilities/DomainNameAttributeTests.cs
@@ -14,7 +14,8 @@ public class DomainNameValidatorAttributeTests
     [InlineData("example123.com")]                  // domain with numbers
     [InlineData("e.com")]                           // short domain
     [InlineData("very-long-subdomain-name.example.com")]  // long subdomain
-    [InlineData("wörldé.com")]                      // unicode domain (IDN)
+    [InlineData("Example.COM")]                     // mixed case
+    [InlineData("xn--bitwarden-emd.com")]           // internationalized domain in ASCII (punycode) form
     public void IsValid_ReturnsTrueWhenValid(string domainName)
     {
         var sut = new DomainNameValidatorAttribute();
@@ -48,8 +49,17 @@ public class DomainNameValidatorAttributeTests
     [InlineData("")]                                // empty string
     [InlineData("   ")]                             // whitespace only
     [InlineData("http://example.com")]              // URL scheme
+    [InlineData("https://example.com")]             // URL scheme (https)
+    [InlineData("www.example.com")]                 // www prefix
     [InlineData("example.com/path")]                // path component
     [InlineData("user@example.com")]                // email format
+    [InlineData("example")]                         // no top-level domain
+    [InlineData("example.c")]                       // single-character top-level domain
+    [InlineData("example.c0m")]                     // digit in top-level domain
+    [InlineData("wörldé.com")]                      // unicode domain; must be submitted in punycode form
+    [InlineData("bitwarden\u0219.com")]             // non-ASCII character in label (U+0219)
+    [InlineData("bitwarde\u0274.com")]              // non-ASCII character in label (U+0274)
+    [InlineData("example\u00AD.com")]               // soft hyphen (U+00AD)
     public void IsValid_ReturnsFalseWhenInvalid(string domainName)
     {
         var sut = new DomainNameValidatorAttribute();
@@ -80,5 +90,28 @@ public class DomainNameValidatorAttributeTests
         var actual = sut.IsValid(longDomain);
 
         Assert.False(actual);
+    }
+
+    [Fact]
+    public void IsValid_ReturnsFalseWhenLabelTooLong()
+    {
+        var sut = new DomainNameValidatorAttribute();
+        // A single label may be at most 63 characters
+        var longLabelDomain = new string('a', 64) + ".com";
+
+        var actual = sut.IsValid(longLabelDomain);
+
+        Assert.False(actual);
+    }
+
+    [Fact]
+    public void IsValid_ReturnsTrueWhenLabelAtMaxLength()
+    {
+        var sut = new DomainNameValidatorAttribute();
+        var maxLabelDomain = new string('a', 63) + ".com";
+
+        var actual = sut.IsValid(maxLabelDomain);
+
+        Assert.True(actual);
     }
 }

--- a/test/Core.Test/Utilities/DomainNameAttributeTests.cs
+++ b/test/Core.Test/Utilities/DomainNameAttributeTests.cs
@@ -51,6 +51,8 @@ public class DomainNameValidatorAttributeTests
     [InlineData("http://example.com")]              // URL scheme
     [InlineData("https://example.com")]             // URL scheme (https)
     [InlineData("www.example.com")]                 // www prefix
+    [InlineData("WWW.example.com")]                 // www prefix, uppercase
+    [InlineData("Www.example.com")]                 // www prefix, mixed case
     [InlineData("example.com/path")]                // path component
     [InlineData("user@example.com")]                // email format
     [InlineData("example")]                         // no top-level domain


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-43021

## 📔 Objective

The server-side `DomainNameValidatorAttribute` accepted internationalized (non-ASCII) domain names, while the web client's `domainNameValidator` (`bitwarden_license/bit-web/.../domain-add-edit-dialog/validators/domain-name.validator.ts`) only accepts ASCII labels. Two sources of validation for the same input should not disagree, so the server now mirrors the client regex exactly.

**Behavior changes**
- Domain names may contain only ASCII letters, digits, dots, and hyphens. Internationalized domain names must be submitted in their ASCII (`xn--`) form, which is also the form DNS resolves.
- Dotless names, URL schemes, and `www.` prefixes are rejected, matching the client.
- The `www.` prefix is rejected regardless of case. The regex lookahead is case-sensitive, and claimed domains are lowercased on save, so an uppercase prefix would otherwise be stored as a value the validator rejects. The server is therefore stricter than the client for `WWW.` inputs; a follow-up could make the client lookahead case-insensitive as well.
- `OrganizationDomainController` now lowercases with `ToLowerInvariant()` so the persisted value cannot differ from the validated one.
- The same attribute validates invite-link allowed domains, so the tightening applies there too.

**Data**: No existing claimed domains contain non-ASCII characters, so no data migration is needed.

**Known limitation**: A domain claimed in `xn--` form will not match members whose email address uses the Unicode form of that domain. The web client never allowed claiming Unicode domains, so no supported configuration changes.

**Testing**
- `DomainNameValidatorAttributeTests` updated: Unicode case moved to invalid; added cases for uppercase, punycode, `https://`, `www.`/`WWW.`/`Www.`, dotless, one-letter and digit TLDs, non-ASCII labels, soft hyphen, and 63/64-character labels.
- `dotnet test test/Core.Test` and `dotnet test test/Api.Test` pass for the affected classes.
