### PR TITLE
[PM-43027] fix: Scope invited member collection and group access to the organization

### DIFF
--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Errors/InvalidCollectionOrGroupAccessError.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/Errors/InvalidCollectionOrGroupAccessError.cs
@@ -1,0 +1,9 @@
+﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers.Models;
+using Bit.Core.AdminConsole.Utilities.Errors;
+
+namespace Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers.Errors;
+
+public record InvalidCollectionOrGroupAccessError(InviteOrganizationUsersResponse Response) : Error<InviteOrganizationUsersResponse>(Code, Response)
+{
+    public const string Code = "One or more collections or groups are invalid";
+}

--- a/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUsersCommand.cs
+++ b/src/Core/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUsersCommand.cs
@@ -37,7 +37,9 @@ public class InviteOrganizationUsersCommand(IEventService eventService,
     IProviderOrganizationRepository providerOrganizationRepository,
     IProviderUserRepository providerUserRepository,
     IPricingClient pricingClient,
-    IGlobalSettings globalSettings
+    IGlobalSettings globalSettings,
+    ICollectionRepository collectionRepository,
+    IGroupRepository groupRepository
     ) : IInviteOrganizationUsersCommand
 {
 
@@ -133,6 +135,12 @@ public class InviteOrganizationUsersCommand(IEventService eventService,
                 new InviteOrganizationUsersResponse(inviteOrganization.OrganizationId)));
         }
 
+        if (!await HasValidCollectionAndGroupAccessAsync(invitesToSend, inviteOrganization.OrganizationId))
+        {
+            return new Failure<InviteOrganizationUsersResponse>(new InvalidCollectionOrGroupAccessError(
+                new InviteOrganizationUsersResponse(inviteOrganization.OrganizationId)));
+        }
+
         var validationResult = await inviteUsersValidator.ValidateAsync(new InviteOrganizationUsersValidationRequest
         {
             Invites = invitesToSend.ToArray(),
@@ -199,6 +207,37 @@ public class InviteOrganizationUsersCommand(IEventService eventService,
         return request.Invites
             .Where(invite => !existingEmails.Contains(invite.Email))
             .ToArray();
+    }
+
+    /// <summary>
+    /// Caller-supplied collection and group ids must resolve to shared collections and groups of the inviting
+    /// organization. Missing, foreign and default-user-collection ids fail identically so the response cannot be
+    /// used to probe for ids belonging to other organizations.
+    /// </summary>
+    private async Task<bool> HasValidCollectionAndGroupAccessAsync(OrganizationUserInviteCommandModel[] invites, Guid organizationId)
+    {
+        var collectionIds = invites.SelectMany(i => i.AssignedCollections).Select(c => c.Id).Distinct().ToList();
+        if (collectionIds.Count > 0)
+        {
+            var collections = await collectionRepository.GetManyByManyIdsAsync(collectionIds);
+            if (collections.Count != collectionIds.Count ||
+                collections.Any(c => c.OrganizationId != organizationId || c.Type == CollectionType.DefaultUserCollection))
+            {
+                return false;
+            }
+        }
+
+        var groupIds = invites.SelectMany(i => i.Groups).Distinct().ToList();
+        if (groupIds.Count > 0)
+        {
+            var groups = await groupRepository.GetManyByManyIds(groupIds);
+            if (groups.Count != groupIds.Count || groups.Any(g => g.OrganizationId != organizationId))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private async Task RevertPasswordManagerChangesAsync(Valid<InviteOrganizationUsersValidationRequest> validatedResult, Organization organization)

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
@@ -158,20 +158,19 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
             // Scope access rows to the organization, matching CollectionGroup_ReadByOrganizationId and
             // CollectionUser_ReadByOrganizationId. Without this a row pointing at another organization's group or
             // member is reported as access on this organization's collection.
-            var groups =
-                from c in collections
-                join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
+            // Queried against the DbSets rather than joined onto the materialized collection list, so the
+            // organization filter runs in SQL. Joining onto the list binds to Enumerable.Join, which reads both
+            // access tables into memory, and the deferred grouping then repeats that read for every collection.
+            var groups = (await (
+                from cg in dbContext.CollectionGroups
                 join grp in dbContext.Groups on cg.GroupId equals grp.Id
                 where grp.OrganizationId == organizationId
-                group cg by cg.CollectionId into g
-                select g;
-            var users =
-                from c in collections
-                join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
+                select cg).ToListAsync()).GroupBy(cg => cg.CollectionId);
+            var users = (await (
+                from cu in dbContext.CollectionUsers
                 join ou in dbContext.OrganizationUsers on cu.OrganizationUserId equals ou.Id
                 where ou.OrganizationId == organizationId
-                group cu by cu.CollectionId into u
-                select u;
+                select cu).ToListAsync()).GroupBy(cu => cu.CollectionId);
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
@@ -159,12 +159,12 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                 from cg in dbContext.CollectionGroups
                 join grp in dbContext.Groups on cg.GroupId equals grp.Id
                 where grp.OrganizationId == organizationId
-                select cg).ToListAsync()).GroupBy(cg => cg.CollectionId);
+                select cg).ToListAsync()).ToLookup(cg => cg.CollectionId);
             var users = (await (
                 from cu in dbContext.CollectionUsers
                 join ou in dbContext.OrganizationUsers on cu.OrganizationUserId equals ou.Id
                 where ou.OrganizationId == organizationId
-                select cu).ToListAsync()).GroupBy(cu => cu.CollectionId);
+                select cu).ToListAsync()).ToLookup(cu => cu.CollectionId);
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
@@ -155,16 +155,19 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
         using (var scope = ServiceScopeFactory.CreateScope())
         {
             var dbContext = GetDatabaseContext(scope);
-            var groups =
-                from c in collections
-                join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
-                group cg by cg.CollectionId into g
-                select g;
-            var users =
-                from c in collections
-                join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
-                group cu by cu.CollectionId into u
-                select u;
+            // Scope access rows to the organization, matching CollectionGroup_ReadByOrganizationId and
+            // CollectionUser_ReadByOrganizationId. Without this a row pointing at another organization's group or
+            // member is reported as access on this organization's collection.
+            var groups = (await (
+                from cg in dbContext.CollectionGroups
+                join g in dbContext.Groups on cg.GroupId equals g.Id
+                where g.OrganizationId == organizationId
+                select cg).ToListAsync()).GroupBy(cg => cg.CollectionId);
+            var users = (await (
+                from cu in dbContext.CollectionUsers
+                join ou in dbContext.OrganizationUsers on cu.OrganizationUserId equals ou.Id
+                where ou.OrganizationId == organizationId
+                select cu).ToListAsync()).GroupBy(cu => cu.CollectionId);
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
@@ -155,12 +155,6 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
         using (var scope = ServiceScopeFactory.CreateScope())
         {
             var dbContext = GetDatabaseContext(scope);
-            // Scope access rows to the organization, matching CollectionGroup_ReadByOrganizationId and
-            // CollectionUser_ReadByOrganizationId. Without this a row pointing at another organization's group or
-            // member is reported as access on this organization's collection.
-            // Queried against the DbSets rather than joined onto the materialized collection list, so the
-            // organization filter runs in SQL. Joining onto the list binds to Enumerable.Join, which reads both
-            // access tables into memory, and the deferred grouping then repeats that read for every collection.
             var groups = (await (
                 from cg in dbContext.CollectionGroups
                 join grp in dbContext.Groups on cg.GroupId equals grp.Id

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
@@ -171,24 +171,22 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
                     collection,
                     new CollectionAccessDetails
                     {
-                        Groups = groups
-                            .FirstOrDefault(g => g.Key == collection.Id)?
+                        Groups = groups[collection.Id]
                             .Select(g => new CollectionAccessSelection
                             {
                                 Id = g.GroupId,
                                 HidePasswords = g.HidePasswords,
                                 ReadOnly = g.ReadOnly,
                                 Manage = g.Manage
-                            }).ToList() ?? new List<CollectionAccessSelection>(),
-                        Users = users
-                            .FirstOrDefault(u => u.Key == collection.Id)?
+                            }).ToList(),
+                        Users = users[collection.Id]
                             .Select(c => new CollectionAccessSelection
                             {
                                 Id = c.OrganizationUserId,
                                 HidePasswords = c.HidePasswords,
                                 ReadOnly = c.ReadOnly,
                                 Manage = c.Manage
-                            }).ToList() ?? new List<CollectionAccessSelection>()
+                            }).ToList()
                     }
                 )
             ).ToList();

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/CollectionRepository.cs
@@ -158,16 +158,20 @@ public class CollectionRepository : Repository<Core.Entities.Collection, Collect
             // Scope access rows to the organization, matching CollectionGroup_ReadByOrganizationId and
             // CollectionUser_ReadByOrganizationId. Without this a row pointing at another organization's group or
             // member is reported as access on this organization's collection.
