### PR TITLE
Resolve Item-Scoped Discounts for Subscription Preview

### DIFF
--- a/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/DiscountMapper.cs
@@ -84,19 +84,23 @@ internal static class DiscountMapper
                 logger.LogError("Discount amount ({Amount}) has no discount id; dropped.", total.Amount);
                 continue;
             }
-            if (total.Discount?.Source?.Coupon is not { } coupon)
+            if (total.Discount?.Source?.Coupon is null)
             {
                 logger.LogError("Discount {DiscountId} has no expanded coupon; dropped.", total.DiscountId);
                 continue;
             }
-            resolved[total.DiscountId] = new ResolvedDiscount(coupon, total.Amount / 100m);
+            resolved[total.DiscountId] = new ResolvedDiscount(total.Discount, total.Amount / 100m);
         }
         return resolved;
     }
 
-    private readonly record struct ResolvedDiscount(Coupon Coupon, decimal AggregateAmount)
+    private readonly record struct ResolvedDiscount(Discount Discount, decimal AggregateAmount)
     {
-        internal bool IsItemScoped => Coupon.AppliesTo?.Products?.Count > 0;
+        internal Coupon Coupon => Discount.Source.Coupon;
+
+        internal bool IsItemScoped =>
+            Discount.SubscriptionItem is not null and not "" ||
+            Coupon.AppliesTo?.Products?.Count > 0;
 
         internal InvoicePreviewDiscount ToPreviewDiscount(decimal amount) => new()
         {

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
@@ -1,4 +1,4 @@
-using Bit.Core.Billing.Services;
+﻿using Bit.Core.Billing.Services;
 using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews.Stripe;

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
@@ -1,4 +1,4 @@
-﻿using Bit.Core.Billing.Services;
+using Bit.Core.Billing.Services;
 using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews.Stripe;
@@ -24,6 +24,36 @@ internal sealed class InvoicePreviewClient(IStripeAdapter stripeAdapter) : IInvo
             invoice.Lines.HasMore = false;
         }
 
+        await ExpandCouponsAsync(invoice);
+
         return invoice;
+    }
+
+    // The preview response cannot carry coupon.applies_to (its expand chain ends at coupon, Stripe's 4-level
+    // cap), so each distinct coupon is refetched with applies_to expanded and spliced onto its discount.
+    private async Task ExpandCouponsAsync(Invoice invoice)
+    {
+        var amounts = (invoice.TotalDiscountAmounts ?? [])
+            .Where(amount => amount.Discount?.Source?.Coupon is not null)
+            .ToList();
+
+        foreach (var couponId in amounts.Select(amount => amount.Discount.Source.Coupon.Id).Distinct())
+        {
+            Coupon? enriched;
+            try
+            {
+                enriched = await stripeAdapter.GetCouponAsync(couponId, new CouponGetOptions { Expand = ["applies_to"] });
+            }
+            catch (StripeException)
+            {
+                // The coupon may have been deleted since it was attached; keep the un-enriched coupon.
+                continue;
+            }
+
+            foreach (var amount in amounts.Where(amount => amount.Discount.Source.Coupon.Id == couponId))
+            {
+                amount.Discount.Source.Coupon = enriched;
+            }
+        }
     }
 }

--- a/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
+++ b/src/Libraries/Invoicing/InvoicePreviews/Stripe/InvoicePreviewClient.cs
@@ -1,9 +1,12 @@
 ﻿using Bit.Core.Billing.Services;
+using Microsoft.Extensions.Logging;
 using Stripe;
 
 namespace Bit.Invoicing.InvoicePreviews.Stripe;
 
-internal sealed class InvoicePreviewClient(IStripeAdapter stripeAdapter) : IInvoicePreviewClient
+internal sealed class InvoicePreviewClient(
+    IStripeAdapter stripeAdapter,
+    ILogger<InvoicePreviewClient> logger) : IInvoicePreviewClient
 {
     public async Task<Invoice> GetInvoiceForPreviewAsync(InvoiceCreatePreviewOptions options)
     {
@@ -44,9 +47,12 @@ internal sealed class InvoicePreviewClient(IStripeAdapter stripeAdapter) : IInvo
             {
                 enriched = await stripeAdapter.GetCouponAsync(couponId, new CouponGetOptions { Expand = ["applies_to"] });
             }
-            catch (StripeException)
+            catch (StripeException stripeException)
             {
                 // The coupon may have been deleted since it was attached; keep the un-enriched coupon.
+                logger.LogWarning(
+                    "InvoicePreviewClient: Could not retrieve coupon ({CouponId}) for applies_to expansion | Code = {Code}",
+                    couponId, stripeException.StripeError?.Code);
                 continue;
             }
 

--- a/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
+++ b/test/Libraries/Invoicing.Test/DiscountMapperTests.cs
@@ -363,4 +363,70 @@ public class DiscountMapperTests
         Assert.Equal(12.79m, Assert.Single(result.CartLevel).Amount);
         Assert.Empty(result.ItemLevel);
     }
+
+    [Fact]
+    public void Partition_CouponPinnedToItemWithoutAppliesTo_LandsOnItsLine()
+    {
+        // Dashboard-attached item discount: scope comes from subscription_item, not the coupon's applies_to.
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 11757,
+          "total_discount_amounts": [
+            { "amount": 225, "discount": { "id": "di_pin", "subscription_item": "si_pin", "source": { "coupon": { "id": "cp_pin", "name": "STORAGE15", "percent_off": 15 } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 1500,
+                "pricing": { "price_details": { "price": { "id": "price_storage", "metadata": { "purchasable_reference": "pm-storage" } } } },
+                "discount_amounts": [ { "amount": 225, "discount": "di_pin" } ]
+              }
+            ]
+          }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        Assert.Empty(result.CartLevel);
+        Assert.Equal(2.25m, Assert.Single(result.ItemLevel["pm-storage"]).Amount);
+    }
+
+    [Fact]
+    public void Partition_MixedInvoice_PinnedCouponLandsOnLine_CartCouponStaysTopLevel()
+    {
+        var invoice = Deserialize("""
+        {
+          "id": "in_test",
+          "total": 241116,
+          "total_discount_amounts": [
+            { "amount": 74419, "discount": { "id": "di_cart", "source": { "coupon": { "id": "cp_cart", "name": "SUB25", "percent_off": 25 } } } },
+            { "amount": 225, "discount": { "id": "di_pin", "subscription_item": "si_pin", "source": { "coupon": { "id": "cp_pin", "name": "STORAGE15", "percent_off": 15 } } } }
+          ],
+          "lines": {
+            "data": [
+              {
+                "amount": 144000,
+                "pricing": { "price_details": { "price": { "id": "price_pm", "metadata": { "purchasable_reference": "pm-seat" } } } },
+                "discount_amounts": [ { "amount": 74419, "discount": "di_cart" } ]
+              },
+              {
+                "amount": 1500,
+                "pricing": { "price_details": { "price": { "id": "price_storage", "metadata": { "purchasable_reference": "pm-storage" } } } },
+                "discount_amounts": [ { "amount": 225, "discount": "di_pin" } ]
+              }
+            ]
+          }
+        }
+        """);
+
+        var result = DiscountMapper.Partition(invoice, new RecordingLogger<DiscountMapperTests>());
+
+        var cart = Assert.Single(result.CartLevel);
+        Assert.Equal(744.19m, cart.Amount);
+        Assert.Equal("SUB25", cart.Label);
+        Assert.Equal(2.25m, Assert.Single(result.ItemLevel["pm-storage"]).Amount);
+        Assert.False(result.ItemLevel.ContainsKey("pm-seat"));
+    }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using Bit.Core.Billing.Services;
 using Bit.Invoicing.InvoicePreviews.Stripe;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Stripe;
 using Xunit;
 
@@ -80,5 +81,87 @@ public class InvoicePreviewClientTests
         await adapter.DidNotReceive()
             .ListInvoiceLineItemsAsync(Arg.Any<string>(), Arg.Any<InvoiceLineItemListOptions>());
         Assert.Same(lines, result.Lines.Data);
+    }
+
+    [Fact]
+    public async Task GetInvoiceForPreviewAsync_RefetchesDistinctCouponsWithAppliesToAndSplices()
+    {
+        var adapter = Substitute.For<IStripeAdapter>();
+        adapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>())
+            .Returns(Invoice.FromJson("""
+            {
+              "id": "in_test",
+              "total_discount_amounts": [
+                { "amount": 225, "discount": { "id": "di_1", "source": { "coupon": { "id": "cp_a", "name": "A", "percent_off": 15 } } } },
+                { "amount": 744, "discount": { "id": "di_2", "source": { "coupon": { "id": "cp_a", "name": "A", "percent_off": 15 } } } },
+                { "amount": 100, "discount": { "id": "di_3", "source": { "coupon": { "id": "cp_b", "name": "B", "percent_off": 10 } } } }
+              ],
+              "lines": { "data": [] }
+            }
+            """));
+        var enriched = new Coupon
+        {
+            Id = "cp_a",
+            Name = "A",
+            PercentOff = 15,
+            AppliesTo = new CouponAppliesTo { Products = ["prod_storage"] },
+        };
+        adapter.GetCouponAsync("cp_a", Arg.Any<CouponGetOptions>()).Returns(enriched);
+        adapter.GetCouponAsync("cp_b", Arg.Any<CouponGetOptions>()).Returns(new Coupon { Id = "cp_b", Name = "B" });
+
+        var client = new InvoicePreviewClient(adapter);
+
+        var result = await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
+
+        await adapter.Received(1).GetCouponAsync("cp_a", Arg.Is<CouponGetOptions>(o => o.Expand.Contains("applies_to")));
+        await adapter.Received(1).GetCouponAsync("cp_b", Arg.Any<CouponGetOptions>());
+        Assert.Same(enriched, result.TotalDiscountAmounts[0].Discount.Source.Coupon);
+        Assert.Same(enriched, result.TotalDiscountAmounts[1].Discount.Source.Coupon);
+        Assert.Null(result.TotalDiscountAmounts[2].Discount.Source.Coupon.AppliesTo);
+    }
+
+    [Fact]
+    public async Task GetInvoiceForPreviewAsync_CouponDeleted_KeepsUnenrichedCoupon()
+    {
+        var adapter = Substitute.For<IStripeAdapter>();
+        adapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>())
+            .Returns(Invoice.FromJson("""
+            {
+              "id": "in_test",
+              "total_discount_amounts": [
+                { "amount": 225, "discount": { "id": "di_1", "source": { "coupon": { "id": "cp_gone", "name": "GONE", "percent_off": 15 } } } }
+              ],
+              "lines": { "data": [] }
+            }
+            """));
+        adapter.GetCouponAsync("cp_gone", Arg.Any<CouponGetOptions>())
+            .Throws(new StripeException(System.Net.HttpStatusCode.BadRequest, new StripeError { Code = "resource_missing" }, "gone"));
+
+        var client = new InvoicePreviewClient(adapter);
+
+        var result = await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
+
+        var coupon = result.TotalDiscountAmounts[0].Discount.Source.Coupon;
+        Assert.Equal("cp_gone", coupon.Id);
+        Assert.Null(coupon.AppliesTo);
+    }
+
+    [Fact]
+    public async Task GetInvoiceForPreviewAsync_NoDiscounts_DoesNotRefetchCoupons()
+    {
+        var adapter = Substitute.For<IStripeAdapter>();
+        adapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>())
+            .Returns(Invoice.FromJson("""
+            {
+              "id": "in_test",
+              "lines": { "data": [ { "id": "il_1" } ] }
+            }
+            """));
+
+        var client = new InvoicePreviewClient(adapter);
+
+        await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
+
+        await adapter.DidNotReceive().GetCouponAsync(Arg.Any<string>(), Arg.Any<CouponGetOptions>());
     }
 }

