### PR TITLE
[PM-42560] fix: Gate billing exception detail behind IsDevelopment

### DIFF
--- a/src/Api/Billing/Controllers/BaseBillingController.cs
+++ b/src/Api/Billing/Controllers/BaseBillingController.cs
@@ -23,12 +23,32 @@ public abstract class BaseBillingController : Controller
     /// <typeparam name="T">The type of the successful result.</typeparam>
     /// <param name="result">The result of executing the billing command.</param>
     /// <returns>An HTTP result response representing the outcome of the command execution.</returns>
-    protected static IResult Handle<T>(BillingCommandResult<T> result) =>
+    protected IResult Handle<T>(BillingCommandResult<T> result) =>
         result.Match<IResult>(
             TypedResults.Ok,
             badRequest => Error.BadRequest(badRequest.Response),
             conflict => Error.Conflict(conflict.Response),
-            unhandled => Error.ServerError(unhandled.Response, unhandled.Exception));
+            unhandled => ServerError(unhandled.Response, unhandled.Exception));
+
+    /// <summary>
+    /// Builds the 500 response for an unhandled billing command failure. Exception detail is only included
+    /// in development, matching <c>ExceptionHandlerFilterAttribute</c>. <see cref="BaseBillingCommand{T}"/>
+    /// has already logged the exception server-side by the time the result reaches here.
+    /// </summary>
+    private JsonHttpResult<ErrorResponseModel> ServerError(string message, Exception? exception)
+    {
+        var model = new ErrorResponseModel(message);
+
+        var environment = HttpContext?.RequestServices.GetService<IWebHostEnvironment>();
+        if (exception != null && environment?.IsDevelopment() == true)
+        {
+            model.ExceptionMessage = exception.Message;
+            model.ExceptionStackTrace = exception.StackTrace;
+            model.InnerExceptionMessage = exception.InnerException?.Message;
+        }
+
+        return TypedResults.Json(model, statusCode: StatusCodes.Status500InternalServerError);
+    }
 
     protected static class Error
     {
@@ -44,14 +64,9 @@ public abstract class BaseBillingController : Controller
             TypedResults.NotFound(new ErrorResponseModel("Resource not found."));
 
         public static JsonHttpResult<ErrorResponseModel> ServerError(
-            string message = "Something went wrong with your request. Please contact support for assistance.",
-            Exception? exception = null) =>
+            string message = "Something went wrong with your request. Please contact support for assistance.") =>
             TypedResults.Json(
-                exception == null ? new ErrorResponseModel(message) : new ErrorResponseModel(message)
-                {
-                    ExceptionMessage = exception.Message,
-                    ExceptionStackTrace = exception.StackTrace
-                },
+                new ErrorResponseModel(message),
                 statusCode: StatusCodes.Status500InternalServerError);
 
         public static JsonHttpResult<ErrorResponseModel> Unauthorized(string message = "Unauthorized.") =>

--- a/src/Api/Billing/Controllers/BaseBillingController.cs
+++ b/src/Api/Billing/Controllers/BaseBillingController.cs
@@ -31,9 +31,7 @@ public abstract class BaseBillingController : Controller
             unhandled => Error.ServerError(unhandled.Response, unhandled.Exception, IncludeExceptionDetail));
 
     /// <summary>
-    /// Whether a 500 response may carry exception detail. Only true in development, matching
-    /// <c>ExceptionHandlerFilterAttribute</c>. An absent request context reads as false, so the
-    /// detail is withheld unless development is positively established.
+    /// Exception detail is only disclosed in development, matching <c>ExceptionHandlerFilterAttribute</c>.
     /// </summary>
     private bool IncludeExceptionDetail =>
         HttpContext?.RequestServices.GetService<IWebHostEnvironment>()?.IsDevelopment() == true;
@@ -51,11 +49,6 @@ public abstract class BaseBillingController : Controller
         public static NotFound<ErrorResponseModel> NotFound() =>
             TypedResults.NotFound(new ErrorResponseModel("Resource not found."));
 
