### PR TITLE
[BRE-2266] Update K6 Load Tests

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -109,6 +109,6 @@ jobs:
         with:
           flags: >-
             --tag test-id=${{ env.TEST_ID }}
-            -o experimental-opentelemetry
+            -o opentelemetry
             ${{ inputs.k6-flags }}
           path: ${{ env.K6_TEST_PATH }}

--- a/perf/load/helpers/auth.js
+++ b/perf/load/helpers/auth.js
@@ -3,7 +3,7 @@ import { check, fail } from "k6";
 
 // Identity rejects password grants that omit the "Bitwarden-Client-Version"
 // header (see ClientVersionValidator), so every request must supply one.
-const CLIENT_VERSION = __ENV.CLIENT_VERSION || "2026.9.0";
+const CLIENT_VERSION = __ENV.CLIENT_VERSION || "2026.8.0";
 
 /**
  * Authenticate using OAuth against Bitwarden

--- a/perf/load/helpers/auth.js
+++ b/perf/load/helpers/auth.js
@@ -1,6 +1,9 @@
 import http from "k6/http";
 import { check, fail } from "k6";
-import encoding from "k6/encoding";
+
+// Identity rejects password grants that omit the "Bitwarden-Client-Version"
+// header (see ClientVersionValidator), so every request must supply one.
+const CLIENT_VERSION = __ENV.CLIENT_VERSION || "2026.9.0";
 
 /**
  * Authenticate using OAuth against Bitwarden
@@ -25,6 +28,7 @@ export function authenticate(
     headers: {
       Accept: "application/json",
       "X-ClientId": clientHeader,
+      "Bitwarden-Client-Version": CLIENT_VERSION,
     },
     tags: { name: "Login" },
   };
@@ -54,7 +58,12 @@ export function authenticate(
       "login status is 200": (r) => r.status === 200,
     })
   ) {
-    fail("login status code was *not* 200");
+    // Only logged on failure: an unsuccessful /connect/token response carries an
+    // OAuth error and message, never a token or other credential material.
+    console.error(
+      `login failed with status ${res.status}: ${String(res.body).slice(0, 500)}`
+    );
+    fail(`login status code was *not* 200, got ${res.status}`);
   }
 
   const json = res.json();


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
- [BRE-2266](https://bitwarden.atlassian.net/browse/BRE-2266)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This PR Updates the `opentelemetry` flag to remove a warning and adds a value for the required `Bitwarden-Client-Version` header for Identity.

There was a [successful run](https://github.com/bitwarden/server/actions/runs/34870765709) of the Load Test workflow, but it failed the actual load tests.


[BRE-2266]: https://bitwarden.atlassian.net/browse/BRE-2266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