--- a/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
+++ b/test/Libraries/Invoicing.Test/InvoicePreviewClientTests.cs
@@ -1,5 +1,7 @@
 ﻿using Bit.Core.Billing.Services;
 using Bit.Invoicing.InvoicePreviews.Stripe;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Stripe;
@@ -14,7 +16,7 @@ public class InvoicePreviewClientTests
     {
         var adapter = Substitute.For<IStripeAdapter>();
         adapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>()).Returns(new Invoice());
-        var client = new InvoicePreviewClient(adapter);
+        var client = new InvoicePreviewClient(adapter, new FakeLogger<InvoicePreviewClient>());
 
         var options = new InvoiceCreatePreviewOptions();
         await client.GetInvoiceForPreviewAsync(options);
@@ -47,7 +49,7 @@ public class InvoicePreviewClientTests
         adapter.ListInvoiceLineItemsAsync(Arg.Any<string>(), Arg.Any<InvoiceLineItemListOptions>())
             .Returns(fullSet);
 
-        var client = new InvoicePreviewClient(adapter);
+        var client = new InvoicePreviewClient(adapter, new FakeLogger<InvoicePreviewClient>());
 
         var result = await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
 
@@ -74,7 +76,7 @@ public class InvoicePreviewClientTests
         };
         adapter.CreateInvoicePreviewAsync(Arg.Any<InvoiceCreatePreviewOptions>()).Returns(invoice);
 