-        /// <summary>
-        /// <c>includeExceptionDetail</c> defaults to false so the exception is never disclosed unless
-        /// the caller positively establishes that it is safe to do so. See
-        /// <see cref="BaseBillingController.IncludeExceptionDetail"/>.
-        /// </summary>
         public static JsonHttpResult<ErrorResponseModel> ServerError(
             string message = "Something went wrong with your request. Please contact support for assistance.",
             Exception? exception = null,

--- a/src/Api/Billing/Controllers/BaseBillingController.cs
+++ b/src/Api/Billing/Controllers/BaseBillingController.cs
@@ -30,9 +30,6 @@ public abstract class BaseBillingController : Controller
             conflict => Error.Conflict(conflict.Response),
             unhandled => Error.ServerError(unhandled.Response, unhandled.Exception, IncludeExceptionDetail));
 
-    /// <summary>
-    /// Exception detail is only disclosed in development, matching <c>ExceptionHandlerFilterAttribute</c>.
-    /// </summary>
     private bool IncludeExceptionDetail =>
         HttpContext?.RequestServices.GetService<IWebHostEnvironment>()?.IsDevelopment() == true;
 

--- a/src/Api/Billing/Controllers/BaseBillingController.cs
+++ b/src/Api/Billing/Controllers/BaseBillingController.cs
@@ -28,27 +28,15 @@ public abstract class BaseBillingController : Controller
             TypedResults.Ok,
             badRequest => Error.BadRequest(badRequest.Response),
             conflict => Error.Conflict(conflict.Response),
-            unhandled => ServerError(unhandled.Response, unhandled.Exception));
+            unhandled => Error.ServerError(unhandled.Response, unhandled.Exception, IncludeExceptionDetail));
 
     /// <summary>
-    /// Builds the 500 response for an unhandled billing command failure. Exception detail is only included
-    /// in development, matching <c>ExceptionHandlerFilterAttribute</c>. <see cref="BaseBillingCommand{T}"/>
-    /// has already logged the exception server-side by the time the result reaches here.
+    /// Whether a 500 response may carry exception detail. Only true in development, matching
+    /// <c>ExceptionHandlerFilterAttribute</c>. An absent request context reads as false, so the
+    /// detail is withheld unless development is positively established.
     /// </summary>
-    private JsonHttpResult<ErrorResponseModel> ServerError(string message, Exception? exception)
-    {
-        var model = new ErrorResponseModel(message);
-
-        var environment = HttpContext?.RequestServices.GetService<IWebHostEnvironment>();
-        if (exception != null && environment?.IsDevelopment() == true)
-        {
-            model.ExceptionMessage = exception.Message;
-            model.ExceptionStackTrace = exception.StackTrace;
-            model.InnerExceptionMessage = exception.InnerException?.Message;
-        }
-
-        return TypedResults.Json(model, statusCode: StatusCodes.Status500InternalServerError);
-    }
+    private bool IncludeExceptionDetail =>
+        HttpContext?.RequestServices.GetService<IWebHostEnvironment>()?.IsDevelopment() == true;
 
     protected static class Error
     {
@@ -63,10 +51,24 @@ public abstract class BaseBillingController : Controller
         public static NotFound<ErrorResponseModel> NotFound() =>
             TypedResults.NotFound(new ErrorResponseModel("Resource not found."));
 
+        /// <summary>
+        /// <c>includeExceptionDetail</c> defaults to false so the exception is never disclosed unless
+        /// the caller positively establishes that it is safe to do so. See
+        /// <see cref="BaseBillingController.IncludeExceptionDetail"/>.
+        /// </summary>
         public static JsonHttpResult<ErrorResponseModel> ServerError(
-            string message = "Something went wrong with your request. Please contact support for assistance.") =>
+            string message = "Something went wrong with your request. Please contact support for assistance.",
+            Exception? exception = null,
+            bool includeExceptionDetail = false) =>
             TypedResults.Json(
-                new ErrorResponseModel(message),
+                exception != null && includeExceptionDetail
+                    ? new ErrorResponseModel(message)
+                    {
+                        ExceptionMessage = exception.Message,
+                        ExceptionStackTrace = exception.StackTrace,
+                        InnerExceptionMessage = exception.InnerException?.Message
+                    }
+                    : new ErrorResponseModel(message),
                 statusCode: StatusCodes.Status500InternalServerError);
 
         public static JsonHttpResult<ErrorResponseModel> Unauthorized(string message = "Unauthorized.") =>

