### PR TITLE
[PM-43475] refactor: Remove unused deprecated Admin Console API endpoints

### DIFF
--- a/src/Api/AdminConsole/Controllers/CollectionsController.cs
+++ b/src/Api/AdminConsole/Controllers/CollectionsController.cs
@@ -221,13 +221,6 @@ public class CollectionsController : Controller
         return new CollectionAccessDetailsResponseModel(collectionWithPermissions);
     }
 
-    [HttpPost("{id}")]
-    [Obsolete("This endpoint is deprecated. Use PUT /{id} instead.")]
-    public async Task<CollectionResponseModel> PostPut(Guid orgId, [InjectCollection] Collection collection, [FromBody] UpdateCollectionRequestModel model)
-    {
-        return await Put(orgId, collection, model);
-    }
-
     [HttpPost("bulk-access")]
     public async Task PostBulkCollectionAccess(Guid orgId, [FromBody] BulkCollectionAccessRequestModel model)
     {
@@ -263,13 +256,6 @@ public class CollectionsController : Controller
         await _deleteCollectionCommand.DeleteAsync(collection);
     }
 
-    [HttpPost("{id}/delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE /{id} instead.")]
-    public async Task PostDelete(Guid orgId, [InjectCollection] Collection collection)
-    {
-        await Delete(orgId, collection);
-    }
-
     [HttpDelete("")]
     public async Task DeleteMany(Guid orgId, [FromBody] CollectionBulkDeleteRequestModel model)
     {
@@ -286,12 +272,5 @@ public class CollectionsController : Controller
         }
 
         await _deleteCollectionCommand.DeleteManyAsync(collections);
-    }
-
-    [HttpPost("delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE / instead.")]
-    public async Task PostDeleteMany(Guid orgId, [FromBody] CollectionBulkDeleteRequestModel model)
-    {
-        await DeleteMany(orgId, model);
     }
 }

--- a/src/Api/AdminConsole/Controllers/GroupsController.cs
+++ b/src/Api/AdminConsole/Controllers/GroupsController.cs
@@ -214,14 +214,6 @@ public class GroupsController : Controller
         return new GroupResponseModel(group);
     }
 
-    [HttpPost("{id}")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead")]
-    [Authorize<ManageGroupsRequirement>]
-    public async Task<GroupResponseModel> PostPut([FromRoute] Guid orgId, Guid id, [FromBody] GroupRequestModel model)
-    {
-        return await Put(orgId, id, model);
-    }
-
     [HttpDelete("{id}")]
     [Authorize<ManageGroupsRequirement>]
     public async Task Delete([FromRoute] Guid orgId, Guid id)
@@ -233,14 +225,6 @@ public class GroupsController : Controller
         }
 
         await _deleteGroupCommand.DeleteAsync(group);
-    }
-
-    [HttpPost("{id}/delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageGroupsRequirement>]
-    public async Task PostDelete([FromRoute] Guid orgId, Guid id)
-    {
-        await Delete(orgId, id);
     }
 
     [HttpDelete("")]
@@ -260,14 +244,6 @@ public class GroupsController : Controller
         await _deleteGroupCommand.DeleteManyAsync(groups);
     }
 
-    [HttpPost("delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageGroupsRequirement>]
-    public async Task PostBulkDelete([FromRoute] Guid orgId, [FromBody] GroupBulkRequestModel model)
-    {
-        await BulkDelete(orgId, model);
-    }
-
     [HttpDelete("{id}/user/{orgUserId}")]
     [Authorize<ManageGroupsRequirement>]
     public async Task DeleteUser([FromRoute] Guid orgId, Guid id, Guid orgUserId)
@@ -279,13 +255,5 @@ public class GroupsController : Controller
         }
 
         await _groupService.DeleteUserAsync(group, orgUserId);
-    }
-
-    [HttpPost("{id}/delete-user/{orgUserId}")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageGroupsRequirement>]
-    public async Task PostDeleteUser([FromRoute] Guid orgId, Guid id, Guid orgUserId)
-    {
-        await DeleteUser(orgId, id, orgUserId);
     }
 }

--- a/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationDomainController.cs
@@ -129,13 +129,6 @@ public class OrganizationDomainController : Controller
         await _deleteOrganizationDomainCommand.DeleteAsync(domain);
     }
 
-    [HttpPost("{orgId}/domain/{id}/remove")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    public async Task PostRemoveDomain(Guid orgId, Guid id)
-    {
-        await RemoveDomain(orgId, id);
-    }
-
     [AllowAnonymous]
     [HttpPost("domain/sso/verified")]
     public async Task<VerifiedOrganizationDomainSsoDetailsResponseModel> GetVerifiedOrgDomainSsoDetailsAsync(

--- a/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationUsersController.cs
@@ -581,14 +581,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
         await _removeOrganizationUserCommand.RemoveUserAsync(orgId, id, userId.Value);
     }
 
-    [HttpPost("{id}/remove")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageUsersRequirement>]
-    public async Task PostRemove([FromRoute] Guid orgId, Guid id)
-    {
-        await Remove(orgId, id);
-    }
-
     [HttpDelete("")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRemove([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
@@ -597,14 +589,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
         var result = await _removeOrganizationUserCommand.RemoveUsersAsync(orgId, model.Ids, userId.Value);
         return new ListResponseModel<OrganizationUserBulkResponseModel>(result.Select(r =>
             new OrganizationUserBulkResponseModel(r.OrganizationUserId, r.ErrorMessage)));
-    }
-
-    [HttpPost("remove")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PostBulkRemove([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
-    {
-        return await BulkRemove(orgId, model);
     }
 
     [HttpDelete("{id}/delete-account")]
@@ -627,14 +611,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
         );
     }
 
-    [HttpPost("{id}/delete-account")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageUsersRequirement>]
-    public async Task PostDeleteAccount([FromRoute] Guid orgId, Guid id)
-    {
-        await DeleteAccount(orgId, id);
-    }
-
     [HttpDelete("delete-account")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkDeleteAccount([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
@@ -653,14 +629,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
         ));
 
         return new ListResponseModel<OrganizationUserBulkResponseModel>(responses);
-    }
-
-    [HttpPost("delete-account")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PostBulkDeleteAccount([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
-    {
-        return await BulkDeleteAccount(orgId, model);
     }
 
     [HttpPut("{id}/revoke")]
@@ -682,14 +650,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
 
         var result = await _selfRevokeOrganizationUserCommand.SelfRevokeUserAsync(orgId, userId.Value);
         return Handle(result);
-    }
-
-    [HttpPatch("{id}/revoke")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead")]
-    [Authorize<ManageUsersRequirement>]
-    public async Task PatchRevokeAsync([FromRoute] Guid orgId, Guid id)
-    {
-        await RevokeAsync(orgId, id);
     }
 
     [HttpPut("revoke")]
@@ -717,14 +677,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
                 ))));
     }
 
-    [HttpPatch("revoke")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead")]
-    [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PatchBulkRevokeAsync([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
-    {
-        return await BulkRevokeAsync(orgId, model);
-    }
-
     [HttpPut("{id}/restore")]
     [Authorize<ManageUsersRequirement>]
     [Obsolete("This endpoint is deprecated. Use _vNext endpoint instead. This will be removed in a future release.")]
@@ -741,14 +693,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
         await RestoreOrRevokeUserAsync(orgId, id, (orgUser, userId) => _restoreOrganizationUserCommand.RestoreUserAsync(orgUser, userId, request.DefaultUserCollectionName));
     }
 
-    [HttpPatch("{id}/restore")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead")]
-    [Authorize<ManageUsersRequirement>]
-    public async Task PatchRestoreAsync([FromRoute] Guid orgId, Guid id)
-    {
-        await RestoreAsync(orgId, id);
-    }
-
     [HttpPut("restore")]
     [Authorize<ManageUsersRequirement>]
     public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> BulkRestoreAsync([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
@@ -756,14 +700,6 @@ public class OrganizationUsersController : BaseAdminConsoleController
         return await RestoreOrRevokeUsersAsync(orgId, model,
             (orgId, orgUserIds, restoringUserId) => _restoreOrganizationUserCommand.RestoreUsersAsync(orgId, orgUserIds,
                 restoringUserId, _userService, model.DefaultUserCollectionName));
-    }
-
-    [HttpPatch("restore")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead")]
-    [Authorize<ManageUsersRequirement>]
-    public async Task<ListResponseModel<OrganizationUserBulkResponseModel>> PatchBulkRestoreAsync([FromRoute] Guid orgId, [FromBody] OrganizationUserBulkRequestModel model)
-    {
-        return await BulkRestoreAsync(orgId, model);
     }
 
     [HttpPut("enable-secrets-manager")]

--- a/src/Api/AdminConsole/Controllers/OrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/OrganizationsController.cs
@@ -243,13 +243,6 @@ public class OrganizationsController : Controller
         return TypedResults.Ok(new OrganizationResponseModel(updatedOrganization, plan));
     }
 
-    [HttpPost("{id}")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead")]
-    public async Task<IResult> PostPut(Guid id, [FromBody] OrganizationUpdateRequestModel model)
-    {
-        return await Put(id, model);
-    }
-
     [HttpPost("{id}/storage")]
     [SelfHosted(NotSelfHostedOnly = true)]
     public async Task<PaymentResponseModel> PostStorage(string id, [FromBody] StorageRequestModel model)
@@ -329,13 +322,6 @@ public class OrganizationsController : Controller
         }
 
         await _organizationDeleteCommand.DeleteAsync(organization);
-    }
-
-    [HttpPost("{id}/delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    public async Task PostDelete(string id, [FromBody] SecretVerificationRequestModel model)
-    {
-        await Delete(id, model);
     }
 
     [HttpPost("{id}/delete-recover-token")]

--- a/src/Api/AdminConsole/Controllers/ProviderOrganizationsController.cs
+++ b/src/Api/AdminConsole/Controllers/ProviderOrganizationsController.cs
@@ -102,12 +102,4 @@ public class ProviderOrganizationsController : Controller
             providerOrganization,
             organization);
     }
-
-    [HttpPost("{id:guid}/delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ProviderAdminRequirement>]
-    public async Task PostDelete([FromRoute] Guid providerId, Guid id)
-    {
-        await Delete(providerId, id);
-    }
 }

--- a/src/Api/AdminConsole/Controllers/ProviderUsersController.cs
+++ b/src/Api/AdminConsole/Controllers/ProviderUsersController.cs
@@ -141,28 +141,12 @@ public class ProviderUsersController : Controller
         await _providerService.SaveUserAsync(model.ToProviderUser(providerUser), userId.Value);
     }
 
-    [HttpPost("{id:guid}")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead")]
-    [Authorize<ManageProviderUsersRequirement>]
-    public async Task PostPut([FromRoute] Guid providerId, Guid id, [FromBody] ProviderUserUpdateRequestModel model)
-    {
-        await Put(providerId, id, model);
-    }
-
     [HttpDelete("{id:guid}")]
     [Authorize<ManageProviderUsersRequirement>]
     public async Task Delete([FromRoute] Guid providerId, Guid id)
     {
         var userId = _userService.GetProperUserId(User);
         await _providerService.DeleteUsersAsync(providerId, new[] { id }, userId.Value);
-    }
-
-    [HttpPost("{id:guid}/delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageProviderUsersRequirement>]
-    public async Task PostDelete([FromRoute] Guid providerId, Guid id)
-    {
-        await Delete(providerId, id);
     }
 
     [HttpDelete("")]
@@ -173,13 +157,5 @@ public class ProviderUsersController : Controller
         var result = await _providerService.DeleteUsersAsync(providerId, model.Ids, userId.Value);
         return new ListResponseModel<ProviderUserBulkResponseModel>(result.Select(r =>
             new ProviderUserBulkResponseModel(r.Item1.Id, r.Item2)));
-    }
-
-    [HttpPost("delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ManageProviderUsersRequirement>]
-    public async Task<ListResponseModel<ProviderUserBulkResponseModel>> PostBulkDelete([FromRoute] Guid providerId, [FromBody] ProviderUserBulkRequestModel model)
-    {
-        return await BulkDelete(providerId, model);
     }
 }

--- a/src/Api/AdminConsole/Controllers/ProvidersController.cs
+++ b/src/Api/AdminConsole/Controllers/ProvidersController.cs
@@ -86,14 +86,6 @@ public class ProvidersController : Controller
         return new ProviderResponseModel(provider);
     }
 
-    [HttpPost("{providerId:guid}")]
-    [Obsolete("This endpoint is deprecated. Use PUT method instead")]
-    [Authorize<ProviderAdminRequirement>]
-    public async Task<ProviderResponseModel> PostPut([FromRoute] Guid providerId, [FromBody] ProviderUpdateRequestModel model)
-    {
-        return await Put(providerId, model);
-    }
-
     [HttpPost("{providerId:guid}/setup")]
     [Authorize<ProviderAdminRequirement>]
     public async Task<ProviderResponseModel> Setup([FromRoute] Guid providerId, [FromBody] ProviderSetupRequestModel model)
@@ -145,13 +137,5 @@ public class ProvidersController : Controller
         }
 
         await _providerService.DeleteAsync(provider);
-    }
-
-    [HttpPost("{providerId}/delete")]
-    [Obsolete("This endpoint is deprecated. Use DELETE method instead")]
-    [Authorize<ProviderAdminRequirement>]
-    public async Task PostDelete([FromRoute] Guid providerId)
-    {
-        await Delete(providerId);
     }
 }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationAbilityCacheTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationAbilityCacheTests.cs
@@ -111,8 +111,11 @@ public class OrganizationAbilityCacheTests : IClassFixture<ApiApplicationFactory
         {
             MasterPasswordHash = "master_password_hash"
         };
-        var response = await _client.PostAsJsonAsync(
-            $"/organizations/{_organization.Id}/delete", deleteRequest);
+        using var message = new HttpRequestMessage(HttpMethod.Delete, $"/organizations/{_organization.Id}")
+        {
+            Content = JsonContent.Create(deleteRequest)
+        };
+        var response = await _client.SendAsync(message);
 
         // Assert - endpoint succeeded and cache was cleared
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUserControllerTests.cs
@@ -57,7 +57,11 @@ public class OrganizationUserControllerTests : IClassFixture<ApiApplicationFacto
             Ids = [orgUserToDelete.Id]
         };
 
-        var httpResponse = await _client.PostAsJsonAsync($"organizations/{_organization.Id}/users/delete-account", request);
+        using var message = new HttpRequestMessage(HttpMethod.Delete, $"organizations/{_organization.Id}/users/delete-account")
+        {
+            Content = JsonContent.Create(request)
+        };
+        var httpResponse = await _client.SendAsync(message);
         var content = await httpResponse.Content.ReadFromJsonAsync<ListResponseModel<OrganizationUserBulkResponseModel>>();
         Assert.Single(content.Data, r => r.Id == orgUserToDelete.Id && r.Error == string.Empty);
 
@@ -99,7 +103,11 @@ public class OrganizationUserControllerTests : IClassFixture<ApiApplicationFacto
             Ids = [validOrgUser.Id, invalidOrgUser.Id]
         };
 
-        var httpResponse = await _client.PostAsJsonAsync($"organizations/{_organization.Id}/users/delete-account", request);
+        using var message = new HttpRequestMessage(HttpMethod.Delete, $"organizations/{_organization.Id}/users/delete-account")
+        {
+            Content = JsonContent.Create(request)
+        };
+        var httpResponse = await _client.SendAsync(message);
 
         Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
         var debug = await httpResponse.Content.ReadAsStringAsync();
@@ -134,7 +142,11 @@ public class OrganizationUserControllerTests : IClassFixture<ApiApplicationFacto
             Ids = new List<Guid> { Guid.NewGuid() }
         };
 
-        var httpResponse = await _client.PostAsJsonAsync($"organizations/{_organization.Id}/users/delete-account", request);
+        using var message = new HttpRequestMessage(HttpMethod.Delete, $"organizations/{_organization.Id}/users/delete-account")
+        {
+            Content = JsonContent.Create(request)
+        };
+        var httpResponse = await _client.SendAsync(message);
 
         Assert.Equal(HttpStatusCode.Forbidden, httpResponse.StatusCode);
     }

--- a/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerPerformanceTests.cs
+++ b/test/Api.IntegrationTest/AdminConsole/Controllers/OrganizationUsersControllerPerformanceTests.cs
@@ -218,7 +218,7 @@ public class OrganizationUsersControllerPerformanceTests(ITestOutputHelper testO
     }
 
     /// <summary>
-    /// Tests POST /organizations/{orgId}/users/remove
+    /// Tests DELETE /organizations/{orgId}/users
     /// </summary>
     [Theory(Skip = "Performance test")]
     [InlineData(10)]
@@ -251,11 +251,15 @@ public class OrganizationUsersControllerPerformanceTests(ITestOutputHelper testO
 
         var requestContent = new StringContent(JsonSerializer.Serialize(removeRequest), Encoding.UTF8, "application/json");
 
-        var response = await client.PostAsync($"/organizations/{orgId}/users/remove", requestContent);
+        using var message = new HttpRequestMessage(HttpMethod.Delete, $"/organizations/{orgId}/users")
+        {
+            Content = requestContent
+        };
+        var response = await client.SendAsync(message);
 
         stopwatch.Stop();
 
-        testOutputHelper.WriteLine($"POST /users/remove - Users: {usersToRemove.Count}; Request duration: {stopwatch.ElapsedMilliseconds} ms; Status: {response.StatusCode}");
+        testOutputHelper.WriteLine($"DELETE /users - Users: {usersToRemove.Count}; Request duration: {stopwatch.ElapsedMilliseconds} ms; Status: {response.StatusCode}");
 
         Assert.True(response.IsSuccessStatusCode);
     }
@@ -355,7 +359,7 @@ public class OrganizationUsersControllerPerformanceTests(ITestOutputHelper testO
     }
 
     /// <summary>
-    /// Tests POST /organizations/{orgId}/users/delete-account
+    /// Tests DELETE /organizations/{orgId}/users/delete-account
     /// </summary>
     [Theory(Skip = "Performance test")]
     [InlineData(10)]
@@ -396,11 +400,15 @@ public class OrganizationUsersControllerPerformanceTests(ITestOutputHelper testO
 
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
-        var response = await client.PostAsync($"/organizations/{orgId}/users/delete-account", requestContent);
+        using var message = new HttpRequestMessage(HttpMethod.Delete, $"/organizations/{orgId}/users/delete-account")
+        {
+            Content = requestContent
+        };
+        var response = await client.SendAsync(message);
 
         stopwatch.Stop();
 
-        testOutputHelper.WriteLine($"POST /users/delete-account - Users: {usersToDelete.Count}; Request duration: {stopwatch.ElapsedMilliseconds} ms; Status: {response.StatusCode}");
+        testOutputHelper.WriteLine($"DELETE /users/delete-account - Users: {usersToDelete.Count}; Request duration: {stopwatch.ElapsedMilliseconds} ms; Status: {response.StatusCode}");
 
         Assert.True(response.IsSuccessStatusCode);
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-43475

## 📔 Objective

Removes obsolete API endpoints from AC Team controllers. These were added under #6229 (and related PRs) to improve Swagger operation IDs — each split a legacy HTTP verb (POST for update/delete, PATCH for revoke/restore) off into its own action marked Obsolete, delegating to a modern PUT/DELETE route at the same path.

We'll need to rewrite these controllers into minimal APIs soon, so I'm doing cleanup first.

All 24 deleted routes were verified against the clients repo locally. Every current client already calls the modern PUT/DELETE verb, so none of the deprecated variants are in use. Affected integration tests are repointed to the modern DELETE routes.