-        var client = new InvoicePreviewClient(adapter);
+        var client = new InvoicePreviewClient(adapter, new FakeLogger<InvoicePreviewClient>());
 
         var result = await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
 
@@ -109,7 +111,7 @@ public class InvoicePreviewClientTests
         adapter.GetCouponAsync("cp_a", Arg.Any<CouponGetOptions>()).Returns(enriched);
         adapter.GetCouponAsync("cp_b", Arg.Any<CouponGetOptions>()).Returns(new Coupon { Id = "cp_b", Name = "B" });
 
-        var client = new InvoicePreviewClient(adapter);
+        var client = new InvoicePreviewClient(adapter, new FakeLogger<InvoicePreviewClient>());
 
         var result = await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
 
@@ -136,14 +138,19 @@ public class InvoicePreviewClientTests
             """));
         adapter.GetCouponAsync("cp_gone", Arg.Any<CouponGetOptions>())
             .Throws(new StripeException(System.Net.HttpStatusCode.BadRequest, new StripeError { Code = "resource_missing" }, "gone"));
+        var logger = new FakeLogger<InvoicePreviewClient>();
 
-        var client = new InvoicePreviewClient(adapter);
+        var client = new InvoicePreviewClient(adapter, logger);
 
         var result = await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
 
         var coupon = result.TotalDiscountAmounts[0].Discount.Source.Coupon;
         Assert.Equal("cp_gone", coupon.Id);
         Assert.Null(coupon.AppliesTo);
+
+        var log = Assert.Single(logger.Collector.GetSnapshot());
+        Assert.Equal(LogLevel.Warning, log.Level);
+        Assert.Contains("cp_gone", log.Message);
     }
 
     [Fact]
@@ -158,7 +165,7 @@ public class InvoicePreviewClientTests
             }
             """));
 
-        var client = new InvoicePreviewClient(adapter);
+        var client = new InvoicePreviewClient(adapter, new FakeLogger<InvoicePreviewClient>());
 
         await client.GetInvoiceForPreviewAsync(new InvoiceCreatePreviewOptions());
 

--- a/test/Libraries/Invoicing.Test/Invoicing.Test.csproj
+++ b/test/Libraries/Invoicing.Test/Invoicing.Test.csproj
@@ -9,6 +9,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="[10.8.0]" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkVersion)" />
     <PackageReference Include="NSubstitute" Version="$(NSubstituteVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />

--- a/test/Libraries/Invoicing.Test/packages.lock.json
+++ b/test/Libraries/Invoicing.Test/packages.lock.json
@@ -8,6 +8,17 @@
         "resolved": "6.0.0",
         "contentHash": "tW3lsNS+dAEII6YGUX/VMoJjBS1QvsxqJeqLaJXub08y1FSjasFPtQ4UBUsudE9PNrzLjooClMsPtY2cZLdXpQ=="
       },
+      "Microsoft.Extensions.Diagnostics.Testing": {
+        "type": "Direct",
+        "requested": "[10.8.0, 10.8.0]",
+        "resolved": "10.8.0",
+        "contentHash": "juYWZdATg/uODFWdYWrlo9a/0KRHGycsVinxI+/IpiBSDW5JZNZa2Fs/Os9N9Q2WHBHnhwANSPo2zljbzFRkRA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.8.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.0.1, )",
@@ -635,6 +646,15 @@
           "StackExchange.Redis": "2.7.27"
         }
       },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "7I0DXMTCqpXpXg+SLLDlfedtv6DN5Lgiv+PR3MclzqKPOHNB17YP42KMNI61ckSrffh0xsuIqQyCIjvWc6vUuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10"
+        }
+      },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -654,11 +674,11 @@
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "R3NN1X+kVu14uoxLEW6sBSQyhogDSbaOQzILnCtuXxBN4hx22AgjWPwZX6v/suERFkEDgU1lk12AglHTrUxhlw==",
+        "resolved": "10.0.10",
+        "contentHash": "GqmN2o1CkJvk7uWp+p4CwBYW0w/zfoEbvsiFDbO2G8l1Uz+mrDAbAcZiXhU2lufKPby1cjAUdd5GTWpebYOkOA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.8",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8"
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
@@ -706,10 +726,10 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "daf62xHIrq8pnE709hgaZZN9tSam9TGGepWe1+bE6V3GEuVwJiMs6ib+38lfMCyAJAHiX0vapxBhsuMSV7U+cg==",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
@@ -807,12 +827,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "K60JhWC2hN/Gi7TP68tBxSzk5ACWOs7lkmPzsfA8Bcf/IXTajujt2ORMf9rSMk1bsng6Lv4Y3fuxp3bm1+15ug==",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.8",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8"
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -822,6 +842,11 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Tx0R6PY9MNSh0mDKSxbpHLuuec93IxF1cel+1ithQnMNr/vbfLSSHOQHGHIppAJCGfPcEo/wO1Ylj+QpXtzo3A=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -834,20 +859,31 @@
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.8",
-        "contentHash": "VOapXeO3lhBH0zYoyAH7tjapuo4V5pTHlevPpiSHueEquAajqd5nF0mttm+h/uE/exwAEuM5s26SzOJtletE3w==",
+        "resolved": "10.0.10",
+        "contentHash": "tnBmu/LwF25ZQK+HBNCu2xrwnkKoB/XEbJyooGGoYxHrhvxbSKi7eOFiJ4AXBy/QU4vtCvCJfoi8k9Ej72qzOQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
-          "Microsoft.Extensions.Options": "10.0.8",
-          "Microsoft.Extensions.Primitives": "10.0.8"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
         "resolved": "10.0.10",
         "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.8.0",
+        "contentHash": "XHlOerNKjVrPJqbuFi196tyFhS7eNMoPUC800xJmCGsSiruE/goGoKyBKzS1HeelAGnoFPFrS+LgNitXNeEYRQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.8.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.ObjectPool": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
       },
       "Microsoft.Identity.Client": {
         "type": "Transitive",


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-43009

## 📔 Objective

A coupon scoped to a single subscription line (e.g. pinned to the storage line) was being surfaced at the invoice/cart level instead of on its line item, so the client's self-computed subtotal came up short.

Root cause: `DiscountMapper` classified discount scope from `Coupon.AppliesTo` alone, so an unrestricted coupon pinned to one line (no `applies_to`) was treated as cart-wide.

**Fix — read both.** A discount is item-scoped when **either**:
- `Discount.SubscriptionItem` is set — the coupon is pinned to one line (already present in the preview response we fetch), or
- `Coupon.AppliesTo.Products` is non-empty — a product-scoped coupon attached at the invoice level.

`AppliesTo` isn't returned on the preview invoice, so `InvoicePreviewClient` refetches each distinct coupon with `applies_to` expanded (one call per coupon) — the same workaround the legacy path uses. Which line a scoped discount belongs to needs no new logic: the line's `discount_amounts` already lists the discount ids applied to it, and the existing partition loop matches on that id.

**Refetch failures are logged.** The refetch fails soft — a deleted coupon shouldn't break the preview — but now logs a warning (coupon id + Stripe error code) when it swallows a `StripeException`, matching the sibling refetch implementations. Without it, a transient Stripe failure would silently drop `applies_to` and reproduce the exact misclassification this PR fixes, with nothing in the logs to explain it.

## 🧪 Testing

Covered by unit tests in `DiscountMapperTests` / `InvoicePreviewClientTests`. The refetch-failure log is asserted with Microsoft's `FakeLogger<T>`, which adds the `Microsoft.Extensions.Diagnostics.Testing` package to `Invoicing.Test`.