-            var groups = (await (
-                from cg in dbContext.CollectionGroups
-                join g in dbContext.Groups on cg.GroupId equals g.Id
-                where g.OrganizationId == organizationId
-                select cg).ToListAsync()).GroupBy(cg => cg.CollectionId);
-            var users = (await (
-                from cu in dbContext.CollectionUsers
+            var groups =
+                from c in collections
+                join cg in dbContext.CollectionGroups on c.Id equals cg.CollectionId
+                join grp in dbContext.Groups on cg.GroupId equals grp.Id
+                where grp.OrganizationId == organizationId
+                group cg by cg.CollectionId into g
+                select g;
+            var users =
+                from c in collections
+                join cu in dbContext.CollectionUsers on c.Id equals cu.CollectionId
                 join ou in dbContext.OrganizationUsers on cu.OrganizationUserId equals ou.Id
                 where ou.OrganizationId == organizationId
-                select cu).ToListAsync()).GroupBy(cu => cu.CollectionId);
+                group cu by cu.CollectionId into u
+                select u;
 
             return collections.Select(collection =>
                 new Tuple<Core.Entities.Collection, CollectionAccessDetails>(

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -891,40 +891,47 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
 
         await using var dbContext = GetDatabaseContext(scope);
 
-        dbContext.OrganizationUsers.AddRange(Mapper.Map<List<OrganizationUser>>(organizationUserCollection.Select(x => x.OrganizationUser)));
-        dbContext.CollectionUsers.AddRange(organizationUserCollection.SelectMany(x => x.Collections, (user, collection) => new CollectionUser
-        {
-            CollectionId = collection.Id,
-            HidePasswords = collection.HidePasswords,
-            OrganizationUserId = user.OrganizationUser.Id,
-            Manage = collection.Manage,
-            ReadOnly = collection.ReadOnly
-        }));
-        dbContext.GroupUsers.AddRange(organizationUserCollection.SelectMany(x => x.Groups, (user, group) => new GroupUser
-        {
-            GroupId = group,
-            OrganizationUserId = user.OrganizationUser.Id
-        }));
-
-        // Bump RevisionDate on all affected collections
-        var affectedCollectionIds = organizationUserCollection
-            .SelectMany(x => x.Collections)
-            .Select(c => c.Id)
-            .Distinct()
-            .ToList();
-        if (affectedCollectionIds.Count > 0)
-        {
-            var organizationId = organizationUserCollection.First().OrganizationUser.OrganizationId;
-            var affectedCollections = await dbContext.Collections
-                .Where(c => c.OrganizationId == organizationId
-                    && affectedCollectionIds.Contains(c.Id))
+        // Match the stored procedure: only collections and groups in the users' organization are attached
+        var organizationId = organizationUserCollection.First().OrganizationUser.OrganizationId;
+        var requestedCollectionIds = organizationUserCollection.SelectMany(x => x.Collections).Select(c => c.Id).Distinct().ToList();
+        var requestedGroupIds = organizationUserCollection.SelectMany(x => x.Groups).Distinct().ToList();
+        var affectedCollections = requestedCollectionIds.Count == 0
+            ? []
+            : await dbContext.Collections
+                .Where(c => c.OrganizationId == organizationId && requestedCollectionIds.Contains(c.Id))
                 .ToListAsync();
-            // Use the same RevisionDate as the created OrganizationUsers
-            var revisionDate = organizationUserCollection.First().OrganizationUser.RevisionDate;
-            foreach (var c in affectedCollections)
+        var organizationCollectionIds = affectedCollections.Select(c => c.Id).ToHashSet();
+        var organizationGroupIds = requestedGroupIds.Count == 0
+            ? []
+            : (await dbContext.Groups
+                .Where(g => g.OrganizationId == organizationId && requestedGroupIds.Contains(g.Id))
+                .Select(g => g.Id)
+                .ToListAsync()).ToHashSet();
+
+        dbContext.OrganizationUsers.AddRange(Mapper.Map<List<OrganizationUser>>(organizationUserCollection.Select(x => x.OrganizationUser)));
+        dbContext.CollectionUsers.AddRange(organizationUserCollection.SelectMany(
+            x => x.Collections.Where(c => organizationCollectionIds.Contains(c.Id)),
+            (user, collection) => new CollectionUser
             {
-                c.RevisionDate = revisionDate;
-            }
+                CollectionId = collection.Id,
+                HidePasswords = collection.HidePasswords,
+                OrganizationUserId = user.OrganizationUser.Id,
+                Manage = collection.Manage,
+                ReadOnly = collection.ReadOnly
+            }));
+        dbContext.GroupUsers.AddRange(organizationUserCollection.SelectMany(
+            x => x.Groups.Where(organizationGroupIds.Contains),
+            (user, group) => new GroupUser
+            {
+                GroupId = group,
+                OrganizationUserId = user.OrganizationUser.Id
+            }));
+
+        // Bump RevisionDate on all affected collections, using the same RevisionDate as the created OrganizationUsers
+        var revisionDate = organizationUserCollection.First().OrganizationUser.RevisionDate;
+        foreach (var c in affectedCollections)
+        {
+            c.RevisionDate = revisionDate;
         }
 
         await dbContext.SaveChangesAsync();

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -882,7 +882,8 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
 
     public async Task CreateManyAsync(IEnumerable<CreateOrganizationUser> organizationUserCollection)
     {
-        if (!organizationUserCollection.Any())
+        var organizationUsersList = organizationUserCollection.ToList();
+        if (organizationUsersList.Count == 0)
         {
             return;
         }
@@ -893,8 +894,8 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
 
         // Match the stored procedure: a collection or group is only attached when it belongs to the same
         // organization as the user it is being attached to.
-        var requestedCollectionIds = organizationUserCollection.SelectMany(x => x.Collections).Select(c => c.Id).Distinct().ToList();
-        var requestedGroupIds = organizationUserCollection.SelectMany(x => x.Groups).Distinct().ToList();
+        var requestedCollectionIds = organizationUsersList.SelectMany(x => x.Collections).Select(c => c.Id).Distinct().ToList();
+        var requestedGroupIds = organizationUsersList.SelectMany(x => x.Groups).Distinct().ToList();
         var requestedCollections = requestedCollectionIds.Count == 0
             ? []
             : await dbContext.Collections.Where(c => requestedCollectionIds.Contains(c.Id)).ToListAsync();
@@ -905,8 +906,8 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
                 .Where(g => requestedGroupIds.Contains(g.Id))
                 .ToDictionaryAsync(g => g.Id, g => g.OrganizationId);
 
-        dbContext.OrganizationUsers.AddRange(Mapper.Map<List<OrganizationUser>>(organizationUserCollection.Select(x => x.OrganizationUser)));
-        var collectionUsers = organizationUserCollection.SelectMany(
+        dbContext.OrganizationUsers.AddRange(Mapper.Map<List<OrganizationUser>>(organizationUsersList.Select(x => x.OrganizationUser)));
+        var collectionUsers = organizationUsersList.SelectMany(
             x => x.Collections.Where(c =>
                 collectionOrganizationIds.TryGetValue(c.Id, out var collectionOrganizationId) &&
                 collectionOrganizationId == x.OrganizationUser.OrganizationId),
@@ -919,7 +920,7 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
                 ReadOnly = collection.ReadOnly
             }).ToList();
         dbContext.CollectionUsers.AddRange(collectionUsers);
-        dbContext.GroupUsers.AddRange(organizationUserCollection.SelectMany(
+        dbContext.GroupUsers.AddRange(organizationUsersList.SelectMany(
             x => x.Groups.Where(g =>
                 groupOrganizationIds.TryGetValue(g, out var groupOrganizationId) &&
                 groupOrganizationId == x.OrganizationUser.OrganizationId),
@@ -932,7 +933,7 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
         // Bump RevisionDate on the collections that were actually attached, using the same RevisionDate as the
         // created OrganizationUsers
         var attachedCollectionIds = collectionUsers.Select(cu => cu.CollectionId).ToHashSet();
-        var revisionDate = organizationUserCollection.First().OrganizationUser.RevisionDate;
+        var revisionDate = organizationUsersList[0].OrganizationUser.RevisionDate;
         foreach (var c in requestedCollections.Where(c => attachedCollectionIds.Contains(c.Id)))
         {
             c.RevisionDate = revisionDate;

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -892,8 +892,6 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
 
         await using var dbContext = GetDatabaseContext(scope);
 
-        // Match the stored procedure: a collection or group is only attached when it belongs to the same
-        // organization as the user it is being attached to.
         var requestedCollectionIds = organizationUsersList.SelectMany(x => x.Collections).Select(c => c.Id).Distinct().ToList();
         var requestedGroupIds = organizationUsersList.SelectMany(x => x.Groups).Distinct().ToList();
         var requestedCollections = requestedCollectionIds.Count == 0

--- a/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
+++ b/src/Infrastructure.EntityFramework/AdminConsole/Repositories/OrganizationUserRepository.cs
@@ -891,26 +891,25 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
 
         await using var dbContext = GetDatabaseContext(scope);
 
-        // Match the stored procedure: only collections and groups in the users' organization are attached
-        var organizationId = organizationUserCollection.First().OrganizationUser.OrganizationId;
+        // Match the stored procedure: a collection or group is only attached when it belongs to the same
+        // organization as the user it is being attached to.
         var requestedCollectionIds = organizationUserCollection.SelectMany(x => x.Collections).Select(c => c.Id).Distinct().ToList();
         var requestedGroupIds = organizationUserCollection.SelectMany(x => x.Groups).Distinct().ToList();
-        var affectedCollections = requestedCollectionIds.Count == 0
+        var requestedCollections = requestedCollectionIds.Count == 0
             ? []
-            : await dbContext.Collections
-                .Where(c => c.OrganizationId == organizationId && requestedCollectionIds.Contains(c.Id))
-                .ToListAsync();
-        var organizationCollectionIds = affectedCollections.Select(c => c.Id).ToHashSet();
-        var organizationGroupIds = requestedGroupIds.Count == 0
+            : await dbContext.Collections.Where(c => requestedCollectionIds.Contains(c.Id)).ToListAsync();
+        var collectionOrganizationIds = requestedCollections.ToDictionary(c => c.Id, c => c.OrganizationId);
+        var groupOrganizationIds = requestedGroupIds.Count == 0
             ? []
-            : (await dbContext.Groups
-                .Where(g => g.OrganizationId == organizationId && requestedGroupIds.Contains(g.Id))
-                .Select(g => g.Id)
-                .ToListAsync()).ToHashSet();
+            : await dbContext.Groups
+                .Where(g => requestedGroupIds.Contains(g.Id))
+                .ToDictionaryAsync(g => g.Id, g => g.OrganizationId);
 
         dbContext.OrganizationUsers.AddRange(Mapper.Map<List<OrganizationUser>>(organizationUserCollection.Select(x => x.OrganizationUser)));
-        dbContext.CollectionUsers.AddRange(organizationUserCollection.SelectMany(
-            x => x.Collections.Where(c => organizationCollectionIds.Contains(c.Id)),
+        var collectionUsers = organizationUserCollection.SelectMany(
+            x => x.Collections.Where(c =>
+                collectionOrganizationIds.TryGetValue(c.Id, out var collectionOrganizationId) &&
+                collectionOrganizationId == x.OrganizationUser.OrganizationId),
             (user, collection) => new CollectionUser
             {
                 CollectionId = collection.Id,
@@ -918,18 +917,23 @@ public class OrganizationUserRepository : Repository<Core.Entities.OrganizationU
                 OrganizationUserId = user.OrganizationUser.Id,
                 Manage = collection.Manage,
                 ReadOnly = collection.ReadOnly
-            }));
+            }).ToList();
+        dbContext.CollectionUsers.AddRange(collectionUsers);
         dbContext.GroupUsers.AddRange(organizationUserCollection.SelectMany(
-            x => x.Groups.Where(organizationGroupIds.Contains),
+            x => x.Groups.Where(g =>
+                groupOrganizationIds.TryGetValue(g, out var groupOrganizationId) &&
+                groupOrganizationId == x.OrganizationUser.OrganizationId),
             (user, group) => new GroupUser
             {
                 GroupId = group,
                 OrganizationUserId = user.OrganizationUser.Id
             }));
 
-        // Bump RevisionDate on all affected collections, using the same RevisionDate as the created OrganizationUsers
+        // Bump RevisionDate on the collections that were actually attached, using the same RevisionDate as the
+        // created OrganizationUsers
+        var attachedCollectionIds = collectionUsers.Select(cu => cu.CollectionId).ToHashSet();
         var revisionDate = organizationUserCollection.First().OrganizationUser.RevisionDate;
-        foreach (var c in affectedCollections)
+        foreach (var c in requestedCollections.Where(c => attachedCollectionIds.Contains(c.Id)))
         {
             c.RevisionDate = revisionDate;
         }

--- a/test/Api.IntegrationTest/AdminConsole/Public/Controllers/MembersControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Public/Controllers/MembersControllerTests.cs
@@ -498,4 +498,37 @@ public class MembersControllerTests : IClassFixture<ApiApplicationFactory>, IAsy
         Assert.Equal(OrganizationUserStatusType.Invited, orgUser.Status);
         Assert.Equal(_organization.Id, orgUser.OrganizationId);
     }
+
+    [Fact]
+    public async Task Post_CollectionFromAnotherOrganization_ReturnsBadRequestAndWritesNothing()
+    {
+        // Create a different organization that owns a collection
+        var ownerEmail = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        await _factory.LoginWithNewAccount(ownerEmail);
+        var (otherOrganization, _) = await OrganizationTestHelpers.SignUpAsync(_factory, plan: PlanType.EnterpriseAnnually,
+            ownerEmail: ownerEmail, passwordManagerSeats: 10, paymentMethod: PaymentMethodType.Card);
+        var otherCollection = await OrganizationTestHelpers.CreateCollectionAsync(_factory, otherOrganization.Id, "other org collection");
+
+        // Re-authenticate with the original organization
+        await _loginHelper.LoginWithOrganizationApiKeyAsync(_organization.Id);
+
+        var email = $"integration-test{Guid.NewGuid()}@bitwarden.com";
+        var request = new MemberCreateRequestModel
+        {
+            Email = email,
+            Type = OrganizationUserType.User,
+            Collections = [new AssociationWithPermissionsRequestModel { Id = otherCollection.Id, Manage = true }],
+            Groups = []
+        };
+
+        var response = await _client.PostAsync("/public/members", JsonContent.Create(request));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var collectionUsers = await _factory.GetService<ICollectionRepository>().GetManyUsersByIdAsync(otherCollection.Id);
+        Assert.Empty(collectionUsers);
+
+        var organizationUsers = await _factory.GetService<IOrganizationUserRepository>().GetManyByOrganizationAsync(_organization.Id, null);
+        Assert.DoesNotContain(organizationUsers, ou => ou.Email == email);
+    }
 }

--- a/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUserCommandTests.cs
+++ b/test/Core.Test/AdminConsole/OrganizationFeatures/OrganizationUsers/InviteUsers/InviteOrganizationUserCommandTests.cs
@@ -1182,4 +1182,215 @@ public class InviteOrganizationUserCommandTests
             .DidNotReceive()
             .SendInvitesAsync(Arg.Any<SendInvitesRequest>());
     }
+
+    [Theory]
+    [BitAutoData]
+    public async Task InviteImportedOrganizationUsersAsync_WhenCollectionBelongsToAnotherOrganization_ThenFailureIsReturnedAndNoUserIsCreated(
+        MailAddress address,
+        Organization organization,
+        Collection collection,
+        FakeTimeProvider timeProvider,
+        SutProvider<InviteOrganizationUsersCommand> sutProvider)
+    {
+        // Arrange
+        collection.Type = CollectionType.SharedCollection;
+        var request = BuildInviteRequest(organization, address.Address, timeProvider,
+            [new CollectionAccessSelection { Id = collection.Id, Manage = true }], []);
+        ArrangeInvitableOrganization(sutProvider, organization, request);
+
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([collection]);
+
+        // Act
+        var result = await sutProvider.Sut.InviteImportedOrganizationUsersAsync(request);
+
+        // Assert
+        await AssertInviteRejectedAsync(result, sutProvider);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task InviteImportedOrganizationUsersAsync_WhenCollectionDoesNotExist_ThenFailureIsReturnedAndNoUserIsCreated(
+        MailAddress address,
+        Organization organization,
+        Guid collectionId,
+        FakeTimeProvider timeProvider,
+        SutProvider<InviteOrganizationUsersCommand> sutProvider)
+    {
+        // Arrange
+        var request = BuildInviteRequest(organization, address.Address, timeProvider,
+            [new CollectionAccessSelection { Id = collectionId }], []);
+        ArrangeInvitableOrganization(sutProvider, organization, request);
+
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([]);
+
+        // Act
+        var result = await sutProvider.Sut.InviteImportedOrganizationUsersAsync(request);
+
+        // Assert
+        await AssertInviteRejectedAsync(result, sutProvider);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task InviteImportedOrganizationUsersAsync_WhenCollectionIsADefaultUserCollection_ThenFailureIsReturnedAndNoUserIsCreated(
+        MailAddress address,
+        Organization organization,
+        Collection collection,
+        FakeTimeProvider timeProvider,
+        SutProvider<InviteOrganizationUsersCommand> sutProvider)
+    {
+        // Arrange
+        collection.OrganizationId = organization.Id;
+        collection.Type = CollectionType.DefaultUserCollection;
+        var request = BuildInviteRequest(organization, address.Address, timeProvider,
+            [new CollectionAccessSelection { Id = collection.Id }], []);
+        ArrangeInvitableOrganization(sutProvider, organization, request);
+
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([collection]);
+
+        // Act
+        var result = await sutProvider.Sut.InviteImportedOrganizationUsersAsync(request);
+
+        // Assert
+        await AssertInviteRejectedAsync(result, sutProvider);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task InviteImportedOrganizationUsersAsync_WhenGroupBelongsToAnotherOrganization_ThenFailureIsReturnedAndNoUserIsCreated(
+        MailAddress address,
+        Organization organization,
+        Group group,
+        FakeTimeProvider timeProvider,
+        SutProvider<InviteOrganizationUsersCommand> sutProvider)
+    {
+        // Arrange
+        var request = BuildInviteRequest(organization, address.Address, timeProvider, [], [group.Id]);
+        ArrangeInvitableOrganization(sutProvider, organization, request);
+
+        sutProvider.GetDependency<IGroupRepository>()
+            .GetManyByManyIds(Arg.Any<IEnumerable<Guid>>())
+            .Returns([group]);
+
+        // Act
+        var result = await sutProvider.Sut.InviteImportedOrganizationUsersAsync(request);
+
+        // Assert
+        await AssertInviteRejectedAsync(result, sutProvider);
+    }
+
+    [Theory]
+    [BitAutoData]
+    public async Task InviteImportedOrganizationUsersAsync_WhenCollectionsAndGroupsBelongToTheOrganization_ThenUserIsCreatedWithThatAccess(
+        MailAddress address,
+        Organization organization,
+        Collection collection,
+        Group group,
+        FakeTimeProvider timeProvider,
+        SutProvider<InviteOrganizationUsersCommand> sutProvider)
+    {
+        // Arrange
+        collection.OrganizationId = organization.Id;
+        collection.Type = CollectionType.SharedCollection;
+        group.OrganizationId = organization.Id;
+        var request = BuildInviteRequest(organization, address.Address, timeProvider,
+            [new CollectionAccessSelection { Id = collection.Id, Manage = true }], [group.Id]);
+        ArrangeInvitableOrganization(sutProvider, organization, request);
+
+        sutProvider.GetDependency<ICollectionRepository>()
+            .GetManyByManyIdsAsync(Arg.Any<IEnumerable<Guid>>())
+            .Returns([collection]);
+        sutProvider.GetDependency<IGroupRepository>()
+            .GetManyByManyIds(Arg.Any<IEnumerable<Guid>>())
+            .Returns([group]);
+
+        // Act
+        var result = await sutProvider.Sut.InviteImportedOrganizationUsersAsync(request);
+
+        // Assert
+        Assert.IsType<Success<InviteOrganizationUsersResponse>>(result);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .Received(1)
+            .CreateManyAsync(Arg.Is<IEnumerable<CreateOrganizationUser>>(users =>
+                users.Single().Collections.Single().Id == collection.Id &&
+                users.Single().Groups.Single() == group.Id));
+    }
+
+    private static InviteOrganizationUsersRequest BuildInviteRequest(
+        Organization organization,
+        string email,
+        FakeTimeProvider timeProvider,
+        IEnumerable<CollectionAccessSelection> collections,
+        IEnumerable<Guid> groups) =>
+        new(
+            invites:
+            [
+                new OrganizationUserInviteCommandModel(
+                    email: email,
+                    assignedCollections: collections,
+                    groups: groups,
+                    type: OrganizationUserType.User,
+                    permissions: new Permissions(),
+                    externalId: null,
+                    accessSecretsManager: false)
+            ],
+            organization: organization,
+            performedBy: Guid.Empty,
+            performedAt: timeProvider.GetUtcNow());
+
+    private static void ArrangeInvitableOrganization(
+        SutProvider<InviteOrganizationUsersCommand> sutProvider,
+        Organization organization,
+        InviteOrganizationUsersRequest request)
+    {
+        var inviteOrganization = new InviteOrganization(organization, new FreePlan());
+        organization.PlanType = inviteOrganization.Plan.Type;
+
+        sutProvider.GetDependency<IPricingClient>()
+            .GetPlan(organization.PlanType)
+            .Returns(inviteOrganization.Plan);
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .SelectKnownEmailsAsync(organization.Id, Arg.Any<IEnumerable<string>>(), false)
+            .Returns([]);
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetByIdAsync(organization.Id)
+            .Returns(organization);
+
+        sutProvider.GetDependency<IInviteUsersValidator>()
+            .ValidateAsync(Arg.Any<InviteOrganizationUsersValidationRequest>())
+            .Returns(new Valid<InviteOrganizationUsersValidationRequest>(GetInviteValidationRequestMock(request, inviteOrganization, organization)));
+
+        sutProvider.GetDependency<IOrganizationRepository>()
+            .GetOccupiedSeatCountByOrganizationIdAsync(organization.Id)
+            .Returns(new OrganizationSeatCounts { Sponsored = 0, Users = 0 });
+
+        sutProvider.GetDependency<IOrganizationUserRepository>()
+            .GetOccupiedSmSeatCountByOrganizationIdAsync(organization.Id)
+            .Returns(0);
+    }
+
+    private static async Task AssertInviteRejectedAsync(
+        CommandResult<InviteOrganizationUsersResponse> result,
+        SutProvider<InviteOrganizationUsersCommand> sutProvider)
+    {
+        var failure = Assert.IsType<Failure<InviteOrganizationUsersResponse>>(result);
+        Assert.Equal(InvalidCollectionOrGroupAccessError.Code, failure.Error.Message);
+
+        await sutProvider.GetDependency<IOrganizationUserRepository>()
+            .DidNotReceive()
+            .CreateManyAsync(Arg.Any<IEnumerable<CreateOrganizationUser>>());
+
+        await sutProvider.GetDependency<ISendOrganizationInvitesCommand>()
+            .DidNotReceive()
+            .SendInvitesAsync(Arg.Any<SendInvitesRequest>());
+    }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryGetManyByOrganizationIdWithAccessTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryGetManyByOrganizationIdWithAccessTests.cs
@@ -1,20 +1,32 @@
 ﻿using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Entities;
+using Bit.Core.Enums;
 using Bit.Core.Models.Data;
 using Bit.Core.Repositories;
+using Bit.Infrastructure.EntityFramework.Repositories;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
+using EfCollectionGroup = Bit.Infrastructure.EntityFramework.AdminConsole.Models.CollectionGroup;
+using EfCollectionUser = Bit.Infrastructure.EntityFramework.AdminConsole.Models.CollectionUser;
 
 namespace Bit.Infrastructure.IntegrationTest.AdminConsole.Repositories.CollectionRepository;
 
 public class CollectionRepositoryGetManyByOrganizationIdWithAccessTests
 {
+    /// <summary>
+    /// A collection carries access rows for its own organization plus planted rows pointing at another
+    /// organization's group and member. Only the organization's own access may be reported.
+    /// </summary>
     [DatabaseTheory, DatabaseData]
-    public async Task GetManyByOrganizationIdWithAccessAsync_ReturnsAccessForThisOrganizationOnly(
+    public async Task GetManyByOrganizationIdWithAccessAsync_WithCrossOrganizationAccessRows_ReturnsOwnAccessOnly(
         IUserRepository userRepository,
         IOrganizationRepository organizationRepository,
         IOrganizationUserRepository organizationUserRepository,
         IGroupRepository groupRepository,
-        ICollectionRepository collectionRepository)
+        ICollectionRepository collectionRepository,
+        Database database,
+        IServiceProvider services)
     {
         // Arrange
         var organization = await organizationRepository.CreateTestOrganizationAsync();
@@ -27,23 +39,20 @@ public class CollectionRepositoryGetManyByOrganizationIdWithAccessTests
             [new CollectionAccessSelection { Id = group.Id, Manage = true }],
             [new CollectionAccessSelection { Id = orgUser.Id, Manage = true }]);
 
-        // A second organization with its own collection and access, to prove the two are not mixed
         var otherOrganization = await organizationRepository.CreateTestOrganizationAsync(identifier: "other");
         var otherUser = await userRepository.CreateTestUserAsync("other");
         var otherOrgUser = await organizationUserRepository.CreateTestOrganizationUserAsync(otherOrganization, otherUser);
         var otherGroup = await groupRepository.CreateTestGroupAsync(otherOrganization);
-        var otherCollection = new Collection { Name = "Other", OrganizationId = otherOrganization.Id };
-        await collectionRepository.CreateAsync(otherCollection,
-            [new CollectionAccessSelection { Id = otherGroup.Id, Manage = true }],
-            [new CollectionAccessSelection { Id = otherOrgUser.Id, Manage = true }]);
+
+        await PlantCrossOrganizationAccessAsync(services, database, collection.Id, otherOrgUser.Id, otherGroup.Id);
 
         // Act
         var results = await collectionRepository.GetManyByOrganizationIdWithAccessAsync(organization.Id);
 
         // Assert
         var result = Assert.Single(results, r => r.Item1.Id == collection.Id);
-        Assert.DoesNotContain(results, r => r.Item1.Id == otherCollection.Id);
 
+        // Single() also asserts the planted foreign rows are absent
         var accessGroup = Assert.Single(result.Item2.Groups);
         Assert.Equal(group.Id, accessGroup.Id);
         Assert.True(accessGroup.Manage);
@@ -51,8 +60,52 @@ public class CollectionRepositoryGetManyByOrganizationIdWithAccessTests
         var accessUser = Assert.Single(result.Item2.Users);
         Assert.Equal(orgUser.Id, accessUser.Id);
         Assert.True(accessUser.Manage);
+    }
 
-        Assert.DoesNotContain(result.Item2.Groups, g => g.Id == otherGroup.Id);
-        Assert.DoesNotContain(result.Item2.Users, u => u.Id == otherOrgUser.Id);
+    /// <summary>
+    /// Writes access rows that point at another organization's member and group. Every repository write path
+    /// refuses to create these — that is what this fix and its siblings enforce — so they are written straight
+    /// to the tables: raw SQL for the Dapper/SqlServer pair, the EF <see cref="DatabaseContext"/> elsewhere.
+    /// </summary>
+    private static async Task PlantCrossOrganizationAccessAsync(
+        IServiceProvider services,
+        Database database,
+        Guid collectionId,
+        Guid organizationUserId,
+        Guid groupId)
+    {
+        if (database.Type == SupportedDatabaseProviders.SqlServer && !database.UseEf)
+        {
+            await using var connection = new SqlConnection(database.ConnectionString);
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = """
+                INSERT INTO [dbo].[CollectionUser] ([CollectionId], [OrganizationUserId], [ReadOnly], [HidePasswords], [Manage])
+                VALUES (@CollectionId, @OrganizationUserId, 0, 0, 1);
+                INSERT INTO [dbo].[CollectionGroup] ([CollectionId], [GroupId], [ReadOnly], [HidePasswords], [Manage])
+                VALUES (@CollectionId, @GroupId, 0, 0, 1);
+                """;
+            command.Parameters.AddWithValue("@CollectionId", collectionId);
+            command.Parameters.AddWithValue("@OrganizationUserId", organizationUserId);
+            command.Parameters.AddWithValue("@GroupId", groupId);
+            await command.ExecuteNonQueryAsync();
+            return;
+        }
+
+        using var scope = services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DatabaseContext>();
+        dbContext.CollectionUsers.Add(new EfCollectionUser
+        {
+            CollectionId = collectionId,
+            OrganizationUserId = organizationUserId,
+            Manage = true
+        });
+        dbContext.CollectionGroups.Add(new EfCollectionGroup
+        {
+            CollectionId = collectionId,
+            GroupId = groupId,
+            Manage = true
+        });
+        await dbContext.SaveChangesAsync();
     }
 }

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryGetManyByOrganizationIdWithAccessTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/CollectionRepository/CollectionRepositoryGetManyByOrganizationIdWithAccessTests.cs
@@ -1,0 +1,58 @@
+﻿using Bit.Core.AdminConsole.Repositories;
+using Bit.Core.Entities;
+using Bit.Core.Models.Data;
+using Bit.Core.Repositories;
+using Xunit;
+
+namespace Bit.Infrastructure.IntegrationTest.AdminConsole.Repositories.CollectionRepository;
+
+public class CollectionRepositoryGetManyByOrganizationIdWithAccessTests
+{
+    [DatabaseTheory, DatabaseData]
+    public async Task GetManyByOrganizationIdWithAccessAsync_ReturnsAccessForThisOrganizationOnly(
+        IUserRepository userRepository,
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        IGroupRepository groupRepository,
+        ICollectionRepository collectionRepository)
+    {
+        // Arrange
+        var organization = await organizationRepository.CreateTestOrganizationAsync();
+        var user = await userRepository.CreateTestUserAsync();
+        var orgUser = await organizationUserRepository.CreateTestOrganizationUserAsync(organization, user);
+        var group = await groupRepository.CreateTestGroupAsync(organization);
+
+        var collection = new Collection { Name = "Shared", OrganizationId = organization.Id };
+        await collectionRepository.CreateAsync(collection,
+            [new CollectionAccessSelection { Id = group.Id, Manage = true }],
+            [new CollectionAccessSelection { Id = orgUser.Id, Manage = true }]);
+
+        // A second organization with its own collection and access, to prove the two are not mixed
+        var otherOrganization = await organizationRepository.CreateTestOrganizationAsync(identifier: "other");
+        var otherUser = await userRepository.CreateTestUserAsync("other");
+        var otherOrgUser = await organizationUserRepository.CreateTestOrganizationUserAsync(otherOrganization, otherUser);
+        var otherGroup = await groupRepository.CreateTestGroupAsync(otherOrganization);
+        var otherCollection = new Collection { Name = "Other", OrganizationId = otherOrganization.Id };
+        await collectionRepository.CreateAsync(otherCollection,
+            [new CollectionAccessSelection { Id = otherGroup.Id, Manage = true }],
+            [new CollectionAccessSelection { Id = otherOrgUser.Id, Manage = true }]);
+
+        // Act
+        var results = await collectionRepository.GetManyByOrganizationIdWithAccessAsync(organization.Id);
+
+        // Assert
+        var result = Assert.Single(results, r => r.Item1.Id == collection.Id);
+        Assert.DoesNotContain(results, r => r.Item1.Id == otherCollection.Id);
+
+        var accessGroup = Assert.Single(result.Item2.Groups);
+        Assert.Equal(group.Id, accessGroup.Id);
+        Assert.True(accessGroup.Manage);
+
+        var accessUser = Assert.Single(result.Item2.Users);
+        Assert.Equal(orgUser.Id, accessUser.Id);
+        Assert.True(accessUser.Manage);
+
+        Assert.DoesNotContain(result.Item2.Groups, g => g.Id == otherGroup.Id);
+        Assert.DoesNotContain(result.Item2.Users, u => u.Id == otherOrgUser.Id);
+    }
+}

--- a/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserCreateTests.cs
+++ b/test/Infrastructure.IntegrationTest/AdminConsole/Repositories/OrganizationUserRepository/OrganizationUserCreateTests.cs
@@ -1,4 +1,5 @@
 ﻿using Bit.Core.AdminConsole.OrganizationFeatures.OrganizationUsers.InviteUsers.Models;
+using Bit.Core.AdminConsole.Repositories;
 using Bit.Core.Entities;
 using Bit.Core.Enums;
 using Bit.Core.Models.Data;
@@ -70,6 +71,56 @@ public class OrganizationUserCreateTests
         await AssertOrgUserAndCollectionRevisionDate(
             organizationUserRepository, collectionRepository,
             orgUser, collection.Id, orgUser.RevisionDate);
+    }
+
+    [DatabaseTheory, DatabaseData]
+    public async Task CreateManyAsync_WithCollectionAndGroupFromAnotherOrganization_DoesNotCreateThatAccess(
+        IOrganizationRepository organizationRepository,
+        IOrganizationUserRepository organizationUserRepository,
+        ICollectionRepository collectionRepository,
+        IGroupRepository groupRepository)
+    {
+        var organization = await organizationRepository.CreateTestOrganizationAsync();
+        var otherOrganization = await organizationRepository.CreateTestOrganizationAsync(identifier: "other");
+        var ownCollection = await collectionRepository.CreateTestCollectionAsync(organization);
+        var otherCollection = await collectionRepository.CreateTestCollectionAsync(otherOrganization);
+        var otherGroup = await groupRepository.CreateTestGroupAsync(otherOrganization);
+
+        var orgUser = new OrganizationUser
+        {
+            Id = CoreHelpers.GenerateComb(),
+            OrganizationId = organization.Id,
+            UserId = null,
+            Email = $"invite-{Guid.NewGuid()}@example.com",
+            Status = OrganizationUserStatusType.Invited,
+            Type = OrganizationUserType.User,
+            CreationDate = DateTime.UtcNow,
+            RevisionDate = DateTime.UtcNow.AddMinutes(10),
+        };
+
+        await organizationUserRepository.CreateManyAsync([
+            new CreateOrganizationUser
+            {
+                OrganizationUser = orgUser,
+                Collections =
+                [
+                    new CollectionAccessSelection { Id = ownCollection.Id, Manage = true },
+                    new CollectionAccessSelection { Id = otherCollection.Id, Manage = true }
+                ],
+                Groups = [otherGroup.Id],
+            }
+        ]);
+
+        var (_, actualCollections) = await organizationUserRepository.GetByIdWithCollectionsAsync(orgUser.Id);
+        var collectionAccess = Assert.Single(actualCollections);
+        Assert.Equal(ownCollection.Id, collectionAccess.Id);
+
+        var (actualOtherCollection, otherCollectionAccess) = await collectionRepository.GetByIdWithAccessAsync(otherCollection.Id);
+        Assert.Empty(otherCollectionAccess.Users);
+        Assert.NotNull(actualOtherCollection);
+        Assert.Equal(otherCollection.RevisionDate, actualOtherCollection.RevisionDate, TimeSpan.FromSeconds(1));
+
+        Assert.Empty(await groupRepository.GetManyIdsByUserIdAsync(orgUser.Id));
     }
 
     private static async Task AssertOrgUserAndCollectionRevisionDate(

--- a/util/Migrator/DbScripts/2026-09-11_00_OrganizationUserCreateManyScopeAccessToOrganization.sql
+++ b/util/Migrator/DbScripts/2026-09-11_00_OrganizationUserCreateManyScopeAccessToOrganization.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE [dbo].[OrganizationUser_CreateManyWithCollectionsAndGroups]
+CREATE OR ALTER PROCEDURE [dbo].[OrganizationUser_CreateManyWithCollectionsAndGroups]
     @organizationUserData NVARCHAR(MAX),
     @collectionData NVARCHAR(MAX),
     @groupData NVARCHAR(MAX),
@@ -135,5 +135,4 @@ BEGIN
             #CollectionUserData CUD ON CUD.[CollectionId] = C.[Id]
     END
 END
-go
-
+GO


### PR DESCRIPTION
## 🎟️ Tracking

- https://bitwarden.atlassian.net/browse/PM-43027

## 📔 Objective
Addresses an issue allowing invitations with collections reaching further than it should. 

<details>
<summary>🤖  Junk</summary>

`POST /public/members` accepted a caller-supplied `collections` array and `groups` array and passed the ids straight to storage without checking they belong to the caller's organization. An organization API key for one organization could write a `CollectionUser` row — including `manage: true` — into a collection owned by an unrelated organization, and a `GroupUser` row referencing that organization's group.

This is a cross-tenant integrity issue, not a disclosure one. The vault read paths (`UserCollectionDetails`, `UserCipherDetails`, and the EF `UserCollectionDetailsQuery`) all join `OrganizationUser` on the collection's `OrganizationId`, so an injected row never yields access to another organization's items.

It was also a regression. Before #7182 this endpoint wrote collections through `OrganizationUser_CreateWithCollections`, which filters by organization on every backend. That refactor routed it onto `OrganizationUser_CreateManyWithCollectionsAndGroups`, a bulk procedure written for SCIM — which cannot supply collection or group ids — and which therefore had no such filter. The protection was dropped rather than never written.

### Approach

Four parts.

**Authorization check in `InviteOrganizationUsersCommand`.** Placed on the shared private path rather than in the controller, so the Public API and SCIM are both covered from one choke point. Missing, foreign, and default-user-collection ids all fail with the same error, so the response cannot be used to probe for ids belonging to other organizations. Rejecting default user collections matches the newer v2 update validator. SCIM pays nothing: it uses the invite overload that hardcodes empty collections and groups, so neither repository is called.

**Organization joins restored in the bulk stored procedure**, with migration `2026-09-11_00_OrganizationUserCreateManyScopeAccessToOrganization.sql`. Scoping the collection temp table also stops the `RevisionDate` bump from reaching into another organization's collections, which forced a spurious resync for the victim.

**A matching filter in EF `OrganizationUserRepository.CreateManyAsync`**, comparing each collection and group against *that user's* organization, exactly as the procedure's per-row join does, rather than against a single batch-level organization.

**EF `CollectionRepository.GetManyByOrganizationIdWithAccessAsync` scoped to the organization.** It joined access rows on collection id alone while `CollectionUser_ReadByOrganizationId` and `CollectionGroup_ReadByOrganizationId` join through the organization. That result feeds orphaned-collection detection in `BulkCollectionAuthorizationHandler`, so on self-hosted PostgreSQL or MySQL a foreign `manage` row stopped a collection counting as orphaned and denied the organization's own Owner. The rewrite also replaces an in-memory join over the entire `CollectionGroup` and `CollectionUser` tables with two scoped queries.

The by-collection-id reads are deliberately left alone: `CollectionUser_ReadByCollectionId` and `CollectionGroup_ReadByCollectionId` do not filter by organization either, so EF already matches them. Changing those would create a divergence rather than remove one.

### Verification

The stored procedure was exercised against SQL Server by deploying it and running the reported exploit inside a single transaction, then rolling back. Before the change it writes one foreign collection row and one foreign group row; after it writes neither, while the caller's own collection still attaches.

| Scenario | Before | After |
| --- | --- | --- |
| Foreign collection rows written | 1 | 0 |
| Foreign group rows written | 1 | 0 |
| Caller's own collection attached | 1 | 1 |

Tests: five unit tests on the command (foreign collection, missing collection, default user collection, foreign group, and a positive case), one Public API integration test asserting the endpoint returns 400 and writes nothing, and two repository tests that run on every provider. The read-side test plants the cross-organization rows directly rather than through a repository, because no write path will create them; it is verified to fail on the Entity Framework provider with the fix reverted and pass with it applied.

### Review notes

A multi-agent review (architecture, code quality, bug analysis, security) produced seven findings, reduced to two after validation and severity audit.

- **Fixed in this branch.** The first version of the read-side regression test passed against the unfixed code — its fixtures attached the other organization's access to that organization's own collection, which the old query already filtered out. Rewritten as described above.
- **Deferred, recorded here.** `HasValidCollectionAndGroupAccessAsync` is now the third near-identical copy of this rule, alongside `UpdateOrganizationUserCommand` and the v2 `UpdateOrganizationUserValidator`. The three have already drifted: v1 silently excludes default user collections while v2 and this path reject them, and v1 and v2 return 404 while this path returns 400. Consolidating them is worth doing but is a wider refactor of an authorization boundary, and folding it into a security fix would make this harder to review. Happy to file a follow-up.

Two findings were dismissed as pre-existing and belong on the VULN-981 ticket rather than here: `GetByIdWithAccessAsync` is unscoped on *both* backends, and no data remediation ships for rows written before this fix.

Related: #8329 (PM-42357) fixes the unfiltered EF collection write paths. It touches the same file but not the same methods, so there is no conflict.

</details> 