--- a/src/Core/Billing/Commands/BaseBillingCommand.cs
+++ b/src/Core/Billing/Commands/BaseBillingCommand.cs
@@ -58,8 +58,7 @@ public abstract class BaseBillingCommand<T>(
                 _ => Unmapped(stripeException)
             };
 
-            // Every branch that returns Unhandled must log the exception, since BaseBillingController
-            // only surfaces exception detail to the caller in development.
+            // Unhandled is the only branch the caller cannot diagnose from the response, so it has to log.
             Unhandled Unmapped(StripeException exception)
             {
                 logger.LogError(exception,

--- a/src/Core/Billing/Commands/BaseBillingCommand.cs
+++ b/src/Core/Billing/Commands/BaseBillingCommand.cs
@@ -55,12 +55,22 @@ public abstract class BaseBillingCommand<T>(
                     new BadRequest(
                         "The tax ID number you provided was invalid. Please try again or contact support for assistance."),
 
-                _ => new Unhandled(stripeException)
+                _ => Unmapped(stripeException)
             };
+
+            // Every branch that returns Unhandled must log the exception, since BaseBillingController
+            // only surfaces exception detail to the caller in development.
+            Unhandled Unmapped(StripeException exception)
+            {
+                logger.LogError(exception,
+                    "{Command}: An unmapped Stripe input error occurred | Code = {Code}", CommandName,
+                    exception.StripeError.Code);
+                return new Unhandled(exception);
+            }
         }
         catch (ConflictException conflictException)
         {
-            logger.LogError("{Command}: {Message}", CommandName, conflictException.Message);
+            logger.LogError(conflictException, "{Command}: {Message}", CommandName, conflictException.Message);
             return DefaultConflict != null ?
                 DefaultConflict :
                 new Unhandled(conflictException);

--- a/test/Api.Test/Billing/Controllers/BaseBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/BaseBillingControllerTests.cs
@@ -1,0 +1,122 @@
+﻿using Bit.Api.Billing.Controllers;
+using Bit.Core.Billing.Commands;
+using Bit.Core.Models.Api;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+using Unhandled = Bit.Core.Billing.Commands.Unhandled;
+
+namespace Bit.Api.Test.Billing.Controllers;
+
+/// <summary>
+/// Regression tests for VULN-845 (PM-42560): <see cref="BaseBillingController"/> used to copy the
+/// exception message and stack trace into every 500 response, with no environment guard, exposing
+/// internal paths and assembly versions to any authenticated user.
+/// </summary>
+public class BaseBillingControllerTests
+{
+    private const string GenericMessage =
+        "Something went wrong with your request. Please contact support for assistance.";
+
+    [Fact]
+    public void Handle_Unhandled_InProduction_OmitsExceptionDetail()
+    {
+        var sut = CreateSut("Production");
+
+        var result = sut.HandleResult(new BillingCommandResult<string>(new Unhandled(BuildException())));
+
+        var json = Assert.IsType<JsonHttpResult<ErrorResponseModel>>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, json.StatusCode);
+        Assert.Equal(GenericMessage, json.Value!.Message);
+        Assert.Null(json.Value.ExceptionMessage);
+        Assert.Null(json.Value.ExceptionStackTrace);
+        Assert.Null(json.Value.InnerExceptionMessage);
+    }
+
+    [Fact]
+    public void Handle_Unhandled_InDevelopment_IncludesExceptionDetail()
+    {
+        var sut = CreateSut("Development");
+        var exception = BuildException();
+
+        var result = sut.HandleResult(new BillingCommandResult<string>(new Unhandled(exception)));
+
+        var json = Assert.IsType<JsonHttpResult<ErrorResponseModel>>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, json.StatusCode);
+        Assert.Equal(GenericMessage, json.Value!.Message);
+        Assert.Equal(exception.Message, json.Value.ExceptionMessage);
+        Assert.Equal(exception.StackTrace, json.Value.ExceptionStackTrace);
+        Assert.Equal(exception.InnerException!.Message, json.Value.InnerExceptionMessage);
+    }
+
+    /// <summary>
+    /// The environment is resolved off the request, so an unset <see cref="HttpContext"/> has to fail
+    /// closed rather than throw or leak.
+    /// </summary>
+    [Fact]
+    public void Handle_Unhandled_WithoutHttpContext_OmitsExceptionDetail()
+    {
+        var sut = new TestBillingController();
+
+        var result = sut.HandleResult(new BillingCommandResult<string>(new Unhandled(BuildException())));
+
+        var json = Assert.IsType<JsonHttpResult<ErrorResponseModel>>(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, json.StatusCode);
+        Assert.Null(json.Value!.ExceptionMessage);
+        Assert.Null(json.Value.ExceptionStackTrace);
+    }
+
+    [Fact]
+    public void Handle_Success_ReturnsOk()
+    {
+        var sut = CreateSut("Production");
+
+        var result = sut.HandleResult(new BillingCommandResult<string>("success"));
+
+        var ok = Assert.IsType<Ok<string>>(result);
+        Assert.Equal("success", ok.Value);
+    }
+
+    private static TestBillingController CreateSut(string environmentName)
+    {
+        var environment = Substitute.For<IWebHostEnvironment>();
+        environment.EnvironmentName.Returns(environmentName);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(environment);
+
+        return new TestBillingController
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Throws and catches so the exception carries a real stack trace, which is the value under test.
+    /// </summary>
+    private static Exception BuildException()
+    {
+        try
+        {
+            throw new InvalidOperationException(
+                "Connection to internal-billing-service failed.",
+                new InvalidOperationException("Inner detail."));
+        }
+        catch (InvalidOperationException exception)
+        {
+            return exception;
+        }
+    }
+
+    private class TestBillingController : BaseBillingController
+    {
+        public IResult HandleResult<T>(BillingCommandResult<T> result) => Handle(result);
+    }
+}

--- a/test/Api.Test/Billing/Controllers/BaseBillingControllerTests.cs
+++ b/test/Api.Test/Billing/Controllers/BaseBillingControllerTests.cs
@@ -13,9 +13,7 @@ using Unhandled = Bit.Core.Billing.Commands.Unhandled;
 namespace Bit.Api.Test.Billing.Controllers;
 
 /// <summary>
-/// Regression tests for VULN-845 (PM-42560): <see cref="BaseBillingController"/> used to copy the
-/// exception message and stack trace into every 500 response, with no environment guard, exposing
-/// internal paths and assembly versions to any authenticated user.
+/// Billing 500s must not disclose exception detail outside development (PM-42560).
 /// </summary>
 public class BaseBillingControllerTests
 {
@@ -53,10 +51,6 @@ public class BaseBillingControllerTests
         Assert.Equal(exception.InnerException!.Message, json.Value.InnerExceptionMessage);
     }
 
-    /// <summary>
-    /// The environment is resolved off the request, so an unset <see cref="HttpContext"/> has to fail
-    /// closed rather than throw or leak.
-    /// </summary>
     [Fact]
     public void Handle_Unhandled_WithoutHttpContext_OmitsExceptionDetail()
     {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-42560](https://bitwarden.atlassian.net/browse/PM-42560) — resolves pen test finding VULN-845 (CWE-209).

## 📔 Objective

`BaseBillingController` put `exception.Message` and `exception.StackTrace` in every billing 500, so any authenticated user could read internal file paths, assembly versions, and stack frames off a failed billing call. Exception detail is now gated on `IsDevelopment()`.

Also adds the missing exception logging to the two `BaseBillingCommand` branches that returned `Unhandled` without it, since the response no longer carries that detail.


[PM-42560]: https://bitwarden.atlassian.net/browse/PM-42560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