### PR TITLE
[PM-40673] Rotate SecurityStamp on 2FA actions

### DIFF
--- a/src/Core/Auth/UserFeatures/TwoFactorAuth/Implementations/ResetUserTwoFactorCommand.cs
+++ b/src/Core/Auth/UserFeatures/TwoFactorAuth/Implementations/ResetUserTwoFactorCommand.cs
@@ -11,6 +11,7 @@ public class ResetUserTwoFactorCommand(
     {
         user.TwoFactorProviders = null;
         user.TwoFactorRecoveryCode = null;
+        user.SecurityStamp = Guid.NewGuid().ToString();
         user.RevisionDate = user.AccountRevisionDate = timeProvider.GetUtcNow().UtcDateTime;
         await userRepository.ReplaceAsync(user);
     }

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -731,6 +731,7 @@ public class UserService : UserManager<User>, IUserService
 
         providers.Remove(type);
         user.SetTwoFactorProviders(providers);
+        user.SecurityStamp = Guid.NewGuid().ToString();
         await SaveUserAsync(user);
         await _eventService.LogUserEventAsync(user.Id, EventType.User_Disabled2fa);
 

--- a/src/Core/Services/Implementations/UserService.cs
+++ b/src/Core/Services/Implementations/UserService.cs
@@ -751,6 +751,7 @@ public class UserService : UserManager<User>, IUserService
 
         user.TwoFactorProviders = null;
         user.TwoFactorRecoveryCode = CoreHelpers.SecureRandomString(32, upper: false, special: false);
+        user.SecurityStamp = Guid.NewGuid().ToString();
         await SaveUserAsync(user);
         await _mailService.SendRecoverTwoFactorEmail(user.Email, DateTime.UtcNow, _currentContext.IpAddress);
         await _eventService.LogUserEventAsync(user.Id, EventType.User_Recovered2fa);

--- a/test/Core.Test/Auth/UserFeatures/TwoFactorAuth/ResetUserTwoFactorCommandTests.cs
+++ b/test/Core.Test/Auth/UserFeatures/TwoFactorAuth/ResetUserTwoFactorCommandTests.cs
@@ -48,6 +48,20 @@ public class ResetUserTwoFactorCommandTests
     }
 
     [Theory, BitAutoData]
+    public async Task ResetAsync_RotatesSecurityStamp(User user)
+    {
+        // Arrange
+        var originalStamp = user.SecurityStamp;
+        var sutProvider = GetSutProvider();
+
+        // Act
+        await sutProvider.Sut.ResetAsync(user);
+
+        // Assert
+        Assert.NotEqual(originalStamp, user.SecurityStamp);
+    }
+
+    [Theory, BitAutoData]
     public async Task ResetAsync_BumpsRevisionAndAccountRevisionDates(User user)
     {
         // Arrange

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -480,6 +480,26 @@ public class UserServiceTests
     }
 
     [Theory, BitAutoData]
+    public async Task RecoverTwoFactorAsync_CorrectCode_RotatesSecurityStamp(
+        User user, SutProvider<UserService> sutProvider)
+    {
+        // Arrange
+        var recoveryCode = "1234";
+        user.TwoFactorRecoveryCode = recoveryCode;
+        var originalStamp = user.SecurityStamp;
+
+        sutProvider.GetDependency<IPolicyRequirementQuery>()
+            .GetAsync<RequireTwoFactorPolicyRequirement>(user.Id)
+            .Returns(new RequireTwoFactorPolicyRequirement([]));
+
+        // Act
+        await sutProvider.Sut.RecoverTwoFactorAsync(user, recoveryCode);
+
+        // Assert
+        Assert.NotEqual(originalStamp, user.SecurityStamp);
+    }
+
+    [Theory, BitAutoData]
     public async Task RecoverTwoFactorAsync_IncorrectCode_ReturnsFalse(
         User user, SutProvider<UserService> sutProvider)
     {

--- a/test/Core.Test/Services/UserServiceTests.cs
+++ b/test/Core.Test/Services/UserServiceTests.cs
@@ -324,6 +324,28 @@ public class UserServiceTests
     }
 
     [Theory, BitAutoData]
+    public async Task DisableTwoFactorProviderAsync_RotatesSecurityStamp(
+        SutProvider<UserService> sutProvider, User user)
+    {
+        // Arrange
+        user.SetTwoFactorProviders(new Dictionary<TwoFactorProviderType, TwoFactorProvider>
+        {
+            [TwoFactorProviderType.Email] = new() { Enabled = true }
+        });
+        var originalStamp = user.SecurityStamp;
+
+        sutProvider.GetDependency<ITwoFactorIsEnabledQuery>()
+            .TwoFactorIsEnabledAsync(user)
+            .Returns(true);
+
+        // Act
+        await sutProvider.Sut.DisableTwoFactorProviderAsync(user, TwoFactorProviderType.Email);
+
+        // Assert
+        Assert.NotEqual(originalStamp, user.SecurityStamp);
+    }
+
+    [Theory, BitAutoData]
     public async Task DisableTwoFactorProviderAsync_UserHasOneProviderEnabled_DoesNotRevokeUserFromOrganization(
         SutProvider<UserService> sutProvider, User user, Organization organization)
     {


### PR DESCRIPTION
- **rotate SecurityStamp during ResetUserTwoFactorCommand.ResetAsync(); add test**
- **rotate SecurityStamp during UserService.RecoverTwoFactorAsync(); add test**
- **rotate SecurityStamp during UserService.DisableTwoFactorProviderAsync(); add test**

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
