### PR TITLE
fix(pam): let a target system be assigned to an inactive access connector

### DIFF
--- a/bitwarden_license/src/Services/Pam/AccessConnector/Commands/AssignAccessConnectorToTargetCommand.cs
+++ b/bitwarden_license/src/Services/Pam/AccessConnector/Commands/AssignAccessConnectorToTargetCommand.cs
@@ -44,11 +44,6 @@ public class AssignAccessConnectorToTargetCommand : IAssignAccessConnectorToTarg
 
         // Both rows were just loaded against the same route organization, so the same-org invariant holds by
         // construction.
-        if (daemon.Status != PamAccessConnectorStatus.Enabled)
-        {
-            throw new BadRequestException("This daemon is disabled.");
-        }
-
         if (target.Method != PamTargetSystemMethod.Automatic)
         {
             throw new BadRequestException("Only automatic target systems can be assigned a daemon.");

--- a/bitwarden_license/test/Services/Pam.Test/AccessConnector/Commands/AssignAccessConnectorToTargetCommandTests.cs
+++ b/bitwarden_license/test/Services/Pam.Test/AccessConnector/Commands/AssignAccessConnectorToTargetCommandTests.cs
@@ -78,7 +78,7 @@ public class AssignAccessConnectorToTargetCommandTests
     }
 
     [Theory, BitAutoData]
-    public async Task AssignAsync_DaemonDisabled_ThrowsBadRequest(Guid actingUserId, PamDaemon daemon, PamTargetSystem target)
+    public async Task AssignAsync_DaemonDisabled_CreatesAssignment(Guid actingUserId, PamDaemon daemon, PamTargetSystem target)
     {
         var sutProvider = Setup();
         daemon.Status = PamAccessConnectorStatus.Disabled;
@@ -86,12 +86,13 @@ public class AssignAccessConnectorToTargetCommandTests
         target.Method = PamTargetSystemMethod.Automatic;
         sutProvider.GetDependency<IPamDaemonRepository>().GetByIdAsync(daemon.Id).Returns(daemon);
         sutProvider.GetDependency<IPamTargetSystemRepository>().GetByIdAsync(target.Id).Returns(target);
+        sutProvider.GetDependency<IPamDaemonRepository>().AssignmentExistsAsync(daemon.Id, target.Id).Returns(false);
 
-        await Assert.ThrowsAsync<BadRequestException>(
-            () => sutProvider.Sut.AssignAsync(daemon.OrganizationId, actingUserId, daemon.Id, target.Id));
+        await sutProvider.Sut.AssignAsync(daemon.OrganizationId, actingUserId, daemon.Id, target.Id);
 
-        await sutProvider.GetDependency<IPamDaemonRepository>().DidNotReceiveWithAnyArgs()
-            .CreateAssignmentAsync(default!);
+        await sutProvider.GetDependency<IPamDaemonRepository>().Received(1)
+            .CreateAssignmentAsync(Arg.Is<PamDaemonTargetAssignment>(
+                a => a.DaemonId == daemon.Id && a.TargetSystemId == target.Id));
     }
 
     [Theory, BitAutoData]


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Allow a target system to be assigned to an access connector that is not currently active, by removing the connector status check from `AssignAccessConnectorToTargetCommand`.

- Assignment is configuration, not execution. Disabling a connector is a reversible pause (`SetAccessConnectorStatusCommand`) that deletes no assignment rows, so a disabled connector can already hold assignments by assigning first and disabling after. The check only blocked one route to a state the API otherwise permits.
- Rotation still cannot run against a disabled connector. Token issuance (`PamDaemonClientProvider`), job claim (`PamRotationJob_Claim.sql`) and poll (`PamRotationJob_ReadManyClaimableByDaemonId.sql`) each re-check the status in the statement that does the work.
- The `Method != Automatic` check stays. A manual target has no integration to drive, so assigning one would create a permanently unroutable row.
- `AssignAsync_DaemonDisabled_ThrowsBadRequest` is inverted to `AssignAsync_DaemonDisabled_CreatesAssignment`. `Pam.Test` passes, 854 tests.
- The removed error string had no i18n key and no client match, so the endpoint contract only narrows: a call that returned 400 now returns 204.

Pairs with the `bitwarden/clients` rotation stack (#23113 to #23141), which drops the matching client side gate. This needs to merge first, otherwise the clients UI offers an assignment the API refuses.
